### PR TITLE
getLogger() Method for Plugins to access a Plugin's logger.

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/plugin/Plugin.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/Plugin.java
@@ -71,6 +71,14 @@ public class Plugin
     }
 
     /**
+     * Get a logger.
+     * @return logger for this plugin
+     */
+    public Logger getLogger() {
+        return logger;
+    }
+
+    /**
      * Called by the loader to initialize the fields in this plugin.
      *
      * @param description the description that describes this plugin


### PR DESCRIPTION
I thought there would be the Logger feature, but it is not accessable because a method was missing.
