### PR TITLE
Fix LoginEvent firing after PreLoginEvent is cancelled

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -277,6 +277,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
                 if ( result.isCancelled() )
                 {
                     disconnect( result.getCancelReason() );
+                    return;
                 }
                 if ( ch.isClosed() )
                 {


### PR DESCRIPTION
Since 1.7, `ch.isClosed()` returns false when called here because of this workaround https://github.com/SpigotMC/BungeeCord/blob/master/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java#L456
