### PR TITLE
Use the cached constructor when instantiating a packet.

### DIFF
--- a/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java
@@ -138,7 +138,7 @@ public enum Protocol
 
             try
             {
-                return packetClasses[id].newInstance();
+                return packetConstructors[id].newInstance();
             } catch ( ReflectiveOperationException ex )
             {
                 throw new BadPacketException( "Could not construct packet with id " + id, ex );


### PR DESCRIPTION
Use the cached constructor when instantiating a packet. Tested and working.