### PR TITLE
Allow setting a connections uuid when in offline mode

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/connection/PendingConnection.java
+++ b/api/src/main/java/net/md_5/bungee/api/connection/PendingConnection.java
@@ -55,6 +55,11 @@ public interface PendingConnection extends Connection
     UUID getUniqueId();
 
     /**
+     * Set the connection's uuid
+     */
+    void setUniqueId(UUID uuid);
+
+    /**
      * Get this connection's online mode.
      *
      * @return the online mode

--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -562,6 +562,14 @@ public class InitialHandler extends PacketHandler implements PendingConnection
     }
 
     @Override
+    public void setUniqueId(UUID uuid)
+    {
+        Preconditions.checkState( thisState == State.USERNAME, "Can only set uuid while state is username" );
+        Preconditions.checkState( !onlineMode, "Can only set uuid when online mode is false" );
+        this.uniqueId = uuid;
+    }
+
+    @Override
     public String getUUID()
     {
         return uniqueId.toString().replaceAll( "-", "" );


### PR DESCRIPTION
This allows developers to manual set the uuid of a pending connection when the event is set to offline mode.