### PR TITLE
Correct method getPlayerCount of Team.

### DIFF
--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/Team.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/Team.java
@@ -25,8 +25,13 @@ public class Team extends DefinedPacket
     private String prefix;
     private String suffix;
     private boolean friendlyFire;
-    private short playerCount;
+//  private short playerCount; is stored in the length of the players array
     private String[] players;
+    
+    public int getPlayerCount()
+    {
+    	return players.length;
+    }
 
     /**
      * Packet to destroy a team.


### PR DESCRIPTION
it seems that i am the first one to use getPlayerCount which always returns 0 before the correction. Did all of you use getPlayers.length instead?
