### PR TITLE
Revert a38b3ce since it's no longer needed

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
@@ -51,7 +51,7 @@ public class UpstreamBridge extends PacketHandler
         PlayerDisconnectEvent event = new PlayerDisconnectEvent( con );
         bungee.getPluginManager().callEvent( event );
         bungee.getTabListHandler().onDisconnect( con );
-        BungeeCord.getInstance().connections.remove( con.getName() ); //TODO: Better way, why do we need to raw access?
+        bungee.getPlayers().remove( con );
 
         if ( con.getServer() != null )
         {


### PR DESCRIPTION
We no longer need raw access because the bug is already fixed.
