### PR TITLE
Fix issues cleaning up after repeating tasks.

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/scheduler/BungeeScheduler.java
+++ b/proxy/src/main/java/net/md_5/bungee/scheduler/BungeeScheduler.java
@@ -44,7 +44,7 @@ public class BungeeScheduler implements TaskScheduler
     @Override
     public void cancel(ScheduledTask task)
     {
-        cancel( task.getId() );
+        task.cancel();
     }
 
     @Override

--- a/proxy/src/main/java/net/md_5/bungee/scheduler/BungeeTask.java
+++ b/proxy/src/main/java/net/md_5/bungee/scheduler/BungeeTask.java
@@ -34,7 +34,12 @@ public class BungeeTask implements Runnable, ScheduledTask
     @Override
     public void cancel()
     {
-        running.set( false );
+        boolean wasRunning = running.getAndSet( false );
+
+        if ( wasRunning )
+        {
+            sched.cancel( this.getId() );
+        }
     }
 
     @Override
@@ -76,11 +81,6 @@ public class BungeeTask implements Runnable, ScheduledTask
             }
         }
 
-        // We might have been previously running before, but now we aren't.
-        // If we weren't already cancelled, then cancel ourselves.
-        if ( running.get() )
-        {
-            sched.cancel( this );
-        }
+        cancel();
     }
 }


### PR DESCRIPTION
A mass of NullPointerExceptions would be outputted when tasks were stopped. This is resolved by checking if we are still running (indicating that we did get cancelled as part of a repeating task) before telling the scheduler to pull the plug.

Ideally, the entire BungeeCord scheduler should be rewritten. It has quite a few issues which could be avoided with a new system.
