### PR TITLE
Finalize the ServerDisconnectEvent target field.

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/event/ServerDisconnectEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/ServerDisconnectEvent.java
@@ -25,5 +25,5 @@ public class ServerDisconnectEvent extends Event
      * Server the player is disconnecting from.
      */
     @NonNull
-    private ServerInfo target;
+    private final ServerInfo target;
 }


### PR DESCRIPTION
There is no good reason for it to be mutable in the first place, considering that the event instance is not used after the method is called.

Pulling this would do a great service to my plugin RedisBungee that would rely on its immutablity.
