### PR TITLE
Add new 1.8 chat features

### DIFF
--- a/chat/src/main/java/net/md_5/bungee/api/chat/BaseComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/BaseComponent.java
@@ -48,6 +48,12 @@ public abstract class BaseComponent
      * obfuscated
      */
     private Boolean obfuscated;
+    /**
+     * The text to insert into the chat when this component (and child
+     * components) are clicked while pressing the shift key
+     */
+    @Getter
+    private String insertion;
 
     /**
      * Appended components that inherit this component's formatting and events
@@ -76,6 +82,7 @@ public abstract class BaseComponent
         setUnderlined( old.isUnderlinedRaw() );
         setStrikethrough( old.isStrikethroughRaw() );
         setObfuscated( old.isObfuscatedRaw() );
+        setInsertion( old.getInsertion() );
         setClickEvent( old.getClickEvent() );
         setHoverEvent( old.getHoverEvent() );
         if ( extra != null )

--- a/chat/src/main/java/net/md_5/bungee/api/chat/ClickEvent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/ClickEvent.java
@@ -45,6 +45,11 @@ public final class ClickEvent
          * {@link net.md_5.bungee.api.chat.ClickEvent#value} into the players
          * text box
          */
-        SUGGEST_COMMAND
+        SUGGEST_COMMAND,
+        /**
+         * Change to the page number given by
+         * {@link net.md_5.bungee.api.chat.ClickEvent#value} in a book
+         */
+        CHANGE_PAGE
     }
 }

--- a/chat/src/main/java/net/md_5/bungee/api/chat/HoverEvent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/HoverEvent.java
@@ -18,6 +18,7 @@ final public class HoverEvent
 
         SHOW_TEXT,
         SHOW_ACHIEVEMENT,
-        SHOW_ITEM
+        SHOW_ITEM,
+        SHOW_ENTITY
     }
 }

--- a/chat/src/main/java/net/md_5/bungee/chat/BaseComponentSerializer.java
+++ b/chat/src/main/java/net/md_5/bungee/chat/BaseComponentSerializer.java
@@ -41,6 +41,10 @@ public class BaseComponentSerializer
         {
             component.setUnderlined( object.get( "obfuscated" ).getAsBoolean() );
         }
+        if ( object.has( "insertion" ) )
+        {
+            component.setInsertion( object.get( "insertion" ).getAsString() );
+        }
         if ( object.has( "extra" ) )
         {
             component.setExtra( Arrays.<BaseComponent>asList( context.<BaseComponent[]>deserialize( object.get( "extra" ), BaseComponent[].class ) ) );
@@ -107,6 +111,10 @@ public class BaseComponentSerializer
             if ( component.isObfuscatedRaw() != null )
             {
                 object.addProperty( "obfuscated", component.isObfuscatedRaw() );
+            }
+            if ( component.getInsertion() != null )
+            {
+                object.addProperty( "insertion", component.getInsertion() );
             }
 
             if ( component.getExtra() != null )


### PR DESCRIPTION
In Minecraft 1.8 some chat features where added:
- insertion: Insert text into the chat while shift clicking a component
- new HoverEvent: SHOW_ENTITY to show information about an entity

This PR adds those features. 
This adds https://github.com/SpigotMC/BungeeCord/issues/1300