### PR TITLE
Downgrade forced host error from [SEVERE] to [WARNING]

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/conf/Configuration.java
+++ b/proxy/src/main/java/net/md_5/bungee/conf/Configuration.java
@@ -114,7 +114,7 @@ public class Configuration implements ProxyConfig
             {
                 if ( !servers.containsKey( server ) )
                 {
-                    ProxyServer.getInstance().getLogger().log( Level.SEVERE, "Forced host server {0} is not defined", server );
+                    ProxyServer.getInstance().getLogger().log( Level.WARNING, "Forced host server {0} is not defined", server );
                 }
             }
         }


### PR DESCRIPTION
As the server can continue if there is not a defined forced host, this doesn't necessarily demand a severe level log message.
