### PR TITLE
Fix the server command tab completion

### DIFF
--- a/module/cmd-server/src/main/java/net/md_5/bungee/module/cmd/server/CommandServer.java
+++ b/module/cmd-server/src/main/java/net/md_5/bungee/module/cmd/server/CommandServer.java
@@ -81,16 +81,19 @@ public class CommandServer extends Command implements TabExecutor
             List<String> completions = new ArrayList<String>();
             for (ServerInfo server : ProxyServer.getInstance().getServers().values())
             {
-                String serverName = server.getName();
-                if (args.length == 1)
+                if (server.canAccess(sender))
                 {
-                    if (serverName.toLowerCase().startsWith(args[0].toLowerCase()))
+                    String serverName = server.getName();
+                    if (args.length == 1)
+                    {
+                        if (serverName.toLowerCase().startsWith(args[0].toLowerCase())) 
+                        {
+                            completions.add(serverName);
+                        }
+                    } else 
                     {
                         completions.add(serverName);
                     }
-                } else
-                {
-                    completions.add(serverName);
                 }
             }
             return completions;


### PR DESCRIPTION
Currently the server command returns a list of server names if no arguments are entered, but if a string such as '/server h' was tab completed, a server named 'horse' would not be shown.

This commit should fix this.
