### PR TITLE
Added a profile to fix JavaDoc outputs with delombok

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,4 +150,66 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>lombok-needs-tools-jar</id>
+            <activation>
+                <file>
+                    <exists>${java.home}/../lib/tools.jar</exists>
+                </file>
+            </activation>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.projectlombok</groupId>
+                        <artifactId>lombok-maven-plugin</artifactId>
+                        <version>1.16.2.0</version>
+
+                        <executions>
+                            <execution>
+                                <phase>generate-sources</phase>
+
+                                <goals>
+                                    <goal>delombok</goal>
+                                </goals>
+
+                                <configuration>
+                                    <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>
+                                    <addOutputDirectory>false</addOutputDirectory>
+                                    <verbose>true</verbose>
+
+                                    <formatPreferences>
+                                        <javaLangAsFQN>skip</javaLangAsFQN>
+                                    </formatPreferences>
+                                </configuration>
+                            </execution>
+                        </executions>
+
+                        <dependencies>
+                            <dependency>
+                                <groupId>sun.jdk</groupId>
+                                <artifactId>tools</artifactId>
+                                <version>1.6</version>
+                                <scope>system</scope>
+                                <systemPath>${java.home}/../lib/tools.jar</systemPath>
+                            </dependency>
+                        </dependencies>
+                    </plugin>
+
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>2.7</version>
+
+                        <configuration>
+                            <sourcepath>${project.build.directory}/generated-sources/delombok</sourcepath>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
This PR fixes the maven configuration to apply delombok to sources before generating the JavaDoc. Note: For this to work the CI needs to be changed so package is executed before javadoc:jar as maven will execute the specified goals in order (e.g. package javadoc:jar sources:jar deploy).

This PR is an extension to CyberTiger's PR (see #1411) with the slight difference that it does not use the sources generated by delombok to compile the project and thus does not require lombok to be present in the classpath for annotations like @SneakyThrows to be present.
