### PR TITLE
PluginMessageEvent and associated changes

### DIFF
--- a/src/main/java/net/md_5/bungee/BungeeCord.java
+++ b/src/main/java/net/md_5/bungee/BungeeCord.java
@@ -8,7 +8,9 @@ import java.net.Socket;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.logging.Level;
@@ -23,6 +25,7 @@ import net.md_5.bungee.command.CommandSender;
 import net.md_5.bungee.command.CommandServer;
 import net.md_5.bungee.command.ConsoleCommandSender;
 import net.md_5.bungee.packet.DefinedPacket;
+import net.md_5.bungee.packet.PacketFAPluginMessage;
 import net.md_5.bungee.plugin.JavaPluginManager;
 import net.md_5.bungee.tablist.GlobalPingTabList;
 import net.md_5.bungee.tablist.GlobalTabList;
@@ -82,6 +85,10 @@ public class BungeeCord
      * Tab list handler
      */
     public TabListHandler tabListHandler;
+    /**
+     * Registered Global Plugin Channels
+     */
+    public Queue<String> globalPluginChannels = new ConcurrentLinkedQueue<>();
     /**
      * Plugin manager.
      */
@@ -184,6 +191,9 @@ public class BungeeCord
                 break;
         }
 
+        // Add RubberBand to the global plugin channel list
+        globalPluginChannels.add("RubberBand");
+
         InetSocketAddress addr = Util.getAddr(config.bindHost);
         listener = new ListenThread(addr);
         listener.start();
@@ -261,5 +271,16 @@ public class BungeeCord
         {
             con.packetQueue.add(packet);
         }
+    }
+
+    /**
+     * Register a plugin channel for all users
+     * 
+     * @param channel name
+     */
+    public void registerPluginChannel(String channel)
+    {
+        globalPluginChannels.add(channel);
+        broadcast(new PacketFAPluginMessage("REGISTER", channel.getBytes()));
     }
 }

--- a/src/main/java/net/md_5/bungee/plugin/JavaPlugin.java
+++ b/src/main/java/net/md_5/bungee/plugin/JavaPlugin.java
@@ -52,6 +52,13 @@ public abstract class JavaPlugin
     }
 
     /**
+     * Called when a plugin message is sent to the client or server
+     */
+    public void onPluginMessage(PluginMessageEvent event)
+    {
+    }
+    
+    /**
      * Register a command for use with the proxy.
      */
     protected final void registerCommand(String label, Command command)

--- a/src/main/java/net/md_5/bungee/plugin/JavaPluginManager.java
+++ b/src/main/java/net/md_5/bungee/plugin/JavaPluginManager.java
@@ -106,4 +106,13 @@ public class JavaPluginManager extends JavaPlugin
             p.onServerConnect(event);
         }
     }
+
+    @Override
+    public void onPluginMessage(PluginMessageEvent event)
+    {
+        for (JavaPlugin p : plugins)
+        {
+            p.onPluginMessage(event);
+        }
+    }
 }


### PR DESCRIPTION
Add and implement an onPluginMessage event
Allow plugins to register global message channels
Added a packetQueue to the ServerConnection class
Created a message tag "KillCon" to kill a downstream connection (Required for Stargate-Bungee)

This commit has everything required to allow a plugin on two servers to teleport a player to a specific location on server transfer. This is implemented in the latest Stargate & Stargate-Bungee, which will be commited to Git this afternoon.
