### PR TITLE
Added better IP forwarding

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/config/ListenerInfo.java
+++ b/api/src/main/java/net/md_5/bungee/api/config/ListenerInfo.java
@@ -69,4 +69,8 @@ public class ListenerInfo
      * Whether to enable udp query.
      */
     private final boolean queryEnabled;
+    /**
+     * Is the input (UpStream) ipforwarded ?
+     */
+    private final boolean isForwarded;
 }

--- a/api/src/main/java/net/md_5/bungee/api/config/ServerInfo.java
+++ b/api/src/main/java/net/md_5/bungee/api/config/ServerInfo.java
@@ -2,9 +2,11 @@ package net.md_5.bungee.api.config;
 
 import java.net.InetSocketAddress;
 import java.util.Collection;
+
 import net.md_5.bungee.api.Callback;
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.ServerPing;
+import net.md_5.bungee.api.connection.PendingConnection;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 
 /**
@@ -66,4 +68,12 @@ public interface ServerInfo
      * @param callback the callback to call when the count has been retrieved.
      */
     void ping(Callback<ServerPing> callback);
+
+    /**
+     * Asynchronously gets the current player count on this server.
+     *
+     * @param callback the callback to call when the count has been retrieved.
+     * @param pendingConnection the Connection for which this ping should be done
+     */
+    void ping(Callback<ServerPing> callback, PendingConnection pendingConnection);
 }

--- a/api/src/main/java/net/md_5/bungee/api/connection/PendingConnection.java
+++ b/api/src/main/java/net/md_5/bungee/api/connection/PendingConnection.java
@@ -57,4 +57,9 @@ public interface PendingConnection extends Connection
      * @param onlineMode
      */
     void setOnlineMode(boolean onlineMode);
+
+    /**
+     * Get the clients real IP
+     */
+    String getIp();
 }

--- a/proxy/src/main/java/net/md_5/bungee/BungeeServerInfo.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeServerInfo.java
@@ -21,6 +21,7 @@ import net.md_5.bungee.api.Callback;
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.ServerPing;
 import net.md_5.bungee.api.config.ServerInfo;
+import net.md_5.bungee.api.connection.PendingConnection;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.connection.Server;
 import net.md_5.bungee.connection.PingHandler;
@@ -48,7 +49,7 @@ public class BungeeServerInfo implements ServerInfo
     @Synchronized("players")
     public void addPlayer(ProxiedPlayer player)
     {
-        players.add( player );
+        players.add(player);
     }
 
     @Synchronized("players")
@@ -68,7 +69,7 @@ public class BungeeServerInfo implements ServerInfo
     public boolean canAccess(CommandSender player)
     {
         Preconditions.checkNotNull( player, "player" );
-        return !restricted || player.hasPermission( "bungeecord.server." + name );
+        return !restricted || player.hasPermission("bungeecord.server." + name);
     }
 
     @Override
@@ -87,7 +88,7 @@ public class BungeeServerInfo implements ServerInfo
     @Override
     public void sendData(String channel, byte[] data)
     {
-        Preconditions.checkNotNull( channel, "channel" );
+        Preconditions.checkNotNull(channel, "channel");
         Preconditions.checkNotNull( data, "data" );
 
         synchronized ( packetQueue )
@@ -106,6 +107,12 @@ public class BungeeServerInfo implements ServerInfo
     @Override
     public void ping(final Callback<ServerPing> callback)
     {
+        ping(callback, null);
+    }
+
+    @Override
+    public void ping(final Callback<ServerPing> callback, final PendingConnection pendingConnection)
+    {
         Preconditions.checkNotNull( callback, "callback" );
 
         ChannelFutureListener listener = new ChannelFutureListener()
@@ -115,7 +122,7 @@ public class BungeeServerInfo implements ServerInfo
             {
                 if ( future.isSuccess() )
                 {
-                    future.channel().pipeline().get( HandlerBoss.class ).setHandler( new PingHandler( BungeeServerInfo.this, callback ) );
+                    future.channel().pipeline().get( HandlerBoss.class ).setHandler( new PingHandler( BungeeServerInfo.this, callback, pendingConnection ) );
                 } else
                 {
                     callback.done( null, future.cause() );

--- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
+++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
@@ -69,7 +69,7 @@ public class ServerConnector extends PacketHandler
         Handshake copiedHandshake = new Handshake( originalHandshake.getProtocolVersion(), originalHandshake.getHost(), originalHandshake.getPort(), 2 );
         if ( BungeeCord.getInstance().config.isIpFoward() )
         {
-            copiedHandshake.setHost( copiedHandshake.getHost() + "\00" + user.getAddress().getHostString() + "\00" + user.getUUID() );
+            copiedHandshake.setHost( copiedHandshake.getHost() + "\00" + user.getPendingConnection().getIp() + "\00" + user.getUUID() );
         }
         channel.write( copiedHandshake );
 

--- a/proxy/src/main/java/net/md_5/bungee/conf/YamlConfig.java
+++ b/proxy/src/main/java/net/md_5/bungee/conf/YamlConfig.java
@@ -24,6 +24,7 @@ import net.md_5.bungee.api.config.ServerInfo;
 import net.md_5.bungee.api.tab.TabListHandler;
 import net.md_5.bungee.tab.Global;
 import net.md_5.bungee.tab.GlobalPing;
+import net.md_5.bungee.tab.Passthrough;
 import net.md_5.bungee.tab.ServerUnique;
 import net.md_5.bungee.util.CaseInsensitiveMap;
 import org.yaml.snakeyaml.DumperOptions;
@@ -39,7 +40,7 @@ public class YamlConfig implements ConfigurationAdapter
     private enum DefaultTabList
     {
 
-        GLOBAL( Global.class ), GLOBAL_PING( GlobalPing.class ), SERVER( ServerUnique.class );
+        GLOBAL( Global.class ), GLOBAL_PING( GlobalPing.class ), SERVER( ServerUnique.class ), PASSTHROUGH( Passthrough.class );
         private final Class<? extends TabListHandler> clazz;
     }
     private Yaml yaml;
@@ -217,8 +218,9 @@ public class YamlConfig implements ConfigurationAdapter
 
             boolean query = get( "query_enabled", false, val );
             int queryPort = get( "query_port", 25577, val );
+            boolean isForwarded = get( "is_forwarded", false, val );
 
-            ListenerInfo info = new ListenerInfo( address, motd, maxPlayers, tabListSize, defaultServer, fallbackServer, forceDefault, forced, value.clazz, setLocalAddress, pingPassthrough, queryPort, query );
+            ListenerInfo info = new ListenerInfo( address, motd, maxPlayers, tabListSize, defaultServer, fallbackServer, forceDefault, forced, value.clazz, setLocalAddress, pingPassthrough, queryPort, query, isForwarded );
             ret.add( info );
         }
 

--- a/proxy/src/main/java/net/md_5/bungee/connection/PingHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/PingHandler.java
@@ -6,6 +6,7 @@ import net.md_5.bungee.api.Callback;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.ServerPing;
 import net.md_5.bungee.api.config.ServerInfo;
+import net.md_5.bungee.api.connection.PendingConnection;
 import net.md_5.bungee.netty.ChannelWrapper;
 import net.md_5.bungee.netty.PacketHandler;
 import net.md_5.bungee.netty.PipelineUtils;
@@ -22,6 +23,7 @@ public class PingHandler extends PacketHandler
 
     private final ServerInfo target;
     private final Callback<ServerPing> callback;
+    private final PendingConnection pendingConnection;
     private ChannelWrapper channel;
 
     @Override
@@ -33,7 +35,7 @@ public class PingHandler extends PacketHandler
         channel.getHandle().pipeline().addAfter( PipelineUtils.FRAME_DECODER, PipelineUtils.PACKET_DECODER, new MinecraftDecoder( Protocol.STATUS, false, ProxyServer.getInstance().getProtocolVersion() ) );
         channel.getHandle().pipeline().addAfter( PipelineUtils.FRAME_PREPENDER, PipelineUtils.PACKET_ENCODER, encoder );
 
-        channel.write( new Handshake( ProxyServer.getInstance().getProtocolVersion(), target.getAddress().getHostString(), target.getAddress().getPort(), 1 ) );
+        channel.write( new Handshake( ( pendingConnection != null ) ? pendingConnection.getVersion() : ProxyServer.getInstance().getProtocolVersion(), ( pendingConnection != null && BungeeCord.getInstance().config.isIpFoward() ) ? target.getAddress().getHostString() + "\00" + pendingConnection.getIp() + "\00" + pendingConnection.getUUID() : target.getAddress().getHostString(), target.getAddress().getPort(), 1 ) );
 
         encoder.setProtocol( Protocol.STATUS );
         channel.write( new StatusRequest() );

--- a/proxy/src/main/java/net/md_5/bungee/tab/Passthrough.java
+++ b/proxy/src/main/java/net/md_5/bungee/tab/Passthrough.java
@@ -1,0 +1,17 @@
+package net.md_5.bungee.tab;
+
+import net.md_5.bungee.api.tab.TabListAdapter;
+import net.md_5.bungee.protocol.packet.PlayerListItem;
+
+import java.util.Collection;
+import java.util.HashSet;
+
+public class Passthrough extends TabListAdapter
+{
+    @Override
+    public boolean onListUpdate(String name, boolean online, int ping)
+    {
+        getPlayer().unsafe().sendPacket(new PlayerListItem(name, online, (short) ping));
+        return true;
+    }
+}


### PR DESCRIPTION
You can now use BungeeCord after another BungeeCord
Pings also respect the IP forwarding
A new Tablist mode "PASSTHROUGH" has been implemented to pass the PlayerListItems through
Added getIp() to the pending Connection to get the real Player IP (even through BungeeCord after BungeeCord). This does not break any Plugins since the getAddress() also works but it can give back the wrong IP
