### PR TITLE
Edit messages without modifying the JAR file.

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/ProxyServer.java
+++ b/api/src/main/java/net/md_5/bungee/api/ProxyServer.java
@@ -130,6 +130,11 @@ public abstract class ProxyServer
     public abstract void setConfigurationAdapter(ConfigurationAdapter adapter);
 
     /**
+     * Reload the proxy server messages from the configuration file.
+     */
+    public abstract void reloadMessages();
+
+    /**
      * Get the currently in use reconnect handler.
      *
      * @return the in use reconnect handler

--- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
@@ -31,7 +31,6 @@ import net.md_5.bungee.conf.Configuration;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;

--- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
@@ -29,7 +29,12 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.util.ResourceLeakDetector;
 import net.md_5.bungee.conf.Configuration;
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.FileWriter;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.io.PrintStream;
 import java.net.InetSocketAddress;
 import java.text.MessageFormat;
@@ -40,6 +45,8 @@ import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
 import java.util.MissingResourceException;
+import java.util.Properties;
+import java.util.PropertyResourceBundle;
 import java.util.ResourceBundle;
 import java.util.Timer;
 import java.util.TimerTask;
@@ -144,6 +151,8 @@ public class BungeeCord extends ProxyServer
     private ConnectionThrottle connectionThrottle;
     private final ModuleManager moduleManager = new ModuleManager();
 
+    private final File messagesFile = new File( "messages.properties" );
+
     
     {
         // TODO: Proper fallback when we interface the manager
@@ -192,12 +201,56 @@ public class BungeeCord extends ProxyServer
             logger.info( "NOTE: This error is non crucial, and BungeeCord will still function correctly! Do not bug the author about it unless you are still unable to get it working" );
         }
 
+        reloadMessages();
+
         if ( NativeCipher.load() )
         {
             logger.info( "Using OpenSSL based native cipher." );
         } else
         {
             logger.info( "Using standard Java JCE cipher. To enable the OpenSSL based native cipher, please make sure you are using 64 bit Ubuntu or Debian with libssl installed." );
+        }
+    }
+
+    @Override
+    public void reloadMessages() {
+        try // Make sure the translation file is up to date
+        {
+            Properties messages = new Properties();
+
+            if ( messagesFile.exists() )
+                try ( InputStream is = new FileInputStream( messagesFile ) ) {
+                    messages.load( is );
+                }
+
+            // Check for new entries
+            int newEntries = 0;
+            for ( String key : bundle.keySet() ) {
+                if ( !messages.containsKey( key ) ) {
+                    messages.put( key, bundle.getObject(key) );
+                    newEntries++;
+                }
+            }
+
+            if ( newEntries > 0 ) {
+                // We need to save the file to add the new entries
+                try ( OutputStream os = new FileOutputStream( messagesFile ) )
+                {
+                    messages.store( os, "BungeeCord messages, last updated for " + getVersion() );
+                }
+            }
+        } catch ( Exception ex )
+        {
+            getLogger().log( Level.SEVERE, "Could not update messages", ex );
+        }
+
+        // Load the messages from the configuration file
+        try ( InputStream is = new FileInputStream( messagesFile ) )
+        {
+            bundle = new PropertyResourceBundle( is );
+        } catch ( Exception ex )
+        {
+            getLogger().log( Level.SEVERE, "Could not reload messages", ex );
         }
     }
 


### PR DESCRIPTION
Currently there is no way to modify the BungeeCord messages without modifying the JAR file. I know you're still working on better translations, however maybe we can use this as a temporary solution until it is done?

This will add a new `messages.yml` file with the customizable messages in them. Once it is loaded the original ResourceBundle will be replaced by a custom one loaded from the file. The file is saved using `UTF-8` to prevent problems with the special characters in it.

Adds #901 and #1017.

If you don't want to pull this I also have this available [in a plugin](https://github.com/Minecrell/BungeeMessages), but I want to try getting it into BungeeCord directly before publishing this plugin.