### PR TITLE
Added option to not handling registered commands at runtime

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/exception/CommandNotHandledException.java
+++ b/api/src/main/java/net/md_5/bungee/api/exception/CommandNotHandledException.java
@@ -1,0 +1,3 @@
+package net.md_5.bungee.api.exception;
+
+public class CommandNotHandledException extends RuntimeException { }

--- a/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
@@ -28,6 +28,7 @@ import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
+import net.md_5.bungee.api.exception.CommandNotHandledException;
 import net.md_5.bungee.event.EventBus;
 import net.md_5.bungee.event.EventHandler;
 import org.yaml.snakeyaml.Yaml;
@@ -145,7 +146,11 @@ public class PluginManager
         {
             if ( tabResults == null )
             {
-                command.execute( sender, args );
+                try {
+                    command.execute( sender, args );
+                } catch (CommandNotHandledException e) {
+                    return false;
+                }
             } else if ( command instanceof TabExecutor )
             {
                 for ( String s : ( (TabExecutor) command ).onTabComplete( sender, args ) )


### PR DESCRIPTION
This could be useful for BungeeCord plugins which have a corresponding Spigot plugin and want the Spigot plugin to handle specific subcommands.
