### PR TITLE
Fix compile error when compiling on OS X

### DIFF
--- a/proxy/src/test/java/net/md_5/bungee/ThrottleTest.java
+++ b/proxy/src/test/java/net/md_5/bungee/ThrottleTest.java
@@ -12,7 +12,13 @@ public class ThrottleTest
     public void testThrottle() throws InterruptedException, UnknownHostException
     {
         ConnectionThrottle throttle = new ConnectionThrottle( 5 );
-        InetAddress address = InetAddress.getLocalHost();
+        InetAddress address;
+        
+        try {
+            address = InetAddress.getLocalHost();
+        } catch (UnknownHostException ex) {
+            address = InetAddress.getByName( null );
+        }
 
         Assert.assertFalse( "Address should not be throttled", throttle.throttle( address ) );
         Assert.assertTrue( "Address should be throttled", throttle.throttle( address ) );


### PR DESCRIPTION
When compiling on OS X the test, ThrottleTest fails because it is unable to retrieve the localhost, this fix will first attempt to retrieve the localhost through getLocalHost() and if it fails will do a reverse lookup allowing it to compile successfully on OS X
