### PR TITLE
Aliases don´t get removed

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
@@ -82,7 +82,7 @@ public class PluginManager
      */
     public void unregisterCommand(Command command)
     {
-        commandMap.values().remove( command );
+        commandMap.values().removeAll( command );
         commandsByPlugin.values().remove( command );
     }
 
@@ -95,7 +95,7 @@ public class PluginManager
     {
         for ( Iterator<Command> it = commandsByPlugin.get( plugin ).iterator(); it.hasNext(); )
         {
-            commandMap.values().remove( it.next() );
+            commandMap.values().removeAll( it.next() );
             it.remove();
         }
     }


### PR DESCRIPTION
Issue: Aliases are put in the commandMap while registering, but they are not removed.
Why?: Only one (the first) String is removed, which is the Command Name.
Solution: Change to removeAll() instead of remove()
