### PR TITLE
Only activate reconnectHandler when we have a non force-to-default listener

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
@@ -240,9 +240,13 @@ public class BungeeCord extends ProxyServer
         pluginsFolder.mkdir();
         pluginManager.detectPlugins( pluginsFolder );
         config.load();
-        if ( reconnectHandler == null )
+        for ( ListenerInfo info : config.getListeners() )
         {
-            reconnectHandler = new YamlReconnectHandler();
+            if ( !info.isForceDefault() && reconnectHandler == null )
+            {
+                reconnectHandler = new YamlReconnectHandler();
+                break;
+            }
         }
         isRunning = true;
 
@@ -342,8 +346,11 @@ public class BungeeCord extends ProxyServer
                 }
 
                 getLogger().info( "Saving reconnect locations" );
-                reconnectHandler.save();
-                reconnectHandler.close();
+                if ( reconnectHandler != null )
+                {
+                    reconnectHandler.save();
+                    reconnectHandler.close();
+                }
                 saveThread.cancel();
                 metricsThread.cancel();
 

--- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
@@ -32,7 +32,6 @@ import net.md_5.bungee.protocol.packet.PacketD1Team;
 import net.md_5.bungee.protocol.packet.PacketFAPluginMessage;
 import net.md_5.bungee.protocol.packet.PacketFFKick;
 
-;
 
 @RequiredArgsConstructor
 public class DownstreamBridge extends PacketHandler
@@ -62,7 +61,10 @@ public class DownstreamBridge extends PacketHandler
     {
         // We lost connection to the server
         server.getInfo().removePlayer( con );
-        bungee.getReconnectHandler().setServer( con );
+        if (bungee.getReconnectHandler() != null)
+        {
+            bungee.getReconnectHandler().setServer( con );
+        }
 
         if ( !server.isObsolete() )
         {

--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -335,14 +335,21 @@ public class InitialHandler extends PacketHandler implements PendingConnection
     {
         Preconditions.checkState( thisState == State.LOGIN, "Not expecting LOGIN" );
 
-        UserConnection userCon = new UserConnection( (BungeeCord) bungee, ch, getName(), this );
+        UserConnection userCon = new UserConnection( bungee, ch, getName(), this );
         userCon.init();
 
         bungee.getPluginManager().callEvent( new PostLoginEvent( userCon ) );
 
         ch.getHandle().pipeline().get( HandlerBoss.class ).setHandler( new UpstreamBridge( bungee, userCon ) );
 
-        ServerInfo server = bungee.getReconnectHandler().getServer( userCon );
+        ServerInfo server;
+        if ( bungee.getReconnectHandler() != null )
+        {
+            server = bungee.getReconnectHandler().getServer( userCon );
+        } else
+        {
+            server = AbstractReconnectManager.getForcedHost( this );
+        }
         userCon.connect( server, true );
 
         thisState = State.FINISHED;


### PR DESCRIPTION
Untested but it compiles 
