### PR TITLE
Show log warning when using one listener and not listening on 0.0.0.0

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/conf/Configuration.java
+++ b/proxy/src/main/java/net/md_5/bungee/conf/Configuration.java
@@ -1,6 +1,7 @@
 package net.md_5.bungee.conf;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Iterables;
 import gnu.trove.map.TMap;
 import java.io.File;
 import java.io.IOException;
@@ -116,6 +117,17 @@ public class Configuration implements ProxyConfig
                 {
                     ProxyServer.getInstance().getLogger().log( Level.SEVERE, "Forced host server {0} is not defined", server );
                 }
+            }
+        }
+
+        if ( listeners.size() == 1 )
+        {
+            ListenerInfo info = Iterables.getOnlyElement( listeners );
+            byte[] address = info.getHost().getAddress().getAddress();
+            // check for IPv4 != 0.0.0.0
+            if ( address.length == 4 && !Arrays.equals( address, new byte[ 4 ] ) )
+            {
+                ProxyServer.getInstance().getLogger().warning( "Not listening on 0.0.0.0, this might prevent you from joining! Set your listener address from " + info.getHost().getAddress() + " to 0.0.0.0 if you have any problems." );
             }
         }
     }


### PR DESCRIPTION
Adds a log message if you try to listen to a host other than `0.0.0.0`. This is usually a misconfiguration. Check isn't performed for non-ipv4 addresses or when there are multiple listeners because in those cases it's usually intended.
