### PR TITLE
[Forge] Fix IP forwarding for Forge 1.8 clients connecting to Spigot servers

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/connection/ProxiedPlayer.java
+++ b/api/src/main/java/net/md_5/bungee/api/connection/ProxiedPlayer.java
@@ -173,6 +173,20 @@ public interface ProxiedPlayer extends Connection, CommandSender
     void sendTitle(Title title);
 
     /**
+     * Gets whether this player is using a FML client.
+     * <p>
+     * This method is only reliable if BungeeCord links Minecraft 1.8 servers 
+     * together, as Bungee can pick up whether a user is a Forge user with the 
+     * initial handshake. If this is used for a 1.7 network, this might return
+     * <code>false</code> even if the user is a FML user, as Bungee can only
+     * determine this information if a handshake successfully completes.
+     * </p>
+     * @return <code>true</code> if it is known that the user is using a FML 
+     *         client, <code>false</code> otherwise.
+     */
+    boolean isForgeUser();
+
+    /**
      * Gets this player's Forge Mod List, if the player has sent this
      * information during the lifetime of their connection to Bungee. There is
      * no guarantee that information is available at any time, as it is only
@@ -181,7 +195,8 @@ public interface ProxiedPlayer extends Connection, CommandSender
      * <p>
      * Consumers of this API should be aware that an empty mod list does
      * <em>not</em> indicate that a user is not a Forge user, and so should not
-     * use this API to check for this - there is no way to tell this reliably.
+     * use this API to check for this. See the {@link #isForgeUser() 
+     * isForgeUser} method instead.
      * </p>
      * <p>
      * Calling this when handling a
@@ -189,7 +204,7 @@ public interface ProxiedPlayer extends Connection, CommandSender
      * place to do so as this event occurs after a FML handshake has completed,
      * if any has occurred.
      * </p>
-     *
+     * 
      * @return A {@link Map} of mods, where the key is the name of the mod, and
      * the value is the version. Returns an empty list if the FML handshake has
      * not occurred for this {@link ProxiedPlayer} yet.

--- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
+++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
@@ -92,6 +92,13 @@ public class ServerConnector extends PacketHandler
             }
             copiedHandshake.setHost( newHost );
         }
+        else if ( !user.getExtraDataInHandshake().isEmpty() ) 
+        {
+            // Only restore the extra data if IP forwarding is off. 
+            // TODO: Add support for this data with IP forwarding.
+            copiedHandshake.setHost( copiedHandshake.getHost() + user.getExtraDataInHandshake() );
+        }
+
         channel.write( copiedHandshake );
 
         channel.setProtocol( Protocol.LOGIN );

--- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
@@ -520,6 +520,12 @@ public final class UserConnection implements ProxiedPlayer
     }
 
     @Override
+    public boolean isForgeUser() 
+    {
+        return forgeClientHandler.isForgeUser();
+    }
+
+    @Override
     public Map<String, String> getModList()
     {
         if ( forgeClientHandler.getClientModList() == null )

--- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
@@ -38,6 +38,7 @@ import net.md_5.bungee.chat.ComponentSerializer;
 import net.md_5.bungee.connection.InitialHandler;
 import net.md_5.bungee.entitymap.EntityMap;
 import net.md_5.bungee.forge.ForgeClientHandler;
+import net.md_5.bungee.forge.ForgeConstants;
 import net.md_5.bungee.forge.ForgeServerHandler;
 import net.md_5.bungee.netty.ChannelWrapper;
 import net.md_5.bungee.netty.HandlerBoss;
@@ -166,6 +167,9 @@ public final class UserConnection implements ProxiedPlayer
         }
 
         forgeClientHandler = new ForgeClientHandler( this );
+
+        // Set whether the connection has a 1.8 FML marker in the handshake.
+        forgeClientHandler.setFmlTokenInHandshake( this.getPendingConnection().getExtraDataInHandshake().contains( ForgeConstants.FML_HANDSHAKE_TOKEN ) );
     }
 
     public void sendPacket(PacketWrapper packet)
@@ -565,6 +569,11 @@ public final class UserConnection implements ProxiedPlayer
     public void sendTitle(Title title)
     {
         title.send( this );
+    }
+
+    public String getExtraDataInHandshake()
+    {
+        return this.getPendingConnection().getExtraDataInHandshake();
     }
 
     public void setCompressionThreshold(int compressionThreshold)

--- a/proxy/src/main/java/net/md_5/bungee/forge/ForgeClientHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/forge/ForgeClientHandler.java
@@ -42,6 +42,14 @@ public class ForgeClientHandler
     private PluginMessage serverIdList = null;
 
     /**
+     * Gets or sets a value indicating whether the '\00FML\00' token was found in
+     * the handshake.
+     */
+    @Getter
+    @Setter
+    private boolean fmlTokenInHandshake = false;
+
+    /**
      * Handles the Forge packet.
      *
      * @param message The Forge Handshake packet to handle.
@@ -143,12 +151,14 @@ public class ForgeClientHandler
 
     /**
      * Returns whether we know if the user is a forge user.
+     * In FML 1.8, a "FML" token is included in the initial handshake.
+     * We can use that to determine if the user is a Forge 1.8 user.
      *
      * @return <code>true</code> if the user is a forge user.
      */
     public boolean isForgeUser()
     {
-        return clientModList != null;
+        return fmlTokenInHandshake || clientModList != null;
     }
 
     /**

--- a/proxy/src/main/java/net/md_5/bungee/forge/ForgeConstants.java
+++ b/proxy/src/main/java/net/md_5/bungee/forge/ForgeConstants.java
@@ -14,6 +14,11 @@ public class ForgeConstants
     public static final String FML_HANDSHAKE_TAG = "FML|HS";
     public static final String FML_REGISTER = "REGISTER";
 
+    /**
+     * The FML 1.8 handshake token.
+     */
+    public static final String FML_HANDSHAKE_TOKEN = "\0FML\0";
+
     public static final PluginMessage FML_RESET_HANDSHAKE = new PluginMessage( FML_HANDSHAKE_TAG, new byte[]
     {
         -2, 0


### PR DESCRIPTION
This PR checks for and removes any null character seperated extra data from the initial handshake packet, restoring it to a vanilla state whilst it is being processed by Bungee. This allows for one of two outcomes:

* If IP forwarding is on, this extra data is not added to the Bungee <-> Server handshake, and the IP forwarding data is appended to the handshake instead. This allows Spigot servers to continue operating as intended with IP forwarding, but FML servers will not start a handshake with FML clients (which is fine for now, no FML 1.8 servers exist that allow for IP forwarding, as far as I can see).
* If IP forwarding is off, the extra data is re-appended to the handshake and sent to the server.

This works around issue #1277. An API call is also added to allow users to detect whether a FML client is being used.