### PR TITLE
Track plugin classloader to use plugin thread group where possible

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/plugin/Plugin.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/Plugin.java
@@ -91,16 +91,35 @@ public class Plugin
 
     //
     private ExecutorService service;
+    private ThreadGroup threadGroup;
+
+    private void ensureExecutorLoaded()
+    {
+        if ( service != null ) return;
+        synchronized ( this )
+        {
+            if ( service != null ) return;
+
+            GroupedThreadFactory pluginThreadFactory = new GroupedThreadFactory( this );
+
+            service = Executors.newCachedThreadPool( new ThreadFactoryBuilder().setNameFormat( getDescription().getName() + " Pool Thread #%1$d" )
+                    .setThreadFactory( pluginThreadFactory ).build() );
+            threadGroup = pluginThreadFactory.getGroup();
+        }
+    }
 
     @Deprecated
     public ExecutorService getExecutorService()
     {
-        if ( service == null )
-        {
-            service = Executors.newCachedThreadPool( new ThreadFactoryBuilder().setNameFormat( getDescription().getName() + " Pool Thread #%1$d" )
-                    .setThreadFactory( new GroupedThreadFactory( this ) ).build() );
-        }
+        ensureExecutorLoaded();
         return service;
+    }
+
+    @Deprecated
+    public ThreadGroup getThreadGroup()
+    {
+        ensureExecutorLoaded();
+        return threadGroup;
     }
     //
 }

--- a/api/src/main/java/net/md_5/bungee/api/plugin/PluginClassloader.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/PluginClassloader.java
@@ -1,5 +1,9 @@
 package net.md_5.bungee.api.plugin;
 
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.Setter;
+
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Set;
@@ -9,6 +13,13 @@ public class PluginClassloader extends URLClassLoader
 {
 
     private static final Set<PluginClassloader> allLoaders = new CopyOnWriteArraySet<>();
+
+    /**
+     * The Plugin this loader was created for. May be null.
+     */
+    @Getter
+    @Setter(AccessLevel.PACKAGE)
+    private Plugin plugin = null;
 
     static
     {

--- a/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
@@ -277,12 +277,14 @@ public class PluginManager
         {
             try
             {
-                URLClassLoader loader = new PluginClassloader( new URL[]
+                PluginClassloader loader = new PluginClassloader( new URL[]
                 {
                     plugin.getFile().toURI().toURL()
                 } );
                 Class<?> main = loader.loadClass( plugin.getMain() );
                 Plugin clazz = (Plugin) main.getDeclaredConstructor().newInstance();
+
+                loader.setPlugin( clazz );
 
                 clazz.init( proxy, plugin );
                 plugins.put( plugin.getName(), clazz );

--- a/api/src/main/java/net/md_5/bungee/api/scheduler/GroupedThreadFactory.java
+++ b/api/src/main/java/net/md_5/bungee/api/scheduler/GroupedThreadFactory.java
@@ -2,6 +2,7 @@ package net.md_5.bungee.api.scheduler;
 
 import java.util.concurrent.ThreadFactory;
 import lombok.Data;
+import lombok.Getter;
 import net.md_5.bungee.api.plugin.Plugin;
 
 @Data
@@ -9,6 +10,7 @@ import net.md_5.bungee.api.plugin.Plugin;
 public class GroupedThreadFactory implements ThreadFactory
 {
 
+    @Getter
     private final ThreadGroup group;
 
     public class BungeeGroup extends ThreadGroup


### PR DESCRIPTION
This commit allows creation of threads in most plugin use cases where it
was previously restricted because of the new security manager. To
accomplish this, the security manager resolves the ClassLoader that is
attempting to create the thread and links it to its plugin to finally
return that plugin's thread group. Specifically, this resolves issues
when trying to create threads and ThreadFactories in places other than
BungeeScheduler.runAsync such as Plugin.onEnable.

This adds #1109.
