### PR TITLE
Fix Crash with Teams. For real this time.

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
@@ -153,10 +153,10 @@ public class DownstreamBridge extends PacketHandler
         if ( team.mode == 0 )
         {
             t = new Team( team.name );
-            con.serverSentScoreboard.addTeam( team );
+            con.serverSentScoreboard.addTeam( t );
         } else
         {
-            con.serverSentScoreboard.getTeam( team.name );
+            t = con.serverSentScoreboard.getTeam( team.name );
         }
         
         if ( t != null )


### PR DESCRIPTION
You forgot to add the Team to the list when a new team is added in the DownstreamBridge. This PR fixes it.
