### PR TITLE
Add a method to get the underlying ThreadFactory for use with external libraries

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/plugin/Plugin.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/Plugin.java
@@ -26,6 +26,7 @@ public class Plugin
     private File file;
     @Getter
     private Logger logger;
+    private final Unsafe unsafe = new Unsafe();
 
     /**
      * Called when the plugin has just been loaded. Most of the proxy will not
@@ -88,18 +89,42 @@ public class Plugin
         this.logger = new PluginLogger( this );
     }
 
-    //
-    private ExecutorService service;
+    public Unsafe unsafe()
+    {
+        return unsafe;
+    }
 
+    //
     @Deprecated
     public ExecutorService getExecutorService()
     {
-        if ( service == null )
-        {
-            service = Executors.newCachedThreadPool( new ThreadFactoryBuilder().setNameFormat( getDescription().getName() + " Pool Thread #%1$d" )
-                    .setThreadFactory( new GroupedThreadFactory( this ) ).build() );
-        }
-        return service;
+        return unsafe().getExecutorService();
     }
     //
+
+    public final class Unsafe {
+        private GroupedThreadFactory groupedThreadFactory;
+        private ExecutorService service;
+
+        private Unsafe(){}
+
+        public ExecutorService getExecutorService()
+        {
+            if ( service == null )
+            {
+                service = Executors.newCachedThreadPool( new ThreadFactoryBuilder().setNameFormat( getDescription().getName() + " Pool Thread #%1$d" )
+                        .setThreadFactory( getGroupedThreadFactory() ).build() );
+            }
+            return service;
+        }
+
+        public GroupedThreadFactory getGroupedThreadFactory()
+        {
+            if ( groupedThreadFactory == null )
+            {
+                groupedThreadFactory = new GroupedThreadFactory( Plugin.this );
+            }
+            return groupedThreadFactory;
+        }
+    }
 }

--- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
@@ -374,7 +374,7 @@ public class BungeeCord extends ProxyServer
                         getLogger().log( Level.SEVERE, "Exception disabling plugin " + plugin.getDescription().getName(), t );
                     }
                     getScheduler().cancel( plugin );
-                    plugin.getExecutorService().shutdownNow();
+                    plugin.unsafe().getExecutorService().shutdownNow();
                 }
 
                 getLogger().info( "Thank you and goodbye" );

--- a/proxy/src/main/java/net/md_5/bungee/scheduler/BungeeScheduler.java
+++ b/proxy/src/main/java/net/md_5/bungee/scheduler/BungeeScheduler.java
@@ -29,7 +29,7 @@ public class BungeeScheduler implements TaskScheduler
         @Override
         public ExecutorService getExecutorService(Plugin plugin)
         {
-            return plugin.getExecutorService();
+            return plugin.unsafe().getExecutorService();
         }
     };
 


### PR DESCRIPTION
This method was added in the sub-class "Unsafe" in Plugin. This follows the Unsafe pattern used in other parts of the project.

getExecutorService() was also moved into the Unsafe class and the old method simply forwards to the one in the Unsafe class, this prevents plugin breakages.

This PR [here](https://github.com/brettwooldridge/HikariCP/pull/113) (which should hopefully soon be accepted) shows how these new API methods might be used with external libraries. This allows BungeeCord to continue to keep track of threads created by plugins.

One thing I am slightly unsure about is if the shutdown call [here](https://github.com/iKeirNez/BungeeCord/blob/35aea66b14b09b45134a6643837cc7c955843ac4/proxy/src/main/java/net/md_5/bungee/BungeeCord.java#L374) will shutdown threads that are assigned to the same group as that ExecutorService, but weren't created by that ExecutorService.
