### PR TITLE
Update lombok dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.14.8</version>
+            <version>1.16.2</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Update the lombok dependency to `1.16.2`. See the full changelog [here](http://projectlombok.org/changelog.html).