### PR TITLE
[Forge] Allow passing of REGISTER messages from Client to Server at the right moment during the FML Handshake.

### DIFF
--- a/api/src/main/java/net/md_5/bungee/Util.java
+++ b/api/src/main/java/net/md_5/bungee/Util.java
@@ -1,7 +1,9 @@
 package net.md_5.bungee;
 
 import com.google.common.base.Joiner;
+import com.google.common.base.Splitter;
 import java.net.InetSocketAddress;
+import java.util.List;
 import java.util.UUID;
 
 /**
@@ -63,6 +65,11 @@ public class Util
     public static String format(Iterable<?> objects, String separators)
     {
         return Joiner.on( separators ).join( objects );
+    }
+
+    public static List<String> split(String string, String separator) 
+    {
+        return Splitter.on( separator ).splitToList( string );
     }
 
     /**

--- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
@@ -230,10 +230,6 @@ public class BungeeCord extends ProxyServer
         pluginManager.loadPlugins();
         config.load();
 
-        registerChannel( ForgeConstants.FML_TAG );
-        registerChannel( ForgeConstants.FML_HANDSHAKE_TAG );
-        registerChannel( ForgeConstants.FORGE_REGISTER );
-
         isRunning = true;
 
         pluginManager.enablePlugins();

--- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
@@ -69,7 +69,6 @@ import net.md_5.bungee.api.plugin.Plugin;
 import net.md_5.bungee.api.plugin.PluginManager;
 import net.md_5.bungee.command.*;
 import net.md_5.bungee.conf.YamlConfig;
-import net.md_5.bungee.forge.ForgeConstants;
 import net.md_5.bungee.log.LoggingOutputStream;
 import net.md_5.bungee.netty.PipelineUtils;
 import net.md_5.bungee.protocol.DefinedPacket;
@@ -539,7 +538,7 @@ public class BungeeCord extends ProxyServer
 
     public PluginMessage registerChannels()
     {
-        return new PluginMessage( "REGISTER", Util.format( pluginChannels, "\00" ).getBytes( Charsets.UTF_8 ), false );
+            return new PluginMessage( "REGISTER", Util.format( pluginChannels, "\00" ).getBytes( Charsets.UTF_8 ), false );
     }
 
     @Override

--- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
+++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
@@ -313,7 +313,7 @@ public class ServerConnector extends PacketHandler
             }
         }
 
-        if ( pluginMessage.getTag().equals( ForgeConstants.FML_HANDSHAKE_TAG ) || pluginMessage.getTag().equals( ForgeConstants.FORGE_REGISTER ) )
+        if ( pluginMessage.getTag().equals( ForgeConstants.FML_HANDSHAKE_TAG ) || pluginMessage.getTag().equals( ForgeConstants.FORGE_TAG ) )
         {
             this.handshakeHandler.handle( pluginMessage );
             if ( user.getForgeClientHandler().checkUserOutdated() )

--- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
+++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
@@ -78,6 +78,8 @@ public class ServerConnector extends PacketHandler
         this.ch = channel;
 
         this.handshakeHandler = new ForgeServerHandler( user, ch, target );
+        user.setForgeServerHandler( handshakeHandler );
+
         Handshake originalHandshake = user.getPendingConnection().getHandshake();
         Handshake copiedHandshake = new Handshake( originalHandshake.getProtocolVersion(), originalHandshake.getHost(), originalHandshake.getPort(), 2 );
 
@@ -309,7 +311,6 @@ public class ServerConnector extends PacketHandler
             {
                 // We now set the server-side handshake handler for the client to this.
                 handshakeHandler.setServerAsForgeServer();
-                user.setForgeServerHandler( handshakeHandler );
             }
         }
 

--- a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
@@ -20,7 +20,6 @@ import net.md_5.bungee.protocol.packet.PluginMessage;
 import java.util.ArrayList;
 import java.util.List;
 import net.md_5.bungee.forge.ForgeConstants;
-import net.md_5.bungee.protocol.ProtocolConstants;
 import net.md_5.bungee.protocol.packet.TabCompleteResponse;
 
 public class UpstreamBridge extends PacketHandler
@@ -168,6 +167,13 @@ public class UpstreamBridge extends PacketHandler
         if ( pluginMessage.getTag().equals( "REGISTER" ) )
         {
             con.getPendingConnection().getRegisterMessages().add( pluginMessage );
+
+            // If we have a forge handshake in progress, send the REGISTER message along containing the forge channel registrations.
+            if ( con.getForgeServerHandler().acceptRegisterMessages() )
+            {
+                // Send it through the full handler sequence.
+                con.getForgeClientHandler().handle( pluginMessage );
+            }
         }
     }
 

--- a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
@@ -166,13 +166,17 @@ public class UpstreamBridge extends PacketHandler
         // TODO: Unregister as well?
         if ( pluginMessage.getTag().equals( "REGISTER" ) )
         {
-            con.getPendingConnection().getRegisterMessages().add( pluginMessage );
-
             // If we have a forge handshake in progress, send the REGISTER message along containing the forge channel registrations.
             if ( con.getForgeServerHandler().acceptRegisterMessages() )
             {
-                // Send it through the full handler sequence.
+                // Send it through the full handler sequence, don't send it to the current server.
                 con.getForgeClientHandler().handle( pluginMessage );
+                throw CancelSendSignal.INSTANCE;
+            }
+            else
+            {
+                // Store the packet for sending later.
+                con.getPendingConnection().getRegisterMessages().add( pluginMessage );
             }
         }
     }

--- a/proxy/src/main/java/net/md_5/bungee/forge/ForgeClientHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/forge/ForgeClientHandler.java
@@ -48,9 +48,9 @@ public class ForgeClientHandler
      */
     public void handle(PluginMessage message) throws IllegalArgumentException
     {
-        if ( !message.getTag().equalsIgnoreCase( ForgeConstants.FML_HANDSHAKE_TAG ) )
+        if ( !message.getTag().equalsIgnoreCase( ForgeConstants.FML_HANDSHAKE_TAG ) && !message.getTag().equalsIgnoreCase( "REGISTER" ) )
         {
-            throw new IllegalArgumentException( "Expecting a Forge Handshake packet." );
+            throw new IllegalArgumentException( "Expecting a Forge Handshake or REGISTER packet." );
         }
 
         message.setAllowExtendedPacket( true ); // FML allows extended packets so this must be enabled

--- a/proxy/src/main/java/net/md_5/bungee/forge/ForgeClientHandshakeState.java
+++ b/proxy/src/main/java/net/md_5/bungee/forge/ForgeClientHandshakeState.java
@@ -70,8 +70,8 @@ enum ForgeClientHandshakeState implements IForgeClientPacketHandler<ForgeClientH
                 @Override
                 public ForgeClientHandshakeState send(PluginMessage message, UserConnection con)
                 {
-                    // Client Hello.
-                    if ( message.getData()[0] == 1 )
+                    // FML Register and Client Hello.
+                    if ( message.getTag().equals( "REGISTER") || message.getData()[0] == 1 )
                     {
                         return this;
                     }

--- a/proxy/src/main/java/net/md_5/bungee/forge/ForgeConstants.java
+++ b/proxy/src/main/java/net/md_5/bungee/forge/ForgeConstants.java
@@ -7,7 +7,7 @@ public class ForgeConstants
 {
 
     // Forge
-    public static final String FORGE_REGISTER = "FORGE";
+    public static final String FORGE_TAG = "FORGE";
 
     // FML
     public static final String FML_TAG = "FML";

--- a/proxy/src/main/java/net/md_5/bungee/forge/ForgeLogger.java
+++ b/proxy/src/main/java/net/md_5/bungee/forge/ForgeLogger.java
@@ -43,7 +43,7 @@ class ForgeLogger
                 default:
                     return "Unknown";
             }
-        } else if ( channel.equals( ForgeConstants.FORGE_REGISTER ) )
+        } else if ( channel.equals( ForgeConstants.FORGE_TAG ) )
         {
             switch ( discrim )
             {

--- a/proxy/src/main/java/net/md_5/bungee/forge/ForgeServerHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/forge/ForgeServerHandler.java
@@ -19,6 +19,7 @@ public class ForgeServerHandler
 {
 
     private final UserConnection con;
+
     @Getter
     private final ChannelWrapper ch;
 
@@ -42,9 +43,9 @@ public class ForgeServerHandler
      */
     public void handle(PluginMessage message) throws IllegalArgumentException
     {
-        if ( !message.getTag().equalsIgnoreCase( ForgeConstants.FML_HANDSHAKE_TAG ) && !message.getTag().equalsIgnoreCase( ForgeConstants.FORGE_REGISTER ) )
+        if ( !message.getTag().equalsIgnoreCase( ForgeConstants.FML_HANDSHAKE_TAG ) && !message.getTag().equalsIgnoreCase(ForgeConstants.FORGE_TAG ) )
         {
-            throw new IllegalArgumentException( "Expecting a Forge REGISTER or FML Handshake packet." );
+            throw new IllegalArgumentException( "Expecting a FML Handshake or FORGE packet." );
         }
 
         message.setAllowExtendedPacket( true ); // FML allows extended packets so this must be enabled
@@ -81,5 +82,15 @@ public class ForgeServerHandler
     public void setServerAsForgeServer()
     {
         serverForge = true;
+    }
+
+    /**
+     * Returns whether the server is able to accept REGISTER messages at the beginning of the handshake.
+     * 
+     * @return <code>true</code> if the server accepts REGISTER messages at this time.
+     */
+    public boolean acceptRegisterMessages()
+    {
+        return state == ForgeServerHandshakeState.HELLO;
     }
 }

--- a/proxy/src/main/java/net/md_5/bungee/forge/ForgeServerHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/forge/ForgeServerHandler.java
@@ -91,6 +91,6 @@ public class ForgeServerHandler
      */
     public boolean acceptRegisterMessages()
     {
-        return state == ForgeServerHandshakeState.HELLO;
+        return state == ForgeServerHandshakeState.START || state == ForgeServerHandshakeState.HELLO;
     }
 }

--- a/proxy/src/main/java/net/md_5/bungee/forge/ForgeServerHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/forge/ForgeServerHandler.java
@@ -1,11 +1,15 @@
 package net.md_5.bungee.forge;
 
+import com.google.common.base.Charsets;
 import java.util.ArrayDeque;
+import java.util.HashSet;
+import java.util.Set;
 
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import net.md_5.bungee.UserConnection;
+import net.md_5.bungee.Util;
 import net.md_5.bungee.api.config.ServerInfo;
 import net.md_5.bungee.forge.ForgeLogger.LogDirection;
 import net.md_5.bungee.netty.ChannelWrapper;
@@ -31,6 +35,9 @@ public class ForgeServerHandler
 
     @Getter
     private boolean serverForge = false;
+
+    @Getter
+    private final Set<String> receivedRegisterMessages = new HashSet<>();
 
     private final ArrayDeque<PluginMessage> packetQueue = new ArrayDeque<PluginMessage>();
 
@@ -72,6 +79,12 @@ public class ForgeServerHandler
      */
     public void receive(PluginMessage message) throws IllegalArgumentException
     {
+        // Store the REGISTER messages being sent if we are in the correct phase.
+        if ( acceptRegisterMessages() && message.getTag().equals( "REGISTER" ) )
+        {
+            receivedRegisterMessages.addAll( Util.split( new String( message.getData(), Charsets.UTF_8 ), "\00") );
+        }
+
         state = state.handle( message, ch );
     }
 

--- a/proxy/src/main/java/net/md_5/bungee/forge/ForgeServerHandshakeState.java
+++ b/proxy/src/main/java/net/md_5/bungee/forge/ForgeServerHandshakeState.java
@@ -29,7 +29,7 @@ public enum ForgeServerHandshakeState implements IForgeServerPacketHandler<Forge
                 @Override
                 public ForgeServerHandshakeState send(PluginMessage message, UserConnection con)
                 {
-                    // Send custom channel registration. Send Hello.
+                    // Send Hello.
                     return HELLO;
                 }
             },
@@ -40,12 +40,9 @@ public enum ForgeServerHandshakeState implements IForgeServerPacketHandler<Forge
                 public ForgeServerHandshakeState handle(PluginMessage message, ChannelWrapper ch)
                 {
                     ForgeLogger.logServer( LogDirection.RECEIVED, this.name(), message );
-                    if ( message.getData()[0] == 1 ) // Client Hello
-                    {
-                        ch.write( message );
-                    }
 
-                    if ( message.getData()[0] == 2 ) // Client ModList
+                    // REGISTER message, Client Hello or Client Mod List
+                    if ( message.getTag().equals( "REGISTER" ) || message.getData()[0] == 1 || message.getData()[0] == 2 ) 
                     {
                         ch.write( message );
                     }
@@ -85,7 +82,7 @@ public enum ForgeServerHandshakeState implements IForgeServerPacketHandler<Forge
                         return this;
                     }
 
-                    if ( message.getTag().equals( ForgeConstants.FORGE_REGISTER ) ) // wait for Forge channel registration
+                    if ( message.getTag().equals( ForgeConstants.FORGE_TAG ) ) // wait for Forge channel registration
                     {
                         return COMPLETE;
                     }


### PR DESCRIPTION
Some mods rely on the channels being registered before Bungee normally gets around to it. This commit allows the required packets to go through, which are the ones in response to the ServerHello message. Without this, the REGISTER packets would be sent later - too late for some mods that rely on it.

I have tested this through debugging, the REGISTER messages are now being sent/passed on at the right time. Thanks to @boq for alerting me to this issue in #1248. 

A small amount of related cleanup has also been done.
