### PR TITLE
Add new plugin message sub-channels to get a players real UUID

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
@@ -321,6 +321,21 @@ public class DownstreamBridge extends PacketHandler
                 out.writeUTF( "GetServer" );
                 out.writeUTF( server.getInfo().getName() );
             }
+            if ( subChannel.equals( "UUID" ) )
+            {
+                out.writeUTF( "UUID" );
+                out.writeUTF( con.getUUID() );
+            }
+            if ( subChannel.equals("UUIDOther") )
+            {
+                ProxiedPlayer player = bungee.getPlayer( in.readUTF() );
+                if ( player != null )
+                {
+                    out.writeUTF( "UUIDOther" );
+                    out.writeUTF( player.getName() );
+                    out.writeUTF( player.getUUID() );
+                }
+            }
 
             // Check we haven't set out to null, and we have written data, if so reply back back along the BungeeCord channel
             if ( out != null )


### PR DESCRIPTION
This pull-request adds 2 new BungeeCord plugin message sub-channels. This feature is needed as child servers cannot determine a players real UUID whilst in offline mode (required for BungeeCord). Both sub-channels are explained in detail below.

**UUID**
Gets the UUID of this player

Arguments
None

Receiver
The player whose UUID you would like

Sending Example
    out.writeUTF("UUID");

Response
    String uuid = in.readUTF();

**UUIDOther**
Gets the UUID of any player connected to the BungeeCord server

Arguments
String the name of the player whom you would like the UUID of

Receiver
Any player

Sending Example
    out.writeUTF("UUIDOther");
    out.writeUTF("Notch");

Response
    String playerName = in.readUTF();
    String uuid = in.readUTF();
