### PR TITLE
Bump netty version to 4.0.17.Final | Allow Linux to take advatange of th...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
 
     <properties>
         <build.number>unknown</build.number>
-        <netty.version>4.0.14.Final</netty.version>
+        <netty.version>4.0.17.Final</netty.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/proxy/pom.xml
+++ b/proxy/pom.xml
@@ -25,7 +25,7 @@
     <dependencies>
         <dependency>
             <groupId>io.netty</groupId>
-            <artifactId>netty-codec-http</artifactId>
+            <artifactId>netty-all</artifactId>
             <version>${netty.version}</version>
             <scope>compile</scope>
         </dependency>

--- a/proxy/src/main/java/net/md_5/bungee/BungeeServerInfo.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeServerInfo.java
@@ -2,9 +2,10 @@ package net.md_5.bungee;
 
 import com.google.common.base.Preconditions;
 import io.netty.bootstrap.Bootstrap;
-import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
-import io.netty.channel.ChannelOption;
+import io.netty.channel.*;
+import io.netty.channel.epoll.EpollEventLoopGroup;
+import io.netty.channel.epoll.EpollSocketChannel;
+import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
@@ -122,13 +123,25 @@ public class BungeeServerInfo implements ServerInfo
                 }
             }
         };
+        MultithreadEventLoopGroup loopGroup = BungeeCord.getInstance().eventLoops;
         new Bootstrap()
-                .channel( NioSocketChannel.class )
-                .group( BungeeCord.getInstance().eventLoops )
+                .channel( getSocketChannel( loopGroup ) )
+                .group( loopGroup )
                 .handler( PipelineUtils.BASE )
                 .option( ChannelOption.CONNECT_TIMEOUT_MILLIS, 5000 ) // TODO: Configurable
                 .remoteAddress( getAddress() )
                 .connect()
                 .addListener( listener );
+    }
+
+    private Class<? extends SocketChannel> getSocketChannel(MultithreadEventLoopGroup eventLoop)
+    {
+        if( eventLoop instanceof EpollEventLoopGroup )
+        {
+            return EpollSocketChannel.class;
+        } else
+        {
+            return NioSocketChannel.class;
+        }
     }
 }


### PR DESCRIPTION
...e superior Epoll class sockets while still leaving NIO sockets implemented for Non-Linux operating systems.

Been working with Epoll a lot recently, seems to reduce latency, CPU usage, lost packets, dropped connections, as well as increase overall capacity. Though I would take a swing at pushing it to BungeeCord but still leaving NioSocket implementation for Non-Linux users.
