### PR TITLE
FML 1.8 keeps breaking IP forwarding

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/config/ListenerInfo.java
+++ b/api/src/main/java/net/md_5/bungee/api/config/ListenerInfo.java
@@ -68,4 +68,11 @@ public class ListenerInfo
      * Whether to enable udp query.
      */
     private final boolean queryEnabled;
+    /**
+     * If a new FML Client connects (1.8) they will have a \000FML\000 Marker in them. This destroys BungeeCords ip
+     * forwarding. If you set this to true it will reappend the marker when it was found. If this is false the
+     * marker will be removed so IP forwarding will work again. Please only set this to true when you have a 1.8 Forge/FML
+     * network.
+     */
+    private boolean reappendFMLMarker = false;
 }

--- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
+++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
@@ -90,7 +90,16 @@ public class ServerConnector extends PacketHandler
             {
                 newHost += "\00" + BungeeCord.getInstance().gson.toJson( profile.getProperties() );
             }
+
+            if ( user.getPendingConnection().getListener().isReappendFMLMarker() && user.getPendingConnection().isFmlMarker() )
+            {
+                newHost += "\000FML\000";
+            }
+
             copiedHandshake.setHost( newHost );
+        } else if ( user.getPendingConnection().getListener().isReappendFMLMarker() && user.getPendingConnection().isFmlMarker() )
+        {
+            copiedHandshake.setHost( copiedHandshake.getHost() + "\000FML\000" );
         }
         channel.write( copiedHandshake );
 

--- a/proxy/src/main/java/net/md_5/bungee/conf/YamlConfig.java
+++ b/proxy/src/main/java/net/md_5/bungee/conf/YamlConfig.java
@@ -218,8 +218,10 @@ public class YamlConfig implements ConfigurationAdapter
 
             boolean query = get( "query_enabled", false, val );
             int queryPort = get( "query_port", 25577, val );
+            boolean reappendFMLMarker = get( "readd_fml_marker", false, val );
 
             ListenerInfo info = new ListenerInfo( address, motd, maxPlayers, tabListSize, defaultServer, fallbackServer, forceDefault, forced, value.toString(), setLocalAddress, pingPassthrough, queryPort, query );
+            info.setReappendFMLMarker( reappendFMLMarker );
             ret.add( info );
         }
 

--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -94,6 +94,8 @@ public class InitialHandler extends PacketHandler implements PendingConnection
     private LoginResult loginProfile;
     @Getter
     private boolean legacy;
+    @Getter
+    private boolean fmlMarker;
 
     private enum State
     {
@@ -253,6 +255,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
         // The new FML appends "\000FML\000" to the host for whatever reason
         if ( handshake.getHost().endsWith( "\000FML\000" ) )
         {
+            this.fmlMarker = true;
             handshake.setHost( handshake.getHost().substring( 0, handshake.getHost().length() - 5 ) );
         }
 


### PR DESCRIPTION
FML adds a extra marker to the IP which breaks IP forwarding.

FML Commit which breaks it: https://github.com/MinecraftForge/FML/commit/2c03f5f173f7391260cd1b543af93ce04ef2ea78
