### PR TITLE
Improve legacy client ping support.

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/connection/PendingConnection.java
+++ b/api/src/main/java/net/md_5/bungee/api/connection/PendingConnection.java
@@ -65,4 +65,12 @@ public interface PendingConnection extends Connection
      * Set this connection's online mode.
      */
     void setOnlineMode(boolean onlineMode);
+
+    /**
+     * Check if the client is using the older unsupported Minecraft protocol
+     * used by Minecraft clients older than 1.7.
+     *
+     * @return Whether the client is using a legacy client.
+     */
+    boolean isLegacy();
 }

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/LegacyPing.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/LegacyPing.java
@@ -1,11 +1,19 @@
 package net.md_5.bungee.protocol.packet;
 
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.RequiredArgsConstructor;
+
 import io.netty.buffer.ByteBuf;
 import net.md_5.bungee.protocol.AbstractPacketHandler;
 import net.md_5.bungee.protocol.DefinedPacket;
 
+@Data
+@RequiredArgsConstructor
+@EqualsAndHashCode(callSuper = false)
 public class LegacyPing extends DefinedPacket
 {
+    private final boolean v1_5;
 
     @Override
     public void read(ByteBuf buf)
@@ -24,23 +32,4 @@ public class LegacyPing extends DefinedPacket
     {
         handler.handle( this );
     }
-
-    @Override
-    public boolean equals(Object obj)
-    {
-        throw new UnsupportedOperationException( "Not supported yet." ); //To change body of generated methods, choose Tools | Templates.
-    }
-
-    @Override
-    public int hashCode()
-    {
-        throw new UnsupportedOperationException( "Not supported yet." ); //To change body of generated methods, choose Tools | Templates.
-    }
-
-    @Override
-    public String toString()
-    {
-        throw new UnsupportedOperationException( "Not supported yet." ); //To change body of generated methods, choose Tools | Templates.
-    }
-
 }


### PR DESCRIPTION
The Vanilla/Spigot server supports all versions of the legacy client pings, but BungeeCord does only support 1.6.4 as of right now. That's why I think we should also support the older versions so users of older versions will get a working server ping and disconnect.
- For clients <= 1.6 only the second line will be removed from the motd.
- For clients <= 1.3 additionally all colors are removed from the motd because they don't support them.

**Tested and working with the following Minecraft versions:**
- 1.7/1.8 are not affected by this change
- 1.6.4
- 1.5.2
- 1.4.7
- 1.3.2
- 1.0
