### PR TITLE
Write server name in ServerIP subchannel response

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
@@ -348,6 +348,7 @@ public class DownstreamBridge extends PacketHandler
                 if ( info != null )
                 {
                     out.writeUTF( "ServerIP" );
+                    out.writeUTF( info.getName() );
                     out.writeUTF( info.getAddress().getAddress().getHostAddress() );
                     out.writeShort( info.getAddress().getPort() );
                 }


### PR DESCRIPTION
Behaves similarly to the UUIDOther implementation.
