### PR TITLE
Added basic support for configurable tab-complete throttling

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/ProxyConfig.java
+++ b/api/src/main/java/net/md_5/bungee/api/ProxyConfig.java
@@ -57,6 +57,11 @@ public interface ProxyConfig
     int getThrottle();
 
     /**
+     * The Tab-Complete throttle delay.
+     */
+    int getTabThrottle ();
+
+    /**
      * Whether the proxy will parse IPs with spigot or not
      */
     @Deprecated

--- a/proxy/src/main/java/net/md_5/bungee/conf/Configuration.java
+++ b/proxy/src/main/java/net/md_5/bungee/conf/Configuration.java
@@ -50,6 +50,7 @@ public class Configuration implements ProxyConfig
     private int playerLimit = -1;
     private Collection<String> disabledCommands;
     private int throttle = 4000;
+    private int tabThrottle = 1000;
     private boolean ipForward;
     private Favicon favicon;
 
@@ -76,6 +77,7 @@ public class Configuration implements ProxyConfig
         onlineMode = adapter.getBoolean( "online_mode", onlineMode );
         playerLimit = adapter.getInt( "player_limit", playerLimit );
         throttle = adapter.getInt( "connection_throttle", throttle );
+        tabThrottle = adapter.getInt( "tab_throttle", tabThrottle );
         ipForward = adapter.getBoolean( "ip_forward", ipForward );
 
         disabledCommands = new CaseInsensitiveSet( (Collection<String>) adapter.getList( "disabled_commands", Arrays.asList( "disabledcommandhere" ) ) );

--- a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
@@ -31,6 +31,8 @@ public class UpstreamBridge extends PacketHandler
     private final ProxyServer bungee;
     private final UserConnection con;
 
+    private long tabCompletionThrottle = -1;
+
     public UpstreamBridge(ProxyServer bungee, UserConnection con)
     {
         this.bungee = bungee;
@@ -124,6 +126,16 @@ public class UpstreamBridge extends PacketHandler
     @Override
     public void handle(TabCompleteRequest tabComplete) throws Exception
     {
+        if ( bungee.getConfig().getTabThrottle() > 0 )
+        {
+            long now = System.currentTimeMillis();
+            if ( tabCompletionThrottle != -1 && (now - tabCompletionThrottle) <= bungee.getConfig().getTabThrottle() )
+            {
+                throw CancelSendSignal.INSTANCE;
+            }
+            tabCompletionThrottle = now;
+        }
+
         List<String> suggestions = new ArrayList<>();
 
         if ( tabComplete.getCursor().startsWith( "/" ) )


### PR DESCRIPTION
Currently players are able to spam tab-completion packets which can cause some badly written plugins to cause an insane amount of load on the server side. Thus tab completion should be throttled gracefully.

**Edit**: Slightly changed the fix to allow users to properly disable the check by setting a value smaller or equal to zero. Fixed another smaller issue which can get the check stuck.
