### PR TITLE
Add timeout argument to ServerInfo.ping

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/config/ServerInfo.java
+++ b/api/src/main/java/net/md_5/bungee/api/config/ServerInfo.java
@@ -80,4 +80,12 @@ public interface ServerInfo
      * @param callback the callback to call when the count has been retrieved.
      */
     void ping(Callback<ServerPing> callback);
+
+    /**
+     * Asynchronously gets the current player count on this server.
+     *
+     * @param callback the callback to call when the count has been retrieved.
+     * @param timeout the maximum connection time to the pinged server.
+     */
+    void ping(Callback<ServerPing> callback, int timeout);
 }

--- a/proxy/src/main/java/net/md_5/bungee/BungeeServerInfo.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeServerInfo.java
@@ -119,10 +119,16 @@ public class BungeeServerInfo implements ServerInfo
     @Override
     public void ping(final Callback<ServerPing> callback)
     {
-        ping( callback, ProxyServer.getInstance().getProtocolVersion() );
+        ping( callback, 500 );
     }
 
-    public void ping(final Callback<ServerPing> callback, final int protocolVersion)
+    @Override
+    public void ping(final Callback<ServerPing> callback, final int timeout)
+    {
+        ping( callback, timeout, ProxyServer.getInstance().getProtocolVersion() );
+    }
+
+    public void ping(final Callback<ServerPing> callback, final int timeout, final int protocolVersion)
     {
         Preconditions.checkNotNull( callback, "callback" );
 
@@ -144,8 +150,8 @@ public class BungeeServerInfo implements ServerInfo
                 .channel( PipelineUtils.getChannel() )
                 .group( BungeeCord.getInstance().eventLoops )
                 .handler( PipelineUtils.BASE )
-                .option( ChannelOption.CONNECT_TIMEOUT_MILLIS, 5000 ) // TODO: Configurable
-                .remoteAddress( getAddress() )
+                .option( ChannelOption.CONNECT_TIMEOUT_MILLIS, timeout )
+                .remoteAddress(getAddress())
                 .connect()
                 .addListener( listener );
     }

--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -221,7 +221,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
 
         if ( forced != null && listener.isPingPassthrough() )
         {
-            ( (BungeeServerInfo) forced ).ping( pingBack, handshake.getProtocolVersion() );
+            ( (BungeeServerInfo) forced ).ping( pingBack, 500, handshake.getProtocolVersion() );
         } else
         {
             int protocol = ( Protocol.supportedVersions.contains( handshake.getProtocolVersion() ) ) ? handshake.getProtocolVersion() : bungee.getProtocolVersion();


### PR DESCRIPTION
- Add timeout argument to ServerInfo.ping(callback, timeout)
- Reduce the default value to 500ms instead of 5000ms

This is not backward compatible with projects not using the bungee-api and relying on the bungee-proxy. But this is the only way I knew to implement this timeout.

This PR has no effect on indentation, unlike #1298, so it replaces it.
