### PR TITLE
Add method to get a connected player via their UUID

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/ProxyServer.java
+++ b/api/src/main/java/net/md_5/bungee/api/ProxyServer.java
@@ -7,6 +7,7 @@ import java.io.File;
 import java.net.InetSocketAddress;
 import java.util.Collection;
 import java.util.Map;
+import java.util.UUID;
 import java.util.logging.Logger;
 import lombok.Getter;
 import net.md_5.bungee.api.config.ConfigurationAdapter;
@@ -78,6 +79,14 @@ public abstract class ProxyServer
      * @return their player instance
      */
     public abstract ProxiedPlayer getPlayer(String name);
+
+    /**
+     * Gets a connected player via their UUID
+     *
+     * @param uuid of the player
+     * @return their player instance
+     */
+    public abstract ProxiedPlayer getPlayer(UUID uuid);
 
     /**
      * Return all servers registered to this proxy, keyed by name. Unlike the

--- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
@@ -439,6 +439,26 @@ public class BungeeCord extends ProxyServer
         }
     }
 
+    public ProxiedPlayer getPlayer(UUID uuid)
+    {
+        connectionLock.readLock().lock();
+        try
+        {
+            for (ProxiedPlayer proxiedPlayer : connections.values())
+            {
+                if (proxiedPlayer.getUniqueId().equals(uuid))
+                {
+                    return proxiedPlayer;
+                }
+            }
+
+            return null;
+        } finally
+        {
+            connectionLock.readLock().unlock();
+        }
+    }
+
     @Override
     public Map<String, ServerInfo> getServers()
     {


### PR DESCRIPTION
I added a helper method to get a player via their UUID.

Since we don't have a map with UUID as the key and player as the value, I had to loop through the values of the existing map. Maybe in the future it could be changed so that the UUID is the key and instead we loop through for the name as UUIDs will probably be getting used more instead of the player name.

I'm not sure if the read locks are needed, let me know if I should remove them.
