### PR TITLE
Add ExceptionEvent so plugins can handle exceptions thrown by EventHandlers

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/plugin/ExceptionEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/ExceptionEvent.java
@@ -1,0 +1,40 @@
+package net.md_5.bungee.api.plugin;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import net.md_5.bungee.event.EventHandlerMethod;
+
+/**
+ * Event that is submitted when a previous event handler caused an error.
+ */
+@RequiredArgsConstructor
+@Getter
+@EqualsAndHashCode
+@ToString
+public final class ExceptionEvent extends Event
+{
+
+    /**
+     * The error that occured.
+     */
+    private final Throwable throwable;
+    /**
+     * The event that was being processed.
+     */
+    private final Event event;
+    /**
+     * The event handler that caused the error.
+     */
+    private final EventHandlerMethod handler;
+
+    /**
+     * Cancelled state.
+     *
+     * A cancelled ExceptionEvent will not be printed to the console.
+     */
+    @Setter
+    private boolean cancelled = false;
+}

--- a/api/src/main/java/net/md_5/bungee/api/plugin/NotifyingExceptionHandler.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/NotifyingExceptionHandler.java
@@ -1,0 +1,39 @@
+package net.md_5.bungee.api.plugin;
+
+import net.md_5.bungee.event.EventHandlerMethod;
+import net.md_5.bungee.event.LoggingExceptionHandler;
+
+import java.util.logging.Logger;
+
+/**
+ * An EventExceptionHandler that will call an ExceptionEvent when an error occurs.
+ */
+public class NotifyingExceptionHandler extends LoggingExceptionHandler
+{
+
+    private final PluginManager pluginManager;
+
+    public NotifyingExceptionHandler(Logger logger, PluginManager pluginManager)
+    {
+        super( logger );
+        this.pluginManager = pluginManager;
+    }
+
+    @Override
+    public void onException(Throwable ex, Object event, EventHandlerMethod method)
+    {
+        // Check if this actually is an event. It should always be one but it doesn't hurt to check.
+        // Additionally, avoid a stack overflow when an ExceptionEvent handler causes an error.
+        if ( event instanceof Event && !( event instanceof ExceptionEvent ) )
+        {
+            ExceptionEvent notification = pluginManager.callEvent( new ExceptionEvent( ex, (Event) event, method ) );
+            if ( notification.isCancelled() )
+            {
+                // The event was cancelled so we should not print this error.
+                return;
+            }
+        }
+        // This is either an ExceptionEvent already or the ExceptionEvent was not cancelled so we should use the LoggingExceptionHandler to print it to console.
+        super.onException( ex, event, method );
+    }
+}

--- a/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
@@ -22,6 +22,7 @@ import java.util.Stack;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import net.md_5.bungee.api.ChatColor;
@@ -56,6 +57,7 @@ public class PluginManager
     {
         this.proxy = proxy;
         eventBus = new EventBus( proxy.getLogger() );
+        eventBus.setExceptionHandler( new NotifyingExceptionHandler( proxy.getLogger() == null ? Logger.getGlobal() : proxy.getLogger(), this ) );
     }
 
     /**

--- a/event/src/main/java/net/md_5/bungee/event/EventBus.java
+++ b/event/src/main/java/net/md_5/bungee/event/EventBus.java
@@ -1,8 +1,9 @@
 package net.md_5.bungee.event;
 
+import lombok.Setter;
+
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -22,6 +23,9 @@ public class EventBus
     private final ReadWriteLock lock = new ReentrantReadWriteLock();
     private final Logger logger;
 
+    @Setter
+    private EventExceptionHandler exceptionHandler;
+
     public EventBus()
     {
         this( null );
@@ -30,6 +34,7 @@ public class EventBus
     public EventBus(Logger logger)
     {
         this.logger = ( logger == null ) ? Logger.getGlobal() : logger;
+        this.exceptionHandler = new LoggingExceptionHandler( this.logger );
     }
 
     public void post(Object event)
@@ -53,7 +58,7 @@ public class EventBus
                         throw new Error( "Method rejected target/argument: " + event, ex );
                     } catch ( InvocationTargetException ex )
                     {
-                        logger.log( Level.WARNING, MessageFormat.format( "Error dispatching event {0} to listener {1}", event, method.getListener() ), ex.getCause() );
+                        exceptionHandler.onException( ex.getCause(), event, method );
                     }
                 }
             }

--- a/event/src/main/java/net/md_5/bungee/event/EventExceptionHandler.java
+++ b/event/src/main/java/net/md_5/bungee/event/EventExceptionHandler.java
@@ -1,0 +1,10 @@
+package net.md_5.bungee.event;
+
+/**
+ * Listener that gets notified when an event handler causes an error during event handling.
+ */
+public interface EventExceptionHandler
+{
+
+    void onException(Throwable exception, Object event, EventHandlerMethod handler);
+}

--- a/event/src/main/java/net/md_5/bungee/event/LoggingExceptionHandler.java
+++ b/event/src/main/java/net/md_5/bungee/event/LoggingExceptionHandler.java
@@ -1,0 +1,23 @@
+package net.md_5.bungee.event;
+
+import lombok.RequiredArgsConstructor;
+
+import java.text.MessageFormat;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * An EventExceptionHandler that logs the error to the logger (console).
+ */
+@RequiredArgsConstructor
+public class LoggingExceptionHandler implements EventExceptionHandler
+{
+
+    private final Logger logger;
+
+    @Override
+    public void onException(Throwable ex, Object event, EventHandlerMethod method)
+    {
+        logger.log( Level.WARNING, MessageFormat.format( "Error dispatching event {0} to listener {1}", event, method.getListener() ), ex );
+    }
+}


### PR DESCRIPTION
Adds an ExceptionEvent which is called when an EventHandler throws an Exception.
- Exceptions in ExceptionEvent handlers will simply be logged.
- An ExceptionEvent can be cancelled and will not be logged in that case (custom logging?).
- It is not possible to find the plugin that owns the handler at the moment because of the way EventHandlers are coded.
- A stack overflow could occur if an ExceptionEvent handler submits another event which causes an error which calls the ExceptionEvent handler which submits another event etc. I doubt this is important, however, because this is very unlikely.
- I personally want this change because I would like to use my own logging system without having to wrap all my event handlers in try-catch blocks.
