### PR TITLE
Correction to previous pull

### DIFF
--- a/src/main/java/net/md_5/bungee/UserConnection.java
+++ b/src/main/java/net/md_5/bungee/UserConnection.java
@@ -115,6 +115,14 @@ public class UserConnection extends GenericConnection implements CommandSender
             }
             reconnecting = false;
             downBridge = new DownstreamBridge();
+            if (server != null)
+            {
+                List<UserConnection> conns = BungeeCord.instance.connectionsByServer.get(server.name);
+                if (conns != null)
+                {
+                    conns.remove(this);
+                }
+            }
             server = newServer;
             List<UserConnection> conns = BungeeCord.instance.connectionsByServer.get(server.name);
             if (conns == null)
@@ -122,7 +130,10 @@ public class UserConnection extends GenericConnection implements CommandSender
                 conns = new ArrayList<>();
                 BungeeCord.instance.connectionsByServer.put(server.name, conns);
             }
-            conns.add(this);
+            if (!conns.contains(this))
+            {
+                conns.add(this);
+            }
             downBridge.start();
         } catch (KickException ex)
         {


### PR DESCRIPTION
Previous version did not properly remove a UserConnection from the server's list when they change servers.

This version also prevents duplicates from being placed in a server's list.
