### PR TITLE
Favicon API

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/Favicon.java
+++ b/api/src/main/java/net/md_5/bungee/api/Favicon.java
@@ -1,0 +1,135 @@
+package net.md_5.bungee.api;
+
+import com.google.common.io.BaseEncoding;
+import com.google.gson.TypeAdapter;
+import com.google.gson.internal.bind.TypeAdapters;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import javax.imageio.ImageIO;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Favicon shown in the server list.
+ */
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class Favicon
+{
+    private static final TypeAdapter<Favicon> FAVICON_TYPE_ADAPTER = new TypeAdapter<Favicon>()
+    {
+        @Override
+        public void write(JsonWriter out, Favicon value) throws IOException
+        {
+            TypeAdapters.STRING.write( out, value.getEncoded() );
+        }
+
+        @Override
+        public Favicon read(JsonReader in) throws IOException
+        {
+            return create( TypeAdapters.STRING.read( in ) );
+        }
+    };
+
+    public static TypeAdapter<Favicon> getFaviconTypeAdapter()
+    {
+        return FAVICON_TYPE_ADAPTER;
+    }
+
+    /**
+     * The encoded favicon, including MIME header.
+     */
+    @Getter
+    private final String encoded;
+
+    /**
+     * Reads a favicon from a file.
+     *
+     * @see #create(java.awt.image.BufferedImage)
+     */
+    public static Favicon read(File file) throws IOException
+    {
+        return read( file.toPath() );
+    }
+
+    /**
+     * Reads a favicon from a file.
+     *
+     * @see #create(java.awt.image.BufferedImage)
+     */
+    public static Favicon read(Path file) throws IOException
+    {
+        try ( InputStream stream = Files.newInputStream( file ) )
+        {
+            return read( stream );
+        }
+    }
+
+    /**
+     * Reads a favicon from a stream.
+     *
+     * @see #create(java.awt.image.BufferedImage)
+     */
+    public static Favicon read(InputStream source) throws IOException
+    {
+        BufferedImage image = ImageIO.read( source );
+        return create( image );
+    }
+
+    /**
+     * Creates a Favicon from an image.
+     * <p/>
+     * Currently, this image must be exactly 64 * 64 pixel in size.
+     */
+    public static Favicon create(BufferedImage image)
+    {
+        // check size
+        if ( image.getWidth() != 64 || image.getHeight() != 64 )
+        {
+            throw new IllegalArgumentException( "Server icon must be exactly 64x64 pixels" );
+        }
+
+        // dump image PNG
+        byte[] imageBytes;
+        try
+        {
+            ByteArrayOutputStream stream = new ByteArrayOutputStream();
+            ImageIO.write( image, "PNG", stream );
+            imageBytes = stream.toByteArray();
+        } catch ( IOException e )
+        {
+            // ByteArrayOutputStream should never throw this
+            throw new AssertionError( e );
+        }
+
+        // encode with header
+        String encoded = "data:image/png;base64," + BaseEncoding.base64().encode( imageBytes );
+
+        // check encoded image size
+        if ( encoded.length() > Short.MAX_VALUE )
+        {
+            throw new IllegalArgumentException( "Favicon file too large for server to process" );
+        }
+
+        // create
+        return create( encoded );
+    }
+
+    /**
+     * Creates a Favicon from an encoded PNG.
+     *
+     * @deprecated Use #create(java.awt.image.BufferedImage) or one of the read methods instead.
+     */
+    @Deprecated
+    public static Favicon create(String encodedString)
+    {
+        return new Favicon( encodedString );
+    }
+}

--- a/api/src/main/java/net/md_5/bungee/api/ServerPing.java
+++ b/api/src/main/java/net/md_5/bungee/api/ServerPing.java
@@ -1,15 +1,13 @@
 package net.md_5.bungee.api;
 
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import net.md_5.bungee.Util;
 
-import java.util.UUID;
-
 /**
- * Represents the standard list data returned by opening a server in the
- * Minecraft client server list, or hitting it with a packet 0xFE.
+ * Represents the standard list data returned by opening a server in the Minecraft client server list, or hitting it with a packet 0xFE.
  */
 @Data
 @NoArgsConstructor
@@ -27,6 +25,7 @@ public class ServerPing
         private String name;
         private int protocol;
     }
+
     private Players players;
 
     @Data
@@ -72,6 +71,35 @@ public class ServerPing
             return uniqueId.toString().replaceAll( "-", "" );
         }
     }
+
     private String description;
-    private String favicon;
+    private Favicon favicon;
+
+    @Deprecated
+    public ServerPing(Protocol version, Players players, String description, String favicon)
+    {
+        this( version, players, description, Favicon.create( favicon ) );
+    }
+
+    @Deprecated
+    public String getFavicon()
+    {
+        return getFaviconObject() == null ? null : getFaviconObject().getEncoded();
+    }
+
+    public Favicon getFaviconObject()
+    {
+        return this.favicon;
+    }
+
+    @Deprecated
+    public void setFavicon(String favicon)
+    {
+        setFavicon( favicon == null ? null : Favicon.create( favicon ) );
+    }
+
+    public void setFavicon(Favicon favicon)
+    {
+        this.favicon = favicon;
+    }
 }

--- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
@@ -1,6 +1,7 @@
 package net.md_5.bungee;
 
 import com.google.gson.GsonBuilder;
+import net.md_5.bungee.api.Favicon;
 import net.md_5.bungee.api.ServerPing;
 import net.md_5.bungee.module.ModuleManager;
 import com.google.common.io.ByteStreams;
@@ -126,14 +127,16 @@ public class BungeeCord extends ProxyServer
     @Getter
     private final Logger logger;
     public final Gson gson = new GsonBuilder()
-            .registerTypeAdapter( ServerPing.PlayerInfo.class, new PlayerInfoSerializer( 5 ) ).create();
+            .registerTypeAdapter( ServerPing.PlayerInfo.class, new PlayerInfoSerializer( 5 ) )
+            .registerTypeAdapter( Favicon.class, Favicon.getFaviconTypeAdapter() ).create();
     public final Gson gsonLegacy = new GsonBuilder()
-            .registerTypeAdapter( ServerPing.PlayerInfo.class, new PlayerInfoSerializer( 4 ) ).create();
+            .registerTypeAdapter( ServerPing.PlayerInfo.class, new PlayerInfoSerializer( 4 ) )
+            .registerTypeAdapter( Favicon.class, Favicon.getFaviconTypeAdapter() ).create();
     @Getter
     private ConnectionThrottle connectionThrottle;
     private final ModuleManager moduleManager = new ModuleManager();
 
-    
+
     {
         // TODO: Proper fallback when we interface the manager
         getPluginManager().registerCommand( null, new CommandReload() );

--- a/proxy/src/main/java/net/md_5/bungee/conf/Configuration.java
+++ b/proxy/src/main/java/net/md_5/bungee/conf/Configuration.java
@@ -1,12 +1,7 @@
 package net.md_5.bungee.conf;
 
 import com.google.common.base.Preconditions;
-import com.google.common.io.BaseEncoding;
-import com.google.common.io.Files;
 import gnu.trove.map.TMap;
-import java.awt.Image;
-import java.awt.image.BufferedImage;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
@@ -14,8 +9,9 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.UUID;
 import java.util.logging.Level;
-import javax.imageio.ImageIO;
 import lombok.Getter;
+import lombok.Setter;
+import net.md_5.bungee.api.Favicon;
 import net.md_5.bungee.api.ProxyConfig;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.config.ConfigurationAdapter;
@@ -55,7 +51,7 @@ public class Configuration implements ProxyConfig
     private Collection<String> disabledCommands;
     private int throttle = 4000;
     private boolean ipFoward;
-    public String favicon;
+    @Setter private Favicon favicon;
 
     public void load()
     {
@@ -67,28 +63,8 @@ public class Configuration implements ProxyConfig
         {
             try
             {
-                BufferedImage image = ImageIO.read( fav );
-                if ( image != null )
-                {
-                    if ( image.getHeight() == 64 && image.getWidth() == 64 )
-                    {
-                        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
-                        ImageIO.write( image, "png", bytes );
-                        favicon = "data:image/png;base64," + BaseEncoding.base64().encode( bytes.toByteArray() );
-                        if ( favicon.length() > Short.MAX_VALUE )
-                        {
-                            ProxyServer.getInstance().getLogger().log( Level.WARNING, "Favicon file too large for server to process" );
-                            favicon = null;
-                        }
-                    } else
-                    {
-                        ProxyServer.getInstance().getLogger().log( Level.WARNING, "Server icon must be exactly 64x64 pixels" );
-                    }
-                } else
-                {
-                    ProxyServer.getInstance().getLogger().log( Level.WARNING, "Could not load server icon for unknown reason. Please double check its format." );
-                }
-            } catch ( IOException ex )
+                setFavicon( Favicon.read( fav ) );
+            } catch ( IOException | IllegalArgumentException ex )
             {
                 ProxyServer.getInstance().getLogger().log( Level.WARNING, "Could not load server icon", ex );
             }
@@ -142,5 +118,16 @@ public class Configuration implements ProxyConfig
                 }
             }
         }
+    }
+
+    @Deprecated
+    public String getFavicon()
+    {
+        return getFaviconObject().getEncoded();
+    }
+
+    public Favicon getFaviconObject()
+    {
+        return favicon;
     }
 }

--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -18,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 import net.md_5.bungee.*;
 import net.md_5.bungee.api.Callback;
 import net.md_5.bungee.api.ChatColor;
+import net.md_5.bungee.api.Favicon;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.ServerPing;
 import net.md_5.bungee.api.chat.BaseComponent;
@@ -130,7 +131,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
     public void handle(LegacyPing ping) throws Exception
     {
         ServerPing legacy = new ServerPing( new ServerPing.Protocol( bungee.getGameVersion(), bungee.getProtocolVersion() ),
-                new ServerPing.Players( listener.getMaxPlayers(), bungee.getOnlineCount(), null ), listener.getMotd(), null );
+                new ServerPing.Players( listener.getMaxPlayers(), bungee.getOnlineCount(), null ), listener.getMotd(), (Favicon) null );
         legacy = bungee.getPluginManager().callEvent( new ProxyPingEvent( this, legacy ) ).getResponse();
 
         String kickMessage = ChatColor.DARK_BLUE
@@ -179,7 +180,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
             pingBack.done( new ServerPing(
                     new ServerPing.Protocol( bungee.getGameVersion(), protocol ),
                     new ServerPing.Players( listener.getMaxPlayers(), bungee.getOnlineCount(), null ),
-                    motd, BungeeCord.getInstance().config.favicon ),
+                    motd, BungeeCord.getInstance().config.getFaviconObject() ),
                     null );
         }
 


### PR DESCRIPTION
Alternative implementation to #965. A bit more flexible (more `read()` methods etc).

This provides a `Favicon` class which has factory methods to create from an image, stream, `File` and `Path`. The Configuration and Gson compiler were modified to use the Favicon class.

**Issues:**
- Configuration.favicon is now private; this will break plugins that try to access it directly. Maybe a dummy variable could be made so they do not produce an exception but instead fail silently?
- Because there are two constructors for ServerPing now, calling one with `null` as the favicon will not compile properly (ambiguous). This should not break already compiled plugins, however.
