### PR TITLE
[Forge] Fix telling newer 1.7 Forge clients that they are outdated, don't bother checking for 1.8 clients

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/forge/ForgeClientHandshakeState.java
+++ b/proxy/src/main/java/net/md_5/bungee/forge/ForgeClientHandshakeState.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import net.md_5.bungee.ServerConnector;
 import net.md_5.bungee.UserConnection;
 import net.md_5.bungee.forge.ForgeLogger.LogDirection;
+import net.md_5.bungee.protocol.ProtocolConstants;
 import net.md_5.bungee.protocol.packet.PluginMessage;
 
 /**
@@ -86,16 +87,19 @@ enum ForgeClientHandshakeState implements IForgeClientPacketHandler<ForgeClientH
                             Map<String, String> clientModList = ForgeUtils.readModList( message );
                             con.getForgeClientHandler().setClientModList( clientModList );
 
-                            // Get the version from the mod list.
-                            // TODO: Remove this once Bungee becomes 1.8 only.
-                            int buildNumber = ForgeUtils.getFmlBuildNumber( clientModList );
-
-                            // If we get 0, we're probably using a testing build, so let it though. Otherwise, check the build number.
-                            if ( buildNumber < ForgeConstants.FML_MIN_BUILD_VERSION && buildNumber != 0 )
+                            // If the user is running 1.8 or above, we don't need to check the version of FML - it's always an OK version.
+                            if ( con.getPendingConnection().getVersion() < ProtocolConstants.MINECRAFT_1_8 )
                             {
-                                // Mark the user as an old Forge user. This will then cause any Forge ServerConnectors to cancel any
-                                // connections to it.
-                                con.getForgeClientHandler().setForgeOutdated( true );
+                                // Get the version from the mod list.
+                                int buildNumber = ForgeUtils.getFmlBuildNumber( clientModList );
+
+                                // If we get 0, we're probably using a testing build, so let it though. Otherwise, check the build number.
+                                if ( buildNumber < ForgeConstants.FML_MIN_BUILD_VERSION && buildNumber != 0 )
+                                {
+                                    // Mark the user as an old Forge user. This will then cause any Forge ServerConnectors to cancel any
+                                    // connections to it.
+                                    con.getForgeClientHandler().setForgeOutdated( true );
+                                }
                             }
                         }
 

--- a/proxy/src/main/java/net/md_5/bungee/forge/ForgeUtils.java
+++ b/proxy/src/main/java/net/md_5/bungee/forge/ForgeUtils.java
@@ -61,11 +61,26 @@ public class ForgeUtils
     {
         if ( modList.containsKey( "FML" ) )
         {
-            Matcher matcher = ForgeConstants.FML_HANDSHAKE_VERSION_REGEX.matcher( modList.get( "FML" ) );
-            if ( matcher.find() )
+            String fmlVersion  = modList.get( "FML" );
+            
+            // FML's version is hardcoded to this for builds beyond 1405 for 1.7.10 - if we see this, return Forge's build number.
+            if ( fmlVersion.equals( "7.10.99.99" ) )
             {
-                // We know from the regex that we have an int.
-                return Integer.parseInt( matcher.group( 4 ) );
+                Matcher matcher = ForgeConstants.FML_HANDSHAKE_VERSION_REGEX.matcher( modList.get( "Forge" ) );
+                if ( matcher.find() )
+                {
+                    // We know from the regex that we have an int.
+                    return Integer.parseInt( matcher.group( 4 ) );
+                }
+            }
+            else 
+            {
+                Matcher matcher = ForgeConstants.FML_HANDSHAKE_VERSION_REGEX.matcher( fmlVersion );
+                if ( matcher.find() )
+                {
+                    // We know from the regex that we have an int.
+                    return Integer.parseInt( matcher.group( 4 ) );
+                }
             }
         }
 


### PR DESCRIPTION
This fixes issue #1476 and https://github.com/MinecraftForge/MinecraftForge/issues/1891

* Only check the version of FML if we are running Minecraft 1.7.10 - 1.8 clients are always valid.
* If the version of FML that is reported is 7.10.99.99 (Forge build 1406+) - report the Forge version instead.