### PR TITLE
Update getGameVersion() to 1.7.10

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
@@ -510,7 +510,7 @@ public class BungeeCord extends ProxyServer
     @Override
     public String getGameVersion()
     {
-        return "1.7.4";
+        return "1.7.10";
     }
 
     @Override


### PR DESCRIPTION
Update the getGameVersion() to 1.7.10 for when Mojang releases it to display correctly on server lists.
