### PR TITLE
Fix NPE when converting invalid color character from legacy text (Fixes #934)

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/chat/TextComponent.java
+++ b/api/src/main/java/net/md_5/bungee/api/chat/TextComponent.java
@@ -42,12 +42,12 @@ public class TextComponent extends BaseComponent
             {
                 i++;
                 c = message.charAt( i );
-                ChatColor format = ChatColor.getByChar( c );
-                if ( format == null ) continue;
                 if ( c >= 'A' && c <= 'Z' )
                 {
                     c += 32;
                 }
+                ChatColor format = ChatColor.getByChar( c );
+                if ( format == null ) continue;
                 if ( builder.length() > 0 )
                 {
                     TextComponent old = component;


### PR DESCRIPTION
Removes all invalid color codes from the string that is converted.
