### PR TITLE
Remove second MotD line for legacy pings.

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -139,12 +139,18 @@ public class InitialHandler extends PacketHandler implements PendingConnection
         String kickMessage = ChatColor.DARK_BLUE
                 + "\00" + 127
                 + "\00" + legacy.getVersion().getName()
-                + "\00" + legacy.getDescription()
+                + "\00" + getFirstLine( legacy.getDescription() )
                 + "\00" + legacy.getPlayers().getOnline()
                 + "\00" + legacy.getPlayers().getMax();
 
         ch.getHandle().writeAndFlush( kickMessage );
         ch.close();
+    }
+
+    private static String getFirstLine(String str)
+    {
+        int pos = str.indexOf( '\n' );
+        return pos == -1 ? str : str.substring( 0, pos );
     }
 
     @Override


### PR DESCRIPTION
Prevents strange characters and the second line of the MotD from appearing on outdated clients (like 1.6.4 or older). (Also why does BungeeCord display `1.7.9` as Minecraft version and not `1.7.10`? Is there a special reason for that?)

![](https://cloud.githubusercontent.com/assets/3035868/4024212/5beb56b6-2bbd-11e4-82a7-35dc7fe89fae.png)
![](https://cloud.githubusercontent.com/assets/3035868/4024233/d94f6c5e-2bbe-11e4-9882-4a97436526fd.png)
