### PR TITLE
Allow multiple status checks in one connection

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -149,7 +149,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
     @Override
     public void handle(StatusRequest statusRequest) throws Exception
     {
-        Preconditions.checkState( thisState == State.STATUS, "Not expecting STATUS" );
+        Preconditions.checkState( thisState == State.STATUS || thisState == State.PING, "Not expecting STATUS" );
 
         ServerInfo forced = AbstractReconnectHandler.getForcedHost( this );
         final String motd = ( forced != null ) ? forced.getMotd() : listener.getMotd();
@@ -185,16 +185,13 @@ public class InitialHandler extends PacketHandler implements PendingConnection
                     motd, BungeeCord.getInstance().config.getFaviconObject() ),
                     null );
         }
-
-        thisState = State.PING;
     }
 
     @Override
     public void handle(PingPacket ping) throws Exception
     {
-        Preconditions.checkState( thisState == State.PING, "Not expecting PING" );
+        Preconditions.checkState( thisState == State.STATUS || thisState == State.PING, "Not expecting PING" );
         unsafe.sendPacket( ping );
-        disconnect( "" );
     }
 
     @Override


### PR DESCRIPTION
Standard Minecraft server (Bukkit and Spigot too) allows multiple status requests in one connection. BungeeCord should allow to do that too, because it could be used in some software.
