### PR TITLE
Add component cancel reasons to the Login and PreLogin

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/event/LoginCancellable.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/LoginCancellable.java
@@ -1,0 +1,14 @@
+package net.md_5.bungee.api.event;
+
+import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.api.plugin.Cancellable;
+
+/**
+ * Describes a Cancellable event that can have an attached component message on cancel, for example to disconnect the
+ * player.
+ */
+public interface LoginCancellable extends Cancellable {
+    void setCancelReason(BaseComponent... components);
+
+    BaseComponent[] getCancelReasonComponents();
+}

--- a/api/src/main/java/net/md_5/bungee/api/event/LoginEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/LoginEvent.java
@@ -4,6 +4,8 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import net.md_5.bungee.api.Callback;
+import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.api.connection.PendingConnection;
 import net.md_5.bungee.api.plugin.Cancellable;
 
@@ -13,7 +15,7 @@ import net.md_5.bungee.api.plugin.Cancellable;
 @Data
 @ToString(callSuper = false)
 @EqualsAndHashCode(callSuper = false)
-public class LoginEvent extends AsyncEvent<LoginEvent> implements Cancellable
+public class LoginEvent extends AsyncEvent<LoginEvent> implements Cancellable, LoginCancellable
 {
 
     /**
@@ -23,7 +25,7 @@ public class LoginEvent extends AsyncEvent<LoginEvent> implements Cancellable
     /**
      * Message to use when kicking if this event is canceled.
      */
-    private String cancelReason;
+    private BaseComponent[] cancelReason;
     /**
      * Connection attempting to login.
      */
@@ -33,5 +35,35 @@ public class LoginEvent extends AsyncEvent<LoginEvent> implements Cancellable
     {
         super( done );
         this.connection = connection;
+    }
+
+    /**
+     * @deprecated Use #setCancelReason(BaseComponent...) instead.
+     */
+    @Deprecated
+    public void setCancelReason(String cancelReason)
+    {
+        setCancelReason( TextComponent.fromLegacyText( cancelReason ) );
+    }
+
+    @Override
+    public void setCancelReason(BaseComponent... components)
+    {
+        this.cancelReason = components;
+    }
+
+    /**
+     * @deprecated Use #getCancelReasonComponents instead.
+     */
+    @Deprecated
+    public String getCancelReason()
+    {
+        return BaseComponent.toLegacyText( getCancelReasonComponents() );
+    }
+
+    @Override
+    public BaseComponent[] getCancelReasonComponents()
+    {
+        return cancelReason;
     }
 }

--- a/api/src/main/java/net/md_5/bungee/api/event/PreLoginEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/PreLoginEvent.java
@@ -4,6 +4,8 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import net.md_5.bungee.api.Callback;
+import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.api.connection.PendingConnection;
 import net.md_5.bungee.api.plugin.Cancellable;
 
@@ -18,7 +20,7 @@ import net.md_5.bungee.api.plugin.Cancellable;
 @Data
 @ToString(callSuper = false)
 @EqualsAndHashCode(callSuper = false)
-public class PreLoginEvent extends AsyncEvent<PreLoginEvent> implements Cancellable
+public class PreLoginEvent extends AsyncEvent<PreLoginEvent> implements Cancellable, LoginCancellable
 {
 
     /**
@@ -28,7 +30,7 @@ public class PreLoginEvent extends AsyncEvent<PreLoginEvent> implements Cancella
     /**
      * Message to use when kicking if this event is canceled.
      */
-    private String cancelReason;
+    private BaseComponent[] cancelReason;
     /**
      * Connection attempting to login.
      */
@@ -38,5 +40,35 @@ public class PreLoginEvent extends AsyncEvent<PreLoginEvent> implements Cancella
     {
         super( done );
         this.connection = connection;
+    }
+
+    /**
+     * @deprecated Use #setCancelReason(BaseComponent...) instead.
+     */
+    @Deprecated
+    public void setCancelReason(String cancelReason)
+    {
+        setCancelReason( TextComponent.fromLegacyText( cancelReason ) );
+    }
+
+    @Override
+    public void setCancelReason(BaseComponent... components)
+    {
+        this.cancelReason = components;
+    }
+
+    /**
+     * @deprecated Use #getCancelReasonComponents instead.
+     */
+    @Deprecated
+    public String getCancelReason()
+    {
+        return BaseComponent.toLegacyText( getCancelReasonComponents() );
+    }
+
+    @Override
+    public BaseComponent[] getCancelReasonComponents()
+    {
+        return cancelReason;
     }
 }

--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -338,7 +338,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
             {
                 if ( result.isCancelled() )
                 {
-                    disconnect( result.getCancelReason() );
+                    disconnect( result.getCancelReasonComponents() );
                     return;
                 }
                 if ( ch.isClosed() )
@@ -435,7 +435,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
             {
                 if ( result.isCancelled() )
                 {
-                    disconnect( result.getCancelReason() );
+                    disconnect( result.getCancelReasonComponents() );
                     return;
                 }
                 if ( ch.isClosed() )


### PR DESCRIPTION
Previously, you had to manually disconnect the player to send components with the kick and had to block the login event so only one disconnect could be queued (since disconnects are sent delayed).
