### PR TITLE
Fix 1.6.4 legacy support

### DIFF
--- a/protocol/src/main/java/net/md_5/bungee/protocol/LegacyDecoder.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/LegacyDecoder.java
@@ -13,16 +13,15 @@ public class LegacyDecoder extends ByteToMessageDecoder
     @Override
     protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception
     {
-        if ( in.readableBytes() < 3 )
+        if ( in.readableBytes() < 2 )
         {
             return;
         }
         int i = in.readerIndex();
         short b1 = in.getUnsignedByte( i++ );
         short b2 = in.getUnsignedByte( i++ );
-        short b3 = in.getUnsignedByte( i++ );
 
-        if ( b1 == 0xFE && b2 == 0x01 && b3 == 0xFA )
+        if ( b1 == 0xFE && b2 == 0x01 )
         {
             out.add( new PacketWrapper( new LegacyPing(), Unpooled.EMPTY_BUFFER ) );
         }


### PR DESCRIPTION
In 1.6.4, the correct format for a ping was to send '0xFE 0x01', however Bungee requires an additional byte (0xFA). 

1.6.4 clients will not show out of date warnings for 1.7.2 versions of Bungee without this fix, they will only show "Communication Error". This fix will also allow server list sites that do not support the new 1.7.2 protocol to query bungee, as well as sites like MineCanary. 
