### PR TITLE
Write log messages with lower levels to the log file.

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/log/BungeeLogger.java
+++ b/proxy/src/main/java/net/md_5/bungee/log/BungeeLogger.java
@@ -3,6 +3,7 @@ package net.md_5.bungee.log;
 import java.io.IOException;
 import java.util.logging.FileHandler;
 import java.util.logging.Formatter;
+import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 import net.md_5.bungee.BungeeCord;
@@ -17,6 +18,8 @@ public class BungeeLogger extends Logger
     {
         super( "BungeeCord", null );
 
+        setLevel( Level.ALL );
+
         try
         {
             FileHandler fileHandler = new FileHandler( "proxy.log", 1 << 24, 8, true );
@@ -24,6 +27,7 @@ public class BungeeLogger extends Logger
             addHandler( fileHandler );
 
             ColouredWriter consoleHandler = new ColouredWriter( bungee.getConsoleReader() );
+            consoleHandler.setLevel( Level.INFO );
             consoleHandler.setFormatter( formatter );
             addHandler( consoleHandler );
         } catch ( IOException ex )

--- a/proxy/src/main/java/net/md_5/bungee/log/ColouredWriter.java
+++ b/proxy/src/main/java/net/md_5/bungee/log/ColouredWriter.java
@@ -63,7 +63,10 @@ public class ColouredWriter extends Handler
     @Override
     public void publish(LogRecord record)
     {
-        print( getFormatter().format( record ) );
+        if ( isLoggable( record ) )
+        {
+            print( getFormatter().format( record ) );
+        }
     }
 
     @Override


### PR DESCRIPTION
At the moment, messages logged using the [`FINE`](http://docs.oracle.com/javase/7/docs/api/java/util/logging/Level.html#FINE) level or lower don't get logged to the console or log file. When adding custom handlers to the plugin logger, they will also not logged by them.
For example, this won't log anything to the custom log file:

``` java
FileHandler handler = new FileHandler("test.log");
handler.setLevel(Level.ALL);
getLogger().addHandler(handler);
getLogger().fine("Test");
```

It is possible to get them to the file handler by setting the plugin logger's level to [`ALL`](http://docs.oracle.com/javase/7/docs/api/java/util/logging/Level.html#ALL), however this will also log all messages to the console.
These changes will make the main BungeeCord logger log messages of any level to the file log, but only messages of with level [`INFO`](http://docs.oracle.com/javase/7/docs/api/java/util/logging/Level.html#INFO) or higher to the console.
