### PR TITLE
Add chat position API.

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/connection/ProxiedPlayer.java
+++ b/api/src/main/java/net/md_5/bungee/api/connection/ProxiedPlayer.java
@@ -2,6 +2,7 @@ package net.md_5.bungee.api.connection;
 
 import java.util.Locale;
 import net.md_5.bungee.api.Callback;
+import net.md_5.bungee.api.ChatPosition;
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.Title;
 import net.md_5.bungee.api.chat.BaseComponent;
@@ -29,6 +30,22 @@ public interface ProxiedPlayer extends Connection, CommandSender
      * @param name the name to set
      */
     void setDisplayName(String name);
+
+    /**
+     * Send a message to the specified screen position of this player.
+     *
+     * @param position the screen position
+     * @param message the message to send
+     */
+    public void sendMessage(ChatPosition position, BaseComponent... message);
+
+    /**
+     * Send a message to the specified screen position of this player.
+     *
+     * @param position the screen position
+     * @param message the message to send
+     */
+    public void sendMessage(ChatPosition position, BaseComponent message);
 
     /**
      * Connects / transfers this user to the specified connection, gracefully

--- a/chat/src/main/java/net/md_5/bungee/api/ChatPosition.java
+++ b/chat/src/main/java/net/md_5/bungee/api/ChatPosition.java
@@ -1,0 +1,11 @@
+package net.md_5.bungee.api;
+
+/**
+ * Represents the position on the screen where a message will appear.
+ */
+public enum ChatPosition
+{
+    CHAT,
+    SYSTEM,
+    ACTION_BAR
+}

--- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
@@ -22,6 +22,7 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import net.md_5.bungee.api.Callback;
+import net.md_5.bungee.api.ChatPosition;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.Title;
 import net.md_5.bungee.api.chat.BaseComponent;
@@ -359,13 +360,44 @@ public final class UserConnection implements ProxiedPlayer
     @Override
     public void sendMessage(BaseComponent... message)
     {
-        unsafe().sendPacket( new Chat( ComponentSerializer.toString( message ) ) );
+        sendMessage( ChatPosition.CHAT, message );
     }
 
     @Override
     public void sendMessage(BaseComponent message)
     {
-        unsafe().sendPacket( new Chat( ComponentSerializer.toString( message ) ) );
+        sendMessage( ChatPosition.CHAT, message );
+    }
+
+    private void sendMessage(ChatPosition position, String message)
+    {
+        unsafe().sendPacket( new Chat( message, (byte) position.ordinal() ) );
+    }
+
+    @Override
+    public void sendMessage(ChatPosition position, BaseComponent... message)
+    {
+        // Action bar doesn't display the new JSON formattings, legacy works - send it using this for now
+        if ( position == ChatPosition.ACTION_BAR && pendingConnection.getVersion() >= ProtocolConstants.MINECRAFT_SNAPSHOT )
+        {
+            sendMessage( position, ComponentSerializer.toString( new TextComponent( TextComponent.toLegacyText( message ) ) ) );
+        } else
+        {
+            sendMessage( position, ComponentSerializer.toString( message ) );
+        }
+    }
+
+    @Override
+    public void sendMessage(ChatPosition position, BaseComponent message)
+    {
+        // Action bar doesn't display the new JSON formattings, legacy works - send it using this for now
+        if ( position == ChatPosition.ACTION_BAR && pendingConnection.getVersion() >= ProtocolConstants.MINECRAFT_SNAPSHOT )
+        {
+            sendMessage( position, ComponentSerializer.toString( new TextComponent( TextComponent.toLegacyText( message ) ) ) );
+        } else
+        {
+            sendMessage( position, ComponentSerializer.toString( message ) );
+        }
     }
 
     @Override


### PR DESCRIPTION
Adds a chat position API so messages can be also sent to the action bar. Currently the messages for the action bar are converted to legacy format so the colors are displayed there too. I just hope Mojang will fix this in the future so we can remove this without having plugin authors change their code.
### Example:

``` java
player.sendMessage( ChatPosition.ACTION_BAR,
    new ComponentBuilder( "Action bar message" ).color( ChatColor.GREEN ).create() );
```
