### PR TITLE
Fixed forced_hosts MOTD

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -152,7 +152,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
             }
 
             ServerPing response = new ServerPing( bungee.getProtocolVersion(), bungee.getGameVersion(),
-                    listener.getMotd(), bungee.getOnlineCount(), listener.getMaxPlayers() );
+                    motd, bungee.getOnlineCount(), listener.getMaxPlayers() );
 
             response = bungee.getPluginManager().callEvent( new ProxyPingEvent( InitialHandler.this, response ) ).getResponse();
 


### PR DESCRIPTION
Noticed a tiny bug in InitialHandler.java (when creating a ServerPing response). The response was still using the old listener.getMotd() when it should be using the new motd variable (to take advantage of the new forced_hosts MOTD methods).
