### PR TITLE
Correct handling of command's parameters for tab completion

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
@@ -126,7 +126,7 @@ public class PluginManager
      */
     public boolean dispatchCommand(CommandSender sender, String commandLine, List<String> tabResults)
     {
-        String[] split = argsSplit.split( commandLine );
+        String[] split = argsSplit.split( commandLine, -1 );
         // Check for chat that only contains " "
         if ( split.length == 0 )
         {


### PR DESCRIPTION
There is some problem with TabExecutor and I think I found the problem.

Exemple :
/send [playerName|all|current] [targetServer]
When I write "/send " (with trailing space) and press Tab, I don't have any suggestion. But when I wrote the first character of an online player, it suggest all players which start with this same character (expected behavior)

The problem is the same when I wrote "/send marcbal " (with trailing space). When I press Tab key, I have "marcbal" suggested instead of servers suggestion. (the result is "/send marcbal marcbal"). But when i wrote the first character of a server name, it suggest all servers which start with this same character (expected behavior)

other example : there is 2 players online in the same server : me (marcbal) and marcbaleeee (for example)
when I wrote "/send marcbal " (with trailing space) and I press Tab key, I have the suggestion of the 2 player names.

I deduced that the onTabComplete() don't care about the trailing space of the command string (example : "/send marcbal ") and probably a problem when splitting (removing last trailing empty args), so, the onTabComplete method try to complete the first argument "marcbal" instead of the second empty argument.

To split the command line, you use the method Pattern.split(CharSequence) that remove trailing empty strings http://docs.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html#split(java.lang.CharSequence)
So, we should use the other split() method, with a second argument which has to be a negative integer value. (see Javadoc)

PS : Sorry for my bad English x)