### PR TITLE
Add a way to check if its a players initial join in ServerConnectEvent

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/event/ServerConnectEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/ServerConnectEvent.java
@@ -31,13 +31,19 @@ public class ServerConnectEvent extends Event implements Cancellable
     @NonNull
     private ServerInfo target;
     /**
+     * If the player has just connected to the Bungee
+     * instance from no previous server.
+     */
+    private final boolean initialJoin;
+    /**
      * Cancelled state.
      */
     private boolean cancelled;
 
-    public ServerConnectEvent(ProxiedPlayer player, ServerInfo target)
+    public ServerConnectEvent(ProxiedPlayer player, ServerInfo target, boolean initialJoin)
     {
         this.player = player;
         this.target = target;
+        this.initialJoin = initialJoin;
     }
 }

--- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
@@ -220,7 +220,7 @@ public final class UserConnection implements ProxiedPlayer
     {
         Preconditions.checkNotNull( info, "info" );
 
-        ServerConnectEvent event = new ServerConnectEvent( this, info );
+        ServerConnectEvent event = new ServerConnectEvent( this, info, getServer() == null );
         if ( bungee.getPluginManager().callEvent( event ).isCancelled() )
         {
             return;


### PR DESCRIPTION
This is useful so plugins don't manually have to create a collection tracking when a player first joins and removing when they leave.