### PR TITLE
Fix typo in unsigned byte read method name

### DIFF
--- a/protocol/src/main/java/net/md_5/bungee/protocol/MinecraftInput.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/MinecraftInput.java
@@ -14,7 +14,7 @@ public class MinecraftInput
         return buf.readByte();
     }
 
-    public short readUnisgnedByte()
+    public short readUnsignedByte()
     {
         return buf.readUnsignedByte();
     }


### PR DESCRIPTION
Changes readUnisgnedByte to readUnsignedByte in MinecraftInput (note this method is not used anywhere, as far as I could tell)
