### PR TITLE
Clear the address cache entry when a connection fails

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/http/HttpClient.java
+++ b/proxy/src/main/java/net/md_5/bungee/http/HttpClient.java
@@ -86,6 +86,7 @@ public class HttpClient
                     future.channel().writeAndFlush( request );
                 } else
                 {
+                    addressCache.invalidate( uri.getHost() );
                     callback.done( null, future.cause() );
                 }
             }


### PR DESCRIPTION
Should help solve the issues caused by mojang swapping the ip address of
the session server.