### PR TITLE
"Quitting" and "ConnectFail" subchannels

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/ServerConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/ServerConnection.java
@@ -2,6 +2,10 @@ package net.md_5.bungee;
 
 import java.net.InetSocketAddress;
 import java.util.concurrent.TimeUnit;
+
+import com.google.common.io.ByteArrayDataOutput;
+import com.google.common.io.ByteStreams;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
@@ -55,6 +59,7 @@ public class ServerConnection implements Server
         if ( !ch.isClosed() )
         {
             // TODO: Can we just use a future here?
+        	sendQuitMessage( ComponentSerializer.toString( reason ) );
             unsafe().sendPacket( new Kick( ComponentSerializer.toString( reason ) ) );
             ch.getHandle().eventLoop().schedule( new Runnable()
             {
@@ -87,5 +92,14 @@ public class ServerConnection implements Server
     public Unsafe unsafe()
     {
         return unsafe;
+    }
+
+    private void sendQuitMessage(String reason)
+    {
+    	ByteArrayDataOutput out = ByteStreams.newDataOutput();
+    	out.writeUTF( "Quitting" );
+    	out.writeUTF( reason );
+    	
+    	sendData("BungeeCord", out.toByteArray());
     }
 }

--- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
+++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
@@ -283,6 +283,7 @@ public class ServerConnector extends PacketHandler
         } else
         {
             user.sendMessage( message );
+            user.sendConnectFail( message );
         }
 
         throw CancelSendSignal.INSTANCE;

--- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
@@ -2,6 +2,9 @@ package net.md_5.bungee;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.io.ByteArrayDataOutput;
+import com.google.common.io.ByteStreams;
+
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
@@ -9,6 +12,7 @@ import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.util.internal.PlatformDependent;
+
 import java.net.InetSocketAddress;
 import java.util.Collection;
 import java.util.Collections;
@@ -19,6 +23,7 @@ import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
+
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -223,6 +228,7 @@ public final class UserConnection implements ProxiedPlayer
         ServerConnectEvent event = new ServerConnectEvent( this, info );
         if ( bungee.getPluginManager().callEvent( event ).isCancelled() )
         {
+        	sendConnectFail( "Connect cancelled" );
             return;
         }
 
@@ -231,11 +237,13 @@ public final class UserConnection implements ProxiedPlayer
         if ( getServer() != null && Objects.equals( getServer().getInfo(), target ) )
         {
             sendMessage( bungee.getTranslation( "already_connected" ) );
+            sendConnectFail( bungee.getTranslation( "already_connected" ) );
             return;
         }
         if ( pendingConnects.contains( target ) )
         {
             sendMessage( bungee.getTranslation( "already_connecting" ) );
+            sendConnectFail( bungee.getTranslation( "already_connecting" ) );
             return;
         }
 
@@ -281,6 +289,7 @@ public final class UserConnection implements ProxiedPlayer
                         } else
                         {
                             sendMessage( bungee.getTranslation( "fallback_kick", future.cause().getClass().getName() ) );
+                            sendConnectFail( bungee.getTranslation( "fallback_kick", future.cause().getClass().getName() ) );
                         }
                     }
                 }
@@ -590,5 +599,19 @@ public final class UserConnection implements ProxiedPlayer
             unsafe.sendPacket( new SetCompression( compressionThreshold ) );
             ch.setCompressionThreshold( compressionThreshold );
         }
+    }
+    
+    public void sendConnectFail(String reason)
+    {
+    	if ( server == null )
+    	{
+    		return;
+    	}
+    	
+    	ByteArrayDataOutput out = ByteStreams.newDataOutput();
+    	out.writeUTF( "ConnectFail" );
+    	out.writeUTF( reason );
+    	
+    	server.sendData( "BungeeCord", out.toByteArray() );
     }
 }


### PR DESCRIPTION
Messages sent via these subchannels are sent from BungeeCord to Bukkit/Spigot server.
Use cases:
1. If we want to send a plugin message to other servers in the proxy (e.g. using "Forward" subchannel) when player quit from server. We cannot do this in PlayerQuitEvent, because connection is closed. We may send our plugin message when server receive "Quitting" plugin message, because "Quitting" message is sending 100ms before BungeeCord close the connection with server.
2. ConnectFail subchannel may be used to inform server, that sending player to other server failed (e.g. player isn't on whitelist), then server may try to connect player to other server.