### PR TITLE
Use short-circuited operator

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
@@ -209,7 +209,7 @@ public final class UserConnection implements ProxiedPlayer
                     pendingConnects.remove( target );
 
                     ServerInfo def = ProxyServer.getInstance().getServers().get( getPendingConnection().getListener().getFallbackServer() );
-                    if ( retry & target != def && ( getServer() == null || def != getServer().getInfo() ) )
+                    if ( retry && target != def && ( getServer() == null || def != getServer().getInfo() ) )
                     {
                         sendMessage( bungee.getTranslation( "fallback_lobby" ) );
                         connect( def, false );


### PR DESCRIPTION
I searched for any reason at all for the use of `&` here and I couldn't find one. This is (very slightly) faster and less confusing.
