### PR TITLE
[Forge] Don't send resets to Clients which are known to not support it

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
+++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
@@ -110,7 +110,7 @@ public class ServerConnector extends PacketHandler
         Preconditions.checkState( thisState == State.LOGIN_SUCCESS, "Not expecting LOGIN_SUCCESS" );
         ch.setProtocol( Protocol.GAME );
         thisState = State.LOGIN;
-        if ( user.getServer() != null && user.getForgeClientHandler().isHandshakeComplete() && !user.getForgeClientHandler().isForgeOutdated() )
+        if ( user.getServer() != null && user.getForgeClientHandler().isForgeClient() && !user.getForgeClientHandler().isForgeOutdated() )
         {
             user.getForgeClientHandler().resetHandshake();
         }

--- a/proxy/src/main/java/net/md_5/bungee/forge/ForgeClientHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/forge/ForgeClientHandler.java
@@ -26,6 +26,13 @@ public class ForgeClientHandler
     private boolean forgeOutdated = false;
 
     /**
+     * The client is non forge until it sends a FML Buildnumber
+     */
+    @Getter
+    @Setter(AccessLevel.PACKAGE)
+    private boolean forgeClient = false;
+
+    /**
      * The users' mod list.
      */
     @Getter
@@ -161,7 +168,7 @@ public class ForgeClientHandler
      */
     public boolean checkUserOutdated()
     {
-        if ( forgeOutdated )
+        if ( isForgeClient() && isForgeOutdated() )
         {
             if ( con.isDimensionChange() )
             {
@@ -172,6 +179,6 @@ public class ForgeClientHandler
             }
         }
 
-        return forgeOutdated;
+        return isForgeOutdated();
     }
 }

--- a/proxy/src/main/java/net/md_5/bungee/forge/ForgeClientHandshakeState.java
+++ b/proxy/src/main/java/net/md_5/bungee/forge/ForgeClientHandshakeState.java
@@ -90,6 +90,13 @@ enum ForgeClientHandshakeState implements IForgeClientPacketHandler<ForgeClientH
                             // TODO: Remove this once Bungee becomes 1.8 only.
                             int buildNumber = ForgeUtils.getFmlBuildNumber( clientModList );
 
+                            // Be sure that FML is inside the modlist so we can be sure its a Forge Mod loader and nothing
+                            // 3rd Party shit using the FML:HS channels
+                            if ( buildNumber != 0 )
+                            {
+                                con.getForgeClientHandler().setForgeClient( true );
+                            }
+
                             // If we get 0, we're probably using a testing build, so let it though. Otherwise, check the build number.
                             if ( buildNumber < ForgeConstants.FML_MIN_BUILD_VERSION && buildNumber != 0 )
                             {


### PR DESCRIPTION
Don't send the reset packet to Forge clients which are known to not support it. This does prevent the crash of Forge Clients which have a build number under 1209. This also prevents Forge Clients under that Buildnumber from joining any other Server (which is a Forge Server) when they don't support resetting the Handshake.
