### PR TITLE
Fix BaseComponent.duplicate() ignoring extra

### DIFF
--- a/chat/src/main/java/net/md_5/bungee/api/chat/BaseComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/BaseComponent.java
@@ -78,9 +78,9 @@ public abstract class BaseComponent
         setObfuscated( old.isObfuscatedRaw() );
         setClickEvent( old.getClickEvent() );
         setHoverEvent( old.getHoverEvent() );
-        if ( extra != null )
+        if ( old.getExtra() != null )
         {
-            for ( BaseComponent component : extra )
+            for ( BaseComponent component : old.getExtra() )
             {
                 addExtra( component.duplicate() );
             }


### PR DESCRIPTION
Currently, calling BaseComponent.duplicate() results in an otherwise identical component with no extra elements.