### PR TITLE
Return a Users UUID as a UUID object whilst keeping support for returnin...

### DIFF
--- a/api/src/main/java/net/md_5/bungee/Util.java
+++ b/api/src/main/java/net/md_5/bungee/Util.java
@@ -2,6 +2,7 @@ package net.md_5.bungee;
 
 import com.google.common.base.Joiner;
 import java.net.InetSocketAddress;
+import java.util.UUID;
 
 /**
  * Series of utility classes to perform various operations.
@@ -62,5 +63,16 @@ public class Util
     public static String format(Iterable<?> objects, String separators)
     {
         return Joiner.on( separators ).join( objects );
+    }
+
+    /**
+     * Converts a String to a UUID
+     *
+     * @param uuid The string to be converted
+     * @return The result
+     */
+    public static UUID getUUID(String uuid)
+    {
+        return UUID.fromString(uuid.substring(0, 8) + "-" + uuid.substring(8, 12) + "-" + uuid.substring(12, 16) + "-" + uuid.substring(16, 20) + "-" + uuid.substring(20, 32));
     }
 }

--- a/api/src/main/java/net/md_5/bungee/api/connection/PendingConnection.java
+++ b/api/src/main/java/net/md_5/bungee/api/connection/PendingConnection.java
@@ -1,6 +1,8 @@
 package net.md_5.bungee.api.connection;
 
 import java.net.InetSocketAddress;
+import java.util.UUID;
+
 import net.md_5.bungee.api.config.ListenerInfo;
 
 /**
@@ -41,8 +43,17 @@ public interface PendingConnection extends Connection
      * Get this connection's UUID, if set.
      *
      * @return the UUID
+     * @deprecated In favour of {@link #getUniqueId()}
      */
+    @Deprecated
     String getUUID();
+
+    /**
+     * Get this connection's UUID, if set.
+     *
+     * @return the UUID
+     */
+    UUID getUniqueId();
 
     /**
      * Get this connection's online mode.

--- a/api/src/main/java/net/md_5/bungee/api/connection/ProxiedPlayer.java
+++ b/api/src/main/java/net/md_5/bungee/api/connection/ProxiedPlayer.java
@@ -5,6 +5,8 @@ import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.config.ServerInfo;
 import net.md_5.bungee.api.tab.TabListHandler;
 
+import java.util.UUID;
+
 /**
  * Represents a player who's connection is being connected to somewhere else,
  * whether it be a remote or embedded server.
@@ -117,6 +119,15 @@ public interface ProxiedPlayer extends Connection, CommandSender
      * Get this connection's UUID, if set.
      *
      * @return the UUID
+     * @deprecated In favour of {@link #getUniqueId()}
      */
+    @Deprecated
     String getUUID();
+
+    /**
+     * Get this connection's UUID, if set.
+     *
+     * @return the UUID
+     */
+    UUID getUniqueId();
 }

--- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
@@ -14,6 +14,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.logging.Level;
 import lombok.Getter;
 import lombok.NonNull;
@@ -420,5 +421,11 @@ public final class UserConnection implements ProxiedPlayer
     public String getUUID()
     {
         return getPendingConnection().getUUID();
+    }
+
+    @Override
+    public UUID getUniqueId()
+    {
+        return getPendingConnection().getUniqueId();
     }
 }

--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -8,6 +8,7 @@ import java.net.URLEncoder;
 import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import java.util.logging.Level;
 import javax.crypto.SecretKey;
 import lombok.Getter;
@@ -81,7 +82,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
     @Getter
     private InetSocketAddress virtualHost;
     @Getter
-    private String UUID;
+    private UUID uniqueId;
 
     private enum State
     {
@@ -320,7 +321,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
                     LoginResult obj = BungeeCord.getInstance().gson.fromJson( result, LoginResult.class );
                     if ( obj != null )
                     {
-                        UUID = obj.getId();
+                        uniqueId = Util.getUUID(obj.getId());
                         finish();
                         return;
                     }
@@ -366,11 +367,11 @@ public class InitialHandler extends PacketHandler implements PendingConnection
                     {
                         if ( ch.getHandle().isActive() )
                         {
-                            if ( UUID == null )
+                            if ( uniqueId == null )
                             {
-                                UUID = java.util.UUID.nameUUIDFromBytes( ( "OfflinePlayer:" + getName() ).getBytes( Charsets.UTF_8 ) ).toString();
+                                uniqueId = java.util.UUID.nameUUIDFromBytes( ( "OfflinePlayer:" + getName() ).getBytes( Charsets.UTF_8 ) );
                             }
-                            unsafe.sendPacket( new LoginSuccess( UUID, getName() ) );
+                            unsafe.sendPacket( new LoginSuccess(uniqueId.toString(), getName() ) );
                             ch.setProtocol( Protocol.GAME );
 
                             UserConnection userCon = new UserConnection( bungee, ch, getName(), InitialHandler.this );
@@ -464,6 +465,11 @@ public class InitialHandler extends PacketHandler implements PendingConnection
     {
         Preconditions.checkState( thisState == State.USERNAME, "Can only set online mode status whilst state is username" );
         this.onlineMode = onlineMode;
+    }
+
+    @Override
+    public String getUUID(){
+        return uniqueId.toString().replaceAll("-", "");
     }
 
     @Override


### PR DESCRIPTION
...g as a String

I added a new method (getUniqueId()) to the ProxiedPlayer interface to return a users UUID as a UUID object (before it was returned as a String). I had to add this as a new method with a slightly different name as changing the return type of getUUID would break any plugins using it. I instead deprecated it ;)

Methods added to the Util class are the same ones used by Minecraft [here](https://github.com/Bukkit/mc-dev/blob/master/net/minecraft/server/UtilUUID.java)

Maybe the getUUID method can be removed once everyone has switched over.
