### PR TITLE
Add event to allow plugin notification that a requested connect event has failed.

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/event/ServerConnectFailedEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/ServerConnectFailedEvent.java
@@ -1,0 +1,41 @@
+package net.md_5.bungee.api.event;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import net.md_5.bungee.api.config.ServerInfo;
+import net.md_5.bungee.api.connection.ProxiedPlayer;
+import net.md_5.bungee.api.plugin.Event;
+
+/**
+ * Called when an connect to a server has failed, only called when the
+ * ProxiedPlayer remains online.
+ */
+@Data
+@ToString(callSuper = false)
+@EqualsAndHashCode(callSuper = false)
+public class ServerConnectFailedEvent extends Event
+{
+    /**
+     * Player whom the server is for.
+     */
+    private final ProxiedPlayer player;
+    /**
+     * TServer info of the failed destination.
+     */
+    private final ServerInfo serverInfo;
+    /**
+     * Throwable reason which caused the connection failure.
+     */
+    private final Throwable throwable;
+    /**
+     * The user should receive the failure message.
+     */
+    private boolean informUser = true;
+
+    public ServerConnectFailedEvent(ProxiedPlayer player, ServerInfo serverInfo, Throwable throwable) {
+        this.player = player;
+        this.serverInfo = serverInfo;
+        this.throwable = throwable;
+    }
+}

--- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
@@ -33,6 +33,7 @@ import net.md_5.bungee.api.config.ServerInfo;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.event.PermissionCheckEvent;
 import net.md_5.bungee.api.event.ServerConnectEvent;
+import net.md_5.bungee.api.event.ServerConnectFailedEvent;
 import net.md_5.bungee.api.score.Scoreboard;
 import net.md_5.bungee.chat.ComponentSerializer;
 import net.md_5.bungee.connection.InitialHandler;
@@ -252,6 +253,8 @@ public final class UserConnection implements ProxiedPlayer
                 ch.pipeline().get( HandlerBoss.class ).setHandler( new ServerConnector( bungee, UserConnection.this, target ) );
             }
         };
+        final ProxiedPlayer playerConnect = this;
+
         ChannelFutureListener listener = new ChannelFutureListener()
         {
             @Override
@@ -280,7 +283,12 @@ public final class UserConnection implements ProxiedPlayer
                             disconnect( bungee.getTranslation( "fallback_kick", future.cause().getClass().getName() ) );
                         } else
                         {
-                            sendMessage( bungee.getTranslation( "fallback_kick", future.cause().getClass().getName() ) );
+                            ServerConnectFailedEvent event = new ServerConnectFailedEvent( playerConnect, target, future.cause() );
+                            bungee.getPluginManager().callEvent( event );
+
+                            if ( event.isInformUser() ) {
+                                sendMessage(bungee.getTranslation("fallback_kick", future.cause().getClass().getName()));
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
At current there's no way for a requesting server to know that a connection request has failed (other then waiting and assuming after a timeout), this event allows a plugin to listen for it, then a plugin could send a message back to the requesting instance.