### PR TITLE
Validate host name on connection

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
+++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
@@ -66,6 +66,11 @@ public class ServerConnector extends PacketHandler
         this.ch = channel;
 
         Handshake originalHandshake = user.getPendingConnection().getHandshake();
+        if ( originalHandshake.getHost() != null && originalHandshake.getHost().contains("\00") )
+        {
+            user.disconnect( "Invalid Hostname" );
+            return;
+        }
         Handshake copiedHandshake = new Handshake( originalHandshake.getProtocolVersion(), originalHandshake.getHost(), originalHandshake.getPort(), 2 );
         if ( BungeeCord.getInstance().config.isIpFoward() )
         {


### PR DESCRIPTION
Ensure that hostname does not contain invalid characters on login.
