### PR TITLE
Disabling plugins in depends-order

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
@@ -4,6 +4,7 @@ import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.gson.GsonBuilder;
 import net.md_5.bungee.api.Favicon;
@@ -32,6 +33,7 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.net.InetSocketAddress;
 import java.text.MessageFormat;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -360,7 +362,22 @@ public class BungeeCord extends ProxyServer
 
                 // TODO: Fix this shit
                 getLogger().info( "Disabling plugins" );
-                pluginManager.disablePlugins();
+                for ( Plugin plugin : Lists.reverse( new ArrayList<>( pluginManager.getPlugins() ) ) )
+                {
+                    try
+                    {
+                        plugin.onDisable();
+                        for ( Handler handler : plugin.getLogger().getHandlers() )
+                        {
+                            handler.close();
+                        }
+                    } catch ( Throwable t )
+                    {
+                        getLogger().log( Level.SEVERE, "Exception disabling plugin " + plugin.getDescription().getName(), t );
+                    }
+                    getScheduler().cancel( plugin );
+                    plugin.getExecutorService().shutdownNow();
+                }
 
                 getLogger().info( "Thank you and goodbye" );
                 // Need to close loggers after last message!


### PR DESCRIPTION
This commit disables/unloads plugins in their depends-order. So far, plugins were disabled in random order.
Example: _**A** depends on **B**_
**A** uses a MySQL connection which is handled by **B**. If **B** would be disabled first and **A** uses the MySQL connection in their onDisable() it would generate an exception.

This commit fixes this problem by checking the dependencies and disabling the plugins in logical order.
