### PR TITLE
Fixes wrong legacy formatting for String messages

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/chat/TextComponent.java
+++ b/api/src/main/java/net/md_5/bungee/api/chat/TextComponent.java
@@ -72,9 +72,14 @@ public class TextComponent extends BaseComponent
                         component.setObfuscated( true );
                         break;
                     case RESET:
+                        if(component.isBold()) component.setBold(false);
+                        if(component.isUnderlined()) component.setUnderlined(false);
+                        if(component.isItalic()) component.setBold(false);
+                        if(component.isStrikethrough()) component.setStrikethrough(false);
+                        if(component.isObfuscated()) component.setObfuscated(false);
+
                         format = ChatColor.WHITE;
                     default:
-                        component = new TextComponent();
                         component.setColor( format );
                         break;
                 }


### PR DESCRIPTION
§4§n§lTest§r also text gave out "Test also Text", where "Test" was red, striked and bold. But also the "also Test" also was bold and striked which does not respond the vanilla behaviour.

Also setting new Color did reset the Font Formatting which also does not respond to the vanilla behaviour.

Both of this Cases are fixed in this PR.

Testing:
§4§n§lTest§r as mentioned above
§n§4Test for the other bug
