### PR TITLE
Store last known dimension and don't send useless respawn packets

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
+++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
@@ -220,7 +220,10 @@ public class ServerConnector extends PacketHandler
             }
             serverScoreboard.clear();
 
-            user.sendDimensionSwitch();
+            if( user.getDimension() == login.getDimension() ){
+                // Only change dimension to reset entities
+                user.unsafe().sendPacket( new Respawn( ( login.getDimension() == 0 ) ? 1 : 0, login.getDifficulty(), login.getGameMode(), login.getLevelType() ) );
+            }
 
             user.setServerEntityId( login.getEntityId() );
             user.unsafe().sendPacket( new Respawn( login.getDimension(), login.getDifficulty(), login.getGameMode(), login.getLevelType() ) );
@@ -243,7 +246,7 @@ public class ServerConnector extends PacketHandler
         // TODO: Move this to the connected() method of DownstreamBridge
         target.addPlayer( user );
         user.getPendingConnects().remove( target );
-        user.setDimensionChange( false );
+        user.setDimension( login.getDimension() );
 
         user.setServer( server );
         ch.getHandle().pipeline().get( HandlerBoss.class ).setHandler( new DownstreamBridge( bungee, user, server ) );
@@ -276,14 +279,7 @@ public class ServerConnector extends PacketHandler
             throw CancelSendSignal.INSTANCE;
         }
 
-        String message = bungee.getTranslation( "connect_kick", target.getName(), event.getKickReason() );
-        if ( user.isDimensionChange() )
-        {
-            user.disconnect( message );
-        } else
-        {
-            user.sendMessage( message );
-        }
+        user.sendMessage( bungee.getTranslation( "connect_kick", target.getName(), event.getKickReason() ) );
 
         throw CancelSendSignal.INSTANCE;
     }

--- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
@@ -79,7 +79,7 @@ public final class UserConnection implements ProxiedPlayer
     private ServerConnection server;
     @Getter
     @Setter
-    private boolean dimensionChange = true;
+    private int dimension = 0;
     @Getter
     private final Collection<ServerInfo> pendingConnects = new HashSet<>();
     /*========================================================================*/
@@ -203,16 +203,8 @@ public final class UserConnection implements ProxiedPlayer
         connect( target, callback, false );
     }
 
-    void sendDimensionSwitch()
-    {
-        dimensionChange = true;
-        unsafe().sendPacket( PacketConstants.DIM1_SWITCH );
-        unsafe().sendPacket( PacketConstants.DIM2_SWITCH );
-    }
-
     public void connectNow(ServerInfo target)
     {
-        sendDimensionSwitch();
         connect( target );
     }
 
@@ -275,13 +267,7 @@ public final class UserConnection implements ProxiedPlayer
                         connect( def, null, false );
                     } else
                     {
-                        if ( dimensionChange )
-                        {
-                            disconnect( bungee.getTranslation( "fallback_kick", future.cause().getClass().getName() ) );
-                        } else
-                        {
-                            sendMessage( bungee.getTranslation( "fallback_kick", future.cause().getClass().getName() ) );
-                        }
+                        sendMessage( bungee.getTranslation( "fallback_kick", future.cause().getClass().getName() ) );
                     }
                 }
             }

--- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
@@ -37,6 +37,7 @@ import net.md_5.bungee.protocol.packet.ScoreboardScore;
 import net.md_5.bungee.protocol.packet.ScoreboardDisplay;
 import net.md_5.bungee.protocol.packet.PluginMessage;
 import net.md_5.bungee.protocol.packet.Kick;
+import net.md_5.bungee.protocol.packet.Respawn;
 import net.md_5.bungee.protocol.packet.SetCompression;
 import net.md_5.bungee.protocol.packet.TabCompleteResponse;
 import net.md_5.bungee.tab.TabList;
@@ -492,6 +493,12 @@ public class DownstreamBridge extends PacketHandler
         }
 
         throw CancelSendSignal.INSTANCE;
+    }
+
+    @Override
+    public void handle(Respawn respawn) throws Exception
+    {
+        con.setDimension( respawn.getDimension() );
     }
 
     @Override

--- a/proxy/src/main/java/net/md_5/bungee/forge/ForgeClientHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/forge/ForgeClientHandler.java
@@ -173,13 +173,7 @@ public class ForgeClientHandler
     {
         if ( forgeOutdated )
         {
-            if ( con.isDimensionChange() )
-            {
-                con.disconnect( BungeeCord.getInstance().getTranslation( "connect_kick_outdated_forge" ) );
-            } else
-            {
-                con.sendMessage( BungeeCord.getInstance().getTranslation( "connect_kick_outdated_forge" ) );
-            }
+            con.sendMessage( BungeeCord.getInstance().getTranslation( "connect_kick_outdated_forge" ) );
         }
 
         return forgeOutdated;


### PR DESCRIPTION
In order to improve server switching without lossing the advantages of the Respawn package (reset entities, for instance)
