### PR TITLE
Provide event to allow changing tab complete response from servers

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/event/ServerTabCompleteEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/ServerTabCompleteEvent.java
@@ -1,0 +1,34 @@
+package net.md_5.bungee.api.event;
+
+import java.util.List;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import net.md_5.bungee.api.connection.Connection;
+
+/**
+ * Event called when a server replies to a tab completion.
+ */
+@Data
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class ServerTabCompleteEvent extends TargetedEvent
+{
+
+    /**
+     * The suggestions that will be sent to the client. This list is mutable.
+     */
+    private final List<String> suggestions;
+
+    /**
+     * The cursor that triggered the tab complete
+     */
+    private final String cursor;
+
+    public ServerTabCompleteEvent(Connection sender, Connection receiver, String cursor, List<String> suggestions)
+    {
+        super( sender, receiver );
+        this.suggestions = suggestions;
+        this.cursor = cursor;
+    }
+}

--- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
@@ -101,6 +101,9 @@ public final class UserConnection implements ProxiedPlayer
     private int gamemode;
     @Getter
     private int compressionThreshold = -1;
+    @Getter
+    @Setter
+    private String lastTabCompleteRequest;
     /*========================================================================*/
     private final Collection<String> groups = new CaseInsensitiveSet();
     private final Collection<String> permissions = new CaseInsensitiveSet();

--- a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
@@ -141,6 +141,8 @@ public class UpstreamBridge extends PacketHandler
         {
             throw CancelSendSignal.INSTANCE;
         }
+
+        con.setLastTabCompleteRequest(tabComplete.getCursor());
     }
 
     @Override


### PR DESCRIPTION
Adds the ServerTabCompleteEvent which is fired upon receiving a TabCompleteResponse packet from a server to the client.
The purpose of this event is to be able to change the results of a tab complete after the request has been processed by the target server.

Use case:
We use this on our server to block people from tab completing the names of currently vanished players in either commands, or in chat.