### PR TITLE
Fix ServerPing NPE w/ String favicons

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/ServerPing.java
+++ b/api/src/main/java/net/md_5/bungee/api/ServerPing.java
@@ -77,7 +77,7 @@ public class ServerPing
     @Deprecated
     public ServerPing(Protocol version, Players players, String description, String favicon)
     {
-        this( version, players, description, Favicon.create( favicon ) );
+        this( version, players, description, favicon == null ? null : Favicon.create( favicon ) );
     }
 
     @Deprecated


### PR DESCRIPTION
**The issue**:
Currently, passing a `null` favicon String to the `ServerPing(Protocol, Players, String, String)` constructor causes a NPE (_NullPointerException_). However, passing a `null` `Favicon` object to the corresponding constructor does not cause one. Setting the favicon String using the `setFavicon(String)` method doesn't cause a NPE either.

Therefore, the NPE thrown by the constructor is inconsistent and should be avoided. Please find a sample NPE here: http://newpaste.md-5.net/pmtqjc8vl (Note the `null` favicon)

**PR breakdown**:
This PR changes the documented (unintended?) behaviour by adding a null check before passing the favicon String to the alternative `Favicon` object constructor. This makes the constructor consistent with the other one and the `setFavicon(String)` method. This also adds compatibility for old (made before Favicon API) plugins passing `null` favicon Strings (and expecting no favicon to be displayed instead of a NPE).

I have also verified that this changes indeed fixes the NPE (Testing the same plugin that caused the NPE with my modified BungeeCord).

Thanks!

(Please ignore my fork being from TheUnnamedDude/BungeeCord, the branch for this PR is from the master repo and does only propose the mentioned changes)
