### PR TITLE
Fixed RemoteQuery, which broke with the Epoll update

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
@@ -280,7 +280,7 @@ public class BungeeCord extends ProxyServer
                         }
                     }
                 };
-                new RemoteQuery( this, info ).start( new InetSocketAddress( info.getHost().getAddress(), info.getQueryPort() ), eventLoops, bindListener );
+                new RemoteQuery( this, info ).start(PipelineUtils.getDatagramChannel(), new InetSocketAddress( info.getHost().getAddress(), info.getQueryPort() ), eventLoops, bindListener );
             }
         }
     }

--- a/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java
+++ b/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java
@@ -7,10 +7,12 @@ import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.ServerChannel;
+import io.netty.channel.epoll.EpollDatagramChannel;
 import io.netty.channel.epoll.EpollEventLoopGroup;
 import io.netty.channel.epoll.EpollServerSocketChannel;
 import io.netty.channel.epoll.EpollSocketChannel;
 import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioDatagramChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.timeout.ReadTimeoutHandler;
@@ -113,6 +115,11 @@ public class PipelineUtils
     public static Class<? extends Channel> getChannel()
     {
         return epoll ? EpollSocketChannel.class : NioSocketChannel.class;
+    }
+    
+    public static Class<? extends Channel> getDatagramChannel()
+    {
+        return epoll ? EpollDatagramChannel.class : NioDatagramChannel.class;
     }
 
     public final static class Base extends ChannelInitializer<Channel>

--- a/query/src/main/java/net/md_5/bungee/query/RemoteQuery.java
+++ b/query/src/main/java/net/md_5/bungee/query/RemoteQuery.java
@@ -1,9 +1,9 @@
 package net.md_5.bungee.query;
 
 import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.EventLoopGroup;
-import io.netty.channel.socket.nio.NioDatagramChannel;
 import java.net.InetSocketAddress;
 import lombok.RequiredArgsConstructor;
 import net.md_5.bungee.api.ProxyServer;
@@ -16,10 +16,10 @@ public class RemoteQuery
     private final ProxyServer bungee;
     private final ListenerInfo listener;
 
-    public void start(InetSocketAddress address, EventLoopGroup eventLoop, ChannelFutureListener future)
+    public void start(Class<? extends Channel> channel, InetSocketAddress address, EventLoopGroup eventLoop, ChannelFutureListener future)
     {
         new Bootstrap()
-                .channel( NioDatagramChannel.class )
+                .channel( channel )
                 .group( eventLoop )
                 .handler( new QueryHandler( bungee, listener ) )
                 .localAddress( address )


### PR DESCRIPTION
The RemoteQuery is broken due to the Epoll update. It's still using a NioDatagramChannel on the EpollEventGroup, where it should be using EpollDatagramChannel.

I've "fixed" it for my needs, but i don't know if it would be the way you would fix that.
