### PR TITLE
Use delombok source files for JavaDocs so all methods are included.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,14 @@
                     <sourceDirectory>src/main/java</sourceDirectory>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.9.1</version>
+                <configuration>
+                    <sourcepath>target/generated-sources/delombok</sourcepath>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
At the moment method generated by lombok are not included in the JavaDocs of the BungeeCord API. If we generate the JavaDocs from the delombok source files then all methods will be included - at least with no description.

Maybe we should add JavaDocs to the lombok methods anyway later, [an issue for lombok explains how to create them](https://code.google.com/p/projectlombok/issues/detail?id=59#c14). (Thanks to @IDragonfire for the link.)
