### PR TITLE
Change order of boolean so the latch is decremented all the time

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/event/AsyncEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/AsyncEvent.java
@@ -67,7 +67,7 @@ public class AsyncEvent<T> extends Event
     {
         Preconditions.checkState( intents.contains( plugin ), "Plugin %s has not registered intent for event %s", plugin, this );
         intents.remove( plugin );
-        if ( fired.get() && latch.decrementAndGet() == 0 )
+        if ( latch.decrementAndGet() == 0 && fired.get() )
         {
             done.done( (T) this, null );
         }


### PR DESCRIPTION
Can't believe you were boasting an easy fix I didn't see, and yet you still managed to screw up...
If fired.get() is false, then the latch won't be decrementing due to the way java lazily looks at conditions, leading to the event never completing. 
