### PR TITLE
Tone down PingHandler too

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/netty/HandlerBoss.java
+++ b/proxy/src/main/java/net/md_5/bungee/netty/HandlerBoss.java
@@ -11,6 +11,7 @@ import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.connection.CancelSendSignal;
 import net.md_5.bungee.connection.DownstreamBridge;
 import net.md_5.bungee.connection.InitialHandler;
+import net.md_5.bungee.connection.PingHandler;
 import net.md_5.bungee.connection.UpstreamBridge;
 
 /**
@@ -38,7 +39,7 @@ public class HandlerBoss extends ChannelInboundMessageHandlerAdapter<Object>
             channel = new ChannelWrapper( ctx.channel() );
             handler.connected( channel );
 
-            if ( !( handler instanceof InitialHandler ) )
+            if ( !( handler instanceof InitialHandler || handler instanceof PingHandler ) )
             {
                 ProxyServer.getInstance().getLogger().log( Level.INFO, "{0} has connected", handler );
             }
@@ -52,7 +53,7 @@ public class HandlerBoss extends ChannelInboundMessageHandlerAdapter<Object>
         {
             handler.disconnected( channel );
 
-            if ( !( handler instanceof InitialHandler ) )
+            if ( !( handler instanceof InitialHandler || handler instanceof PingHandler ) )
             {
                 ProxyServer.getInstance().getLogger().log( Level.INFO, "{0} has disconnected", handler );
             }


### PR DESCRIPTION
By using https://github.com/ElasticPortalSuite/BungeeCord/commit/fd411edddb3a4821293d4afe37f368156ca2022b as base, this PR tones down the PingHandler too.

Reason for this is that some plugins (like mine) check the MOTD/playercount/... every X seconds for Y servers, making the log almost unreadable because of the spam.

Hope that fits in.
