### PR TITLE
No permission message fix.

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
@@ -147,7 +147,7 @@ public class PluginManager
         String permission = command.getPermission();
         if ( permission != null && !permission.isEmpty() && !sender.hasPermission( permission ) )
         {
-            if ( !( command instanceof TabExecutor ) )
+            if ( !( command instanceof TabExecutor ) || tabResults == null )
             {
                 sender.sendMessage( proxy.getTranslation( "no_permission" ) );
             }


### PR DESCRIPTION
Show the no permission message even if the command is a TabExecutor but the command was not dispatched by the tab completer.