### PR TITLE
Fix unregisterCommand(s) - second try

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
@@ -82,7 +82,7 @@ public class PluginManager
      */
     public void unregisterCommand(Command command)
     {
-        commandMap.values().remove( command );
+        while ( commandMap.values().remove( command ) );
         commandsByPlugin.values().remove( command );
     }
 
@@ -95,7 +95,8 @@ public class PluginManager
     {
         for ( Iterator<Command> it = commandsByPlugin.get( plugin ).iterator(); it.hasNext(); )
         {
-            commandMap.values().remove( it.next() );
+            Command command = it.next();
+            while ( commandMap.values().remove( command ) );
             it.remove();
         }
     }


### PR DESCRIPTION
Issue: Aliases are put in the commandMap while registering, but they are not removed.
Why?: Only one (the first) String is removed, which is the Command Name.
Solution: Instead of removing only once, remove as long as it returns true

Sorry, my first attempt was sh*t :) I tested this and it works now
