### PR TITLE
Add verbose setting to prevent BungeeCord from spamming

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/config/Configuration.java
+++ b/proxy/src/main/java/net/md_5/bungee/config/Configuration.java
@@ -49,6 +49,7 @@ public class Configuration
      */
     private boolean onlineMode = true;
     private int playerLimit = -1;
+    private boolean verbose = false;
 
     public void load()
     {
@@ -59,6 +60,7 @@ public class Configuration
         uuid = adapter.getString( "stats", uuid );
         onlineMode = adapter.getBoolean( "online_mode", onlineMode );
         playerLimit = adapter.getInt( "player_limit", playerLimit );
+        verbose = adapter.getBoolean( "verbose", verbose );
 
         DefaultTabList tab = DefaultTabList.valueOf( adapter.getString( "tab_list", "GLOBAL_PING" ) );
         if ( tab == null )

--- a/proxy/src/main/java/net/md_5/bungee/netty/HandlerBoss.java
+++ b/proxy/src/main/java/net/md_5/bungee/netty/HandlerBoss.java
@@ -6,6 +6,8 @@ import io.netty.channel.ChannelInboundMessageHandlerAdapter;
 import io.netty.handler.timeout.ReadTimeoutException;
 import java.io.IOException;
 import java.util.logging.Level;
+
+import net.md_5.bungee.BungeeCord;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.connection.CancelSendSignal;
 import net.md_5.bungee.packet.DefinedPacket;
@@ -33,7 +35,8 @@ public class HandlerBoss extends ChannelInboundMessageHandlerAdapter<byte[]>
         if ( handler != null )
         {
             handler.connected( ctx.channel() );
-            ProxyServer.getInstance().getLogger().log( Level.INFO, "{0} has connected", handler );
+            if (BungeeCord.getInstance().config.isVerbose())
+            	ProxyServer.getInstance().getLogger().log( Level.INFO, "{0} has connected", handler );
         }
     }
 
@@ -42,7 +45,8 @@ public class HandlerBoss extends ChannelInboundMessageHandlerAdapter<byte[]>
     {
         if ( handler != null )
         {
-            ProxyServer.getInstance().getLogger().log( Level.INFO, "{0} has disconnected", handler );
+            if (BungeeCord.getInstance().config.isVerbose())
+            	ProxyServer.getInstance().getLogger().log( Level.INFO, "{0} has disconnected", handler );
             handler.disconnected( ctx.channel() );
         }
     }


### PR DESCRIPTION
I've created a bungeecord plugin which caches the MOTD of the servers behind the listeners to display those on querying the server. But every update spams two [PingHandler] connect/disconnect messages then ;-)
So I thought, adding a verbose setting would help a lot.
