### PR TITLE
Allow server removal on reload

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/conf/Configuration.java
+++ b/proxy/src/main/java/net/md_5/bungee/conf/Configuration.java
@@ -147,7 +147,7 @@ public class Configuration implements ProxyConfig
             }
 
             player.connect( servers.get( def ) );
-            player.sendMessage( ProxyServer.getInstance().getTranslation( "server_removed" ) );
+            player.sendMessage( ProxyServer.getInstance().getTranslation( "server_removed", def ) );
         }
     }
 

--- a/proxy/src/main/resources/messages.properties
+++ b/proxy/src/main/resources/messages.properties
@@ -21,5 +21,5 @@ server_went_down=\u00a7cThe server you were previously on went down, you have be
 total_players=Total players online: {0}
 name_too_long=Cannot have username longer than 16 characters
 ping_cannot_connect=\u00a7c[Bungee] Can't connect to server.
-server_removed=\u00a7cThe server you were on has been removed, you have been connected to the lobby
+server_removed=\u00a7cThe server you were on has been removed, you have been connected to {0}
 server_removed_kick=\u00a7cThe server you were on has been removed, you have been disconnected


### PR DESCRIPTION
Allows removing servers on reload. When players are connected to a server that has been removed on a reload, they are redirected to the default server.
