### PR TITLE
Make ProxyPingEvent async

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/event/ProxyPingEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/ProxyPingEvent.java
@@ -1,9 +1,9 @@
 package net.md_5.bungee.api.event;
 
-import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import net.md_5.bungee.api.Callback;
 import net.md_5.bungee.api.ServerPing;
 import net.md_5.bungee.api.connection.PendingConnection;
 import net.md_5.bungee.api.plugin.Event;
@@ -12,10 +12,9 @@ import net.md_5.bungee.api.plugin.Event;
  * Called when the proxy is pinged with packet 0xFE from the server list.
  */
 @Data
-@AllArgsConstructor
 @ToString(callSuper = false)
 @EqualsAndHashCode(callSuper = false)
-public class ProxyPingEvent extends Event
+public class ProxyPingEvent extends AsyncEvent<ProxyPingEvent>
 {
 
     /**
@@ -26,4 +25,11 @@ public class ProxyPingEvent extends Event
      * The data to respond with.
      */
     private ServerPing response;
+
+    public ProxyPingEvent(PendingConnection connection, ServerPing response, Callback<ProxyPingEvent> done)
+    {
+        super( done );
+        this.connection = connection;
+        this.response = response;
+    }
 }


### PR DESCRIPTION
Allows bungee plugins to do additional processing before responding to the ping. This is especially useful with virtual hosts.

Please let me know if the callback is not handled correctly. I was going off of the handling of other async events.
