### PR TITLE
Add <server> in the usage of /send

### DIFF
--- a/module/cmd-send/src/main/java/net/md_5/bungee/module/cmd/send/CommandSend.java
+++ b/module/cmd-send/src/main/java/net/md_5/bungee/module/cmd/send/CommandSend.java
@@ -26,7 +26,7 @@ public class CommandSend extends Command implements TabExecutor
     {
         if ( args.length != 2 )
         {
-            sender.sendMessage( ChatColor.RED + "Not enough arguments, usage: /send <player|all|current> <target>" );
+            sender.sendMessage( ChatColor.RED + "Not enough arguments, usage: /send <player|server|all|current> <target>" );
             return;
         }
         ServerInfo target = ProxyServer.getInstance().getServerInfo( args[1] );

--- a/module/cmd-send/src/main/java/net/md_5/bungee/module/cmd/send/CommandSend.java
+++ b/module/cmd-send/src/main/java/net/md_5/bungee/module/cmd/send/CommandSend.java
@@ -26,7 +26,7 @@ public class CommandSend extends Command implements TabExecutor
     {
         if ( args.length != 2 )
         {
-            sender.sendMessage( ChatColor.RED + "Not enough arguments, usage: /send <player|server|all|current> <target>" );
+            sender.sendMessage( ChatColor.RED + "Not enough arguments, usage: /send <server|player|all|current> <target>" );
             return;
         }
         ServerInfo target = ProxyServer.getInstance().getServerInfo( args[1] );


### PR DESCRIPTION
Just a small cosmetic fix that shows server owners that this argument exists.