### PR TITLE
Allow the security manager to be disabled with an configuration option

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
@@ -159,7 +159,24 @@ public class BungeeCord extends ProxyServer
 
     public BungeeCord() throws IOException
     {
-        System.setSecurityManager( new BungeeSecurityManager() );
+        if ( Boolean.getBoolean( "net.md_5.bungee.disableSecurityManager" ) )
+        {
+            System.err.println( "*** Warning: You have disabled the BungeeCord security manager. ***" );
+            System.err.println( "*** Disabling the BungeeCord security manager may compromise the stability of your server! ***" );
+            System.err.println( "*** SpigotMC is not responsible for any harm caused by disabling the security manager! ***" );
+            System.err.println( "*** Please proceed with caution! ***" );
+            System.err.println( "*** Starting server in 10 seconds ***" );
+            try
+            {
+                Thread.sleep( TimeUnit.SECONDS.toMillis( 10 ) );
+            } catch (InterruptedException ignored)
+            {
+                // Ignored, we should never be interrupted at this point!
+            }
+        } else
+        {
+            System.setSecurityManager( new BungeeSecurityManager() );
+        }
 
         try
         {


### PR DESCRIPTION
**Note**: I would consider this a temporary flag that should be removed after this feature has been given more consideration.

I do not think the impacts of this feature were thought out properly, although I agree with the intention of these. For example, DB pool implementations such as [BoneCP](http://jolbox.com) rely on the creation of threads. A related issue has to do with fetching via HTTPS (with HttpUrlConnection), which again spawns another thread.

When the property `net.md_5.bungee.disableSecurityManager` is set to `true`, a nag message is triggered and the proxy starts up after 10 seconds.
