### PR TITLE
Fix Deadlock in EventBus post

### DIFF
--- a/event/src/main/java/net/md_5/bungee/event/EventBus.java
+++ b/event/src/main/java/net/md_5/bungee/event/EventBus.java
@@ -34,32 +34,33 @@ public class EventBus
 
     public void post(Object event)
     {
+        EventHandlerMethod[] handlers = null;
         lock.readLock().lock();
         try
         {
-            EventHandlerMethod[] handlers = byEventBaked.get( event.getClass() );
-            if ( handlers != null )
-            {
-                for ( EventHandlerMethod method : handlers )
-                {
-                    try
-                    {
-                        method.invoke( event );
-                    } catch ( IllegalAccessException ex )
-                    {
-                        throw new Error( "Method became inaccessible: " + event, ex );
-                    } catch ( IllegalArgumentException ex )
-                    {
-                        throw new Error( "Method rejected target/argument: " + event, ex );
-                    } catch ( InvocationTargetException ex )
-                    {
-                        logger.log( Level.WARNING, MessageFormat.format( "Error dispatching event {0} to listener {1}", event, method.getListener() ), ex.getCause() );
-                    }
-                }
-            }
+            handlers = byEventBaked.get( event.getClass() );
         } finally
         {
             lock.readLock().unlock();
+        }
+        if ( handlers != null )
+        {
+            for ( EventHandlerMethod method : handlers )
+            {
+                try
+                {
+                    method.invoke( event );
+                } catch ( IllegalAccessException ex )
+                {
+                    throw new Error( "Method became inaccessible: " + event, ex );
+                } catch ( IllegalArgumentException ex )
+                {
+                    throw new Error( "Method rejected target/argument: " + event, ex );
+                } catch ( InvocationTargetException ex )
+                {
+                    logger.log( Level.WARNING, MessageFormat.format( "Error dispatching event {0} to listener {1}", event, method.getListener() ), ex.getCause() );
+                }
+            }
         }
     }
 


### PR DESCRIPTION
This pull request fixes https://github.com/SpigotMC/BungeeCord/issues/1493 .
The proposed fix recognizes that the EventHandlerMethod[] being obtained is never modified. When there is an addition or removal of a listener, the handlers are baked, and a new EventHandlerMethod[] is created instead of modifying the previous, which pretty much mirrors what a COWArrayList does. That means you don't need to hold the read lock for the entirety of the post, only for the acquisition of the EventHandlerMethod[].