### PR TITLE
Fix wrong Javadoc link in the Title API.

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/ProxyServer.java
+++ b/api/src/main/java/net/md_5/bungee/api/ProxyServer.java
@@ -285,7 +285,7 @@ public abstract class ProxyServer
 
     /**
      * Creates a new empty title configuration.
-     * In most cases you will want to {@link #reset()} the current title first so
+     * In most cases you will want to {@link Title#reset() reset} the current title first so
      * your title won't be affected by a previous one.
      *
      * @return A new empty title configuration.


### PR DESCRIPTION
The current part of the `createTitle()` JavaDocs has a wrong link to an unknown `reset()` method of `ProxyServer`. We will probably not add a `reset()` method to the proxy server, but in case we ever do then it would probably delete or reset something else than just the title, that's why we should fix the JavaDocs now before someone gets confused. :)
