### PR TITLE
Let the PluginLoader also load Annotation driven Plugins. 

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -43,5 +43,10 @@
             <version>${project.version}</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>javassist</groupId>
+            <artifactId>javassist</artifactId>
+            <version>3.12.1.GA</version>
+        </dependency>
     </dependencies>
 </project>

--- a/api/src/main/java/net/md_5/bungee/api/plugin/PluginAutoDetector.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/PluginAutoDetector.java
@@ -1,0 +1,102 @@
+package net.md_5.bungee.api.plugin;
+
+import javassist.bytecode.AnnotationsAttribute;
+import javassist.bytecode.ClassFile;
+import javassist.bytecode.annotation.Annotation;
+import javassist.bytecode.annotation.ArrayMemberValue;
+import javassist.bytecode.annotation.MemberValue;
+import javassist.bytecode.annotation.StringMemberValue;
+import net.md_5.bungee.api.ProxyServer;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.lang.String;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.logging.Level;
+
+public class PluginAutoDetector
+{
+    public static PluginDescription checkPlugin( JarFile jarFile )
+    {
+        Enumeration<JarEntry> jarEntries = jarFile.entries();
+
+        if (jarEntries == null)
+        {
+            ProxyServer.getInstance().getLogger().log( Level.WARNING, "Could not load Plugin. File " + jarFile + " is empty" );
+            return null;
+        }
+
+        try
+        {
+            while ( jarEntries.hasMoreElements() )
+            {
+                JarEntry jarEntry = jarEntries.nextElement();
+
+                if ( jarEntry != null && jarEntry.getName().endsWith(".class") )
+                {
+                    ClassFile classFile = new ClassFile( new DataInputStream( jarFile.getInputStream( jarEntry ) ) );
+                    if ( classFile.getSuperclass().equals( "net.md_5.bungee.api.plugin.Plugin" ) )
+                    {
+                        PluginDescription pluginDescription = new PluginDescription();
+                        pluginDescription.setName( classFile.getName().substring( classFile.getName().lastIndexOf('.') + 1 ) );
+
+                        AnnotationsAttribute visible = (AnnotationsAttribute) classFile.getAttribute( AnnotationsAttribute.visibleTag );
+
+                        for ( Annotation annotation : visible.getAnnotations())
+                        {
+                            switch (annotation.getTypeName())
+                            {
+                                case "net.md_5.bungee.api.plugin.annotation.Description":
+                                    pluginDescription.setDescription(((StringMemberValue)annotation.getMemberValue("value")).getValue());
+                                    break;
+
+                                case "net.md_5.bungee.api.plugin.annotation.Author":
+                                    pluginDescription.setAuthor(((StringMemberValue)annotation.getMemberValue("value")).getValue());
+                                    break;
+
+                                case "net.md_5.bungee.api.plugin.annotation.Version":
+                                    pluginDescription.setVersion(((StringMemberValue)annotation.getMemberValue("value")).getValue());
+                                    break;
+
+                                case "net.md_5.bungee.api.plugin.annotation.Depends":
+                                    MemberValue[] dependsValues = ((ArrayMemberValue) annotation.getMemberValue("value")).getValue();
+                                    HashSet<String> dependsStringValues = new HashSet<>();
+                                    for ( MemberValue value : dependsValues )
+                                    {
+                                        dependsStringValues.add(((StringMemberValue)value).getValue());
+                                    }
+
+                                    pluginDescription.setDepends(dependsStringValues);
+                                    break;
+
+                                case "net.md_5.bungee.api.plugin.annotation.SoftDepends":
+                                    MemberValue[] softDependsValues = ((ArrayMemberValue) annotation.getMemberValue("value")).getValue();
+                                    HashSet<String>  softDependsStringValues = new HashSet<>();
+                                    for ( MemberValue value : softDependsValues )
+                                    {
+                                        softDependsStringValues.add(((StringMemberValue)value).getValue());
+                                    }
+
+                                    pluginDescription.setSoftDepends(softDependsStringValues);
+                                    break;
+                            }
+                        }
+
+                        pluginDescription.setMain( classFile.getName() );
+
+                        return pluginDescription;
+                    }
+                }
+            }
+
+            return null;
+        } catch (IOException e)
+        {
+            ProxyServer.getInstance().getLogger().log( Level.WARNING, "Could not load Plugin. File " + jarFile + " is corrupted", e );
+            return null;
+        }
+    }
+}

--- a/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
@@ -320,13 +320,21 @@ public class PluginManager
                     {
                         pdf = jar.getJarEntry( "plugin.yml" );
                     }
-                    Preconditions.checkNotNull( pdf, "Plugin must have a plugin.yml or bungee.yml" );
 
-                    try ( InputStream in = jar.getInputStream( pdf ) )
+                    if ( pdf == null )
                     {
-                        PluginDescription desc = yaml.loadAs( in, PluginDescription.class );
-                        desc.setFile( file );
-                        toLoad.put( desc.getName(), desc );
+                        PluginDescription desc = PluginAutoDetector.checkPlugin( jar );
+                        Preconditions.checkNotNull(desc, "Plugin does not contain plugin.yml, bungee.yml or is automaticly detectable");
+                        desc.setFile(file);
+                        toLoad.put(desc.getName(), desc);
+                    } else
+                    {
+                        try (InputStream in = jar.getInputStream(pdf))
+                        {
+                            PluginDescription desc = yaml.loadAs(in, PluginDescription.class);
+                            desc.setFile(file);
+                            toLoad.put(desc.getName(), desc);
+                        }
                     }
                 } catch ( Exception ex )
                 {

--- a/api/src/main/java/net/md_5/bungee/api/plugin/annotation/Author.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/annotation/Author.java
@@ -1,0 +1,13 @@
+package net.md_5.bungee.api.plugin.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface Author
+{
+    String value() default "";
+}

--- a/api/src/main/java/net/md_5/bungee/api/plugin/annotation/Depends.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/annotation/Depends.java
@@ -1,0 +1,13 @@
+package net.md_5.bungee.api.plugin.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface Depends
+{
+    String[] value() default {};
+}

--- a/api/src/main/java/net/md_5/bungee/api/plugin/annotation/Description.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/annotation/Description.java
@@ -1,0 +1,13 @@
+package net.md_5.bungee.api.plugin.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface Description
+{
+    String value() default "";
+}

--- a/api/src/main/java/net/md_5/bungee/api/plugin/annotation/SoftDepends.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/annotation/SoftDepends.java
@@ -1,0 +1,13 @@
+package net.md_5.bungee.api.plugin.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface SoftDepends
+{
+    String[] value() default {};
+}

--- a/api/src/main/java/net/md_5/bungee/api/plugin/annotation/Version.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/annotation/Version.java
@@ -1,0 +1,13 @@
+package net.md_5.bungee.api.plugin.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface Version
+{
+    String value() default "";
+}


### PR DESCRIPTION
A example for a annotation driven Plugin can be found here: http://newpaste.md-5.net/ptvvzel5s

This is how it works:
- It looks for bungee.yml
- If not found for plugin.yml
- If not found it scans the Plugins JAR for a Class which extends Plugin and scans for metadata Annotations

Annotations can be given multiple times and the last one found will be set into the Description to load. The name is resoved out of the Classname of the Plugin Class (the simplename).

To read the ByteCode from the .class file inside the JAR i added JavaSSIST, the smallest and most effective Bytecode manipulation Lib i could find.
