### PR TITLE
Fix AsyncEvent callback triggering.

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/event/AsyncEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/AsyncEvent.java
@@ -33,11 +33,11 @@ public class AsyncEvent<T> extends Event
     @SuppressWarnings("unchecked")
     public void postCall()
     {
-        fired.set( true );
         if ( latch.get() == 0 )
         {
             done.done( (T) this, null );
         }
+        fired.set( true );
     }
 
     /**
@@ -67,9 +67,14 @@ public class AsyncEvent<T> extends Event
     {
         Preconditions.checkState( intents.contains( plugin ), "Plugin %s has not registered intent for event %s", plugin, this );
         intents.remove( plugin );
-        if ( latch.decrementAndGet() == 0 && fired.get() )
+        if ( fired.get() )
         {
-            done.done( (T) this, null );
+            if ( latch.decrementAndGet() == 0 )
+            {
+                done.done( (T) this, null );
+            }
+        } else {
+            latch.decrementAndGet();
         }
     }
 }


### PR DESCRIPTION
Before this, two concurrent postCall() and completeIntent() calls might cause the callback to be called more than once. Example:

> Thread A does postCall()
> Thread B does completeIntent()
> Initially, latch = 1 and fired = false
>
> A:  fired.set(true)
> B:  latch.decrementAndGet() == 0 && fired.get()            *(=true )*
> B:  **done.done()**
> A:  latch.get() == 0        *(=true )*
> A:  **done.done()**