### PR TITLE
Implement support for plugin hard dependencies.

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/plugin/PluginDescription.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/PluginDescription.java
@@ -1,5 +1,7 @@
 package net.md_5.bungee.api.plugin;
 
+import java.util.Set;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
@@ -27,6 +29,10 @@ public class PluginDescription
      * Plugin author.
      */
     private String author;
+    /**
+     * Plugin hard dependencies.
+     */
+    private Set<String> depends;
 
     public PluginDescription()
     {


### PR DESCRIPTION
Hard dependencies are specified in the plugin.yml:

```
depends:
- plugin1
- plugin2
```

Dependencies are guaranteed to be enabled before the dependents. Dependents will not be enabled if any of the dependencies are not enabled. This will also catch circular dependency errors.
