### PR TITLE
Update src/main/java/net/md_5/bungee/InitialHandler.java

### DIFF
--- a/src/main/java/net/md_5/bungee/InitialHandler.java
+++ b/src/main/java/net/md_5/bungee/InitialHandler.java
@@ -58,6 +58,11 @@ public class InitialHandler implements Runnable
                     {
                         throw new KickException("Not authenticated with minecraft.net");
                     }
+                    
+                    //Check for multiple connections
+                    if(BungeeCord.instance.connections.containsKey(handshake.username)) {
+                        throw new KickException("You are already connected to the server");
+                    }
 
                     // fire post auth event
                     BungeeCord.instance.pluginManager.onLogin(event);


### PR DESCRIPTION
Found that when force_default_server is set to true, Its possible for a single user to have multiple connections to different servers connected by BungeeCord. Added in a check to block that.
