### PR TITLE
Ability to catch and rewrite backend's tab-completion responses

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/event/TabCompleteResponseEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/TabCompleteResponseEvent.java
@@ -1,0 +1,36 @@
+package net.md_5.bungee.api.event;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import net.md_5.bungee.api.connection.Connection;
+import net.md_5.bungee.api.plugin.Cancellable;
+
+import java.util.List;
+
+/**
+ * Event called when a backend server sends a response to a player asking to tab-complete a chat message or command.
+ * Note that this is not called when BungeeCord or a plugin responds to a tab-complete request. Use {@link TabCompleteEvent} for that.
+ */
+@Data
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class TabCompleteResponseEvent extends TargetedEvent implements Cancellable
+{
+    /**
+     * Whether the event is cancelled
+     */
+    private boolean cancelled;
+
+    /**
+     * Mutable list of suggestions sent back to the player.
+     * If this list is empty, an empty list is sent back to the client.
+     */
+     private final List<String> suggestions;
+
+    public TabCompleteResponseEvent(Connection sender, Connection receiver, List<String> suggestions)
+    {
+        super( sender, receiver );
+        this.suggestions = suggestions;
+    }
+}

--- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
@@ -4,7 +4,6 @@ import com.google.common.io.ByteArrayDataOutput;
 import com.google.common.io.ByteStreams;
 import java.io.DataInput;
 import java.util.Objects;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
@@ -12,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import net.md_5.bungee.ServerConnection;
 import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.api.event.ServerDisconnectEvent;
+import net.md_5.bungee.api.event.TabCompleteResponseEvent;
 import net.md_5.bungee.UserConnection;
 import net.md_5.bungee.Util;
 import net.md_5.bungee.api.ProxyServer;
@@ -38,6 +38,7 @@ import net.md_5.bungee.protocol.packet.ScoreboardDisplay;
 import net.md_5.bungee.protocol.packet.PluginMessage;
 import net.md_5.bungee.protocol.packet.Kick;
 import net.md_5.bungee.protocol.packet.SetCompression;
+import net.md_5.bungee.protocol.packet.TabCompleteResponse;
 import net.md_5.bungee.tab.TabList;
 
 @RequiredArgsConstructor
@@ -477,6 +478,19 @@ public class DownstreamBridge extends PacketHandler
     {
         con.setCompressionThreshold( setCompression.getThreshold() );
         server.getCh().setCompressionThreshold( setCompression.getThreshold() );
+    }
+
+    @Override
+    public void handle(TabCompleteResponse tabCompleteResponse) throws Exception
+    {
+        TabCompleteResponseEvent tabCompleteResponseEvent = new TabCompleteResponseEvent( con.getServer(), con,
+                tabCompleteResponse.getCommands() );
+
+        if ( !bungee.getPluginManager().callEvent( tabCompleteResponseEvent ).isCancelled() )
+        {
+            con.unsafe().sendPacket( tabCompleteResponse );
+        }
+        throw CancelSendSignal.INSTANCE;
     }
 
     @Override


### PR DESCRIPTION
###### The issue:
It is not currently possible to catch tab-completion responses from backend servers (e.g. Spigot) to clients. However, this would be a helpful feature, since currently, to block tab-completion responses, server owners have to install a plugin on every backend server. 
###### Problems:
- [x] I have already created (nearly) working code<sup>[1]</sup> to resolve above issue, but I am unable to get it to write changes in the suggestions back to the packet. I have thought of possible fixes for that, but couldn't find any clean ones: 
  - writing to `buf` directly from the `DownstreamBridge#handle(TabCompleteResponse)` method would require a reference to the `PacketWrapper`
  - re-writing the `buf` in `#handle(PacketWrapper)` would require an ugly `instanceof` or handling in `EntityMap`
  - Changes in the API to allow for this would probably not be accepted just to support such a small event that I am not sure how many people could actually use.
- [x] I am not sure if this kind of event suits the goal of BungeeCord, ~~since I have not been able to find any code that rewrites backend->client (except `EntityMap`, but that's something else).~~

###### Use cases:
 - Block commands blocked by users from appearing in tab completions globally, reducing administration effort of copying configuration files for [xxyy/CommandBlockerUltimate](https://github.com/xxyy/CommandBlockerUltimate)
 - Block names of vanished players globally (thanks @Schmoller)
 - Keep Spigot backend tab completions while adding or removing your own stuffs 
 -  completes  the tab complete API with a counterpart to `TabCompleteEvent`.

###### Relevant links:
- [I wanted to put something else here, but I forgot what, so take a link to the related plugin](https://github.com/xxyy/commandblockerultimate/)

<sup>[1]</sup> ~~I accidentally the imports, I will fix that once I get the confirmation that this PR has the chance of being pulled.~~

What I want to ask you for is clarification on whether such changes would be suitable for BungeeCord and, if so, some advice on properly writing back changes. 

*Thanks.*