### PR TITLE
Don't send no permission message on tab completion.

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
@@ -147,7 +147,9 @@ public class PluginManager
         String permission = command.getPermission();
         if ( permission != null && !permission.isEmpty() && !sender.hasPermission( permission ) )
         {
-            sender.sendMessage( proxy.getTranslation( "no_permission" ) );
+            if (tabResults != null && (!(command instanceof TabExecutor))) {
+                sender.sendMessage( proxy.getTranslation( "no_permission" ) );
+            }
             return true;
         }
 


### PR DESCRIPTION
Instead returns the empty completions.
