### PR TITLE
Improve compression configuration, can save lots of CPU time

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/ProxyConfig.java
+++ b/api/src/main/java/net/md_5/bungee/api/ProxyConfig.java
@@ -51,6 +51,16 @@ public interface ProxyConfig
     Collection<String> getDisabledCommands();
 
     /**
+     * Wheter player connections are going to use the custom threshold or the threshold set by the server
+     */
+    boolean isCustomTreshold();
+
+    /**
+     * Returns the threshold used for player connection
+     */
+    int getPlayerThreshold();
+
+    /**
      * The connection throttle delay.
      */
     @Deprecated

--- a/protocol/src/main/java/net/md_5/bungee/protocol/MinecraftDecoder.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/MinecraftDecoder.java
@@ -34,7 +34,7 @@ public class MinecraftDecoder extends MessageToMessageDecoder<ByteBuf>
                 packet.read( in, prot.getDirection(), protocolVersion );
                 if ( in.readableBytes() != 0 )
                 {
-                    throw new BadPacketException( "Did not read all bytes from packet " + packet.getClass() + " " + packetId + " Protocol " + protocol + " Direction " + prot );
+                    throw new BadPacketException( "Did not read all bytes from packet " + packet.getClass() + " " + packetId + " Protocol " + protocol + " Direction " + prot.getDirection().name() );
                 }
             } else
             {

--- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
+++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
@@ -143,7 +143,10 @@ public class ServerConnector extends PacketHandler
     @Override
     public void handle(SetCompression setCompression) throws Exception
     {
-        user.setCompressionThreshold( setCompression.getThreshold() );
+        if ( !ProxyServer.getInstance().getConfig().isCustomTreshold() )
+        {
+            user.setCompressionThreshold( setCompression.getThreshold() );
+        }
         ch.setCompressionThreshold( setCompression.getThreshold() );
     }
 

--- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
@@ -584,7 +584,7 @@ public final class UserConnection implements ProxiedPlayer
 
     public void setCompressionThreshold(int compressionThreshold)
     {
-        if ( ch.getHandle().isActive() && this.compressionThreshold == -1 )
+        if ( ch.getHandle().isActive() && this.compressionThreshold == -1 && compressionThreshold != this.compressionThreshold )
         {
             this.compressionThreshold = compressionThreshold;
             unsafe.sendPacket( new SetCompression( compressionThreshold ) );

--- a/proxy/src/main/java/net/md_5/bungee/conf/Configuration.java
+++ b/proxy/src/main/java/net/md_5/bungee/conf/Configuration.java
@@ -49,6 +49,8 @@ public class Configuration implements ProxyConfig
     private boolean onlineMode = true;
     private int playerLimit = -1;
     private Collection<String> disabledCommands;
+    private boolean customTreshold = false;
+    private int playerThreshold = 256;
     private int throttle = 4000;
     private boolean ipForward;
     private Favicon favicon;
@@ -75,6 +77,8 @@ public class Configuration implements ProxyConfig
         uuid = adapter.getString( "stats", uuid );
         onlineMode = adapter.getBoolean( "online_mode", onlineMode );
         playerLimit = adapter.getInt( "player_limit", playerLimit );
+        customTreshold = adapter.getBoolean( "use_custom_threshold", customTreshold );
+        playerThreshold = adapter.getInt( "user_threshold", playerThreshold);
         throttle = adapter.getInt( "connection_throttle", throttle );
         ipForward = adapter.getBoolean( "ip_forward", ipForward );
 

--- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
@@ -479,7 +479,10 @@ public class DownstreamBridge extends PacketHandler
     @Override
     public void handle(SetCompression setCompression) throws Exception
     {
-        con.setCompressionThreshold( setCompression.getThreshold() );
+        if ( !ProxyServer.getInstance().getConfig().isCustomTreshold() )
+        {
+            con.setCompressionThreshold( setCompression.getThreshold() );
+        }
         server.getCh().setCompressionThreshold( setCompression.getThreshold() );
     }
 

--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -284,9 +284,9 @@ public class InitialHandler extends PacketHandler implements PendingConnection
                 ch.setProtocol( Protocol.STATUS );
                 break;
             case 2:
+                // Login
                 thisState = State.USERNAME;
                 ch.setProtocol( Protocol.LOGIN );
-                // Login
                 break;
             default:
                 throw new IllegalArgumentException( "Cannot request protocol " + handshake.getRequestedProtocol() );
@@ -500,6 +500,11 @@ public class InitialHandler extends PacketHandler implements PendingConnection
                             if ( server == null )
                             {
                                 server = bungee.getServerInfo( listener.getDefaultServer() );
+                            }
+
+                            if ( ProxyServer.getInstance().getConfig().isCustomTreshold() )
+                            {
+                                userCon.setCompressionThreshold( ProxyServer.getInstance().getConfig().getPlayerThreshold() );
                             }
 
                             userCon.connect( server, null, true );


### PR DESCRIPTION
Allows to use a different compression thresohold between User <-> Bungee and Bungee <-> Server. This way you can disable compression in your server.properties - which means the server does not need to compress and BungeeCord doesn´t have to decompress every chunk packet. It will be compressed once by BungeeCord at the end of the pipeline, not two times as of now (plus 1 decompress).
I don´t know exact values, but this will lower your CPU usage a lot (both server & bungee)