### PR TITLE
Use an actual ArrayList when creating a TextComponent with extras.

### DIFF
--- a/chat/src/main/java/net/md_5/bungee/api/chat/TextComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/TextComponent.java
@@ -156,7 +156,7 @@ public class TextComponent extends BaseComponent
     public TextComponent(BaseComponent... extras)
     {
         setText( "" );
-        setExtra( Arrays.asList( extras ) );
+        setExtra( new ArrayList<BaseComponent>( Arrays.asList( extras ) ) );
     }
 
     /**


### PR DESCRIPTION
Arrays#asList returns a java.util.Arrays.ArrayList, which does not support adding more elements.  This previously broke BaseComponent#addExtra under certain circumstances.