### PR TITLE
Add support for FML with IP Forwarding enabled

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
+++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
@@ -90,12 +90,23 @@ public class ServerConnector extends PacketHandler
             {
                 newHost += "\00" + BungeeCord.getInstance().gson.toJson( profile.getProperties() );
             }
+
+            // In order to be able to support Forge servers that use IP forwarding, we change the original host string from:
+            //     <host><extradata>
+            // to
+            //     <host><BungeeData>\00|<extradata>
+            // Implementations can then simply split on the string "\00|" and take the first chunk of the string and
+            // do their normal processing, and may ignore the extra data if they so wish.
+            if ( !user.getExtraDataInHandshake().isEmpty() ) 
+            {
+                newHost += "\00|" + user.getExtraDataInHandshake();
+            }
+
             copiedHandshake.setHost( newHost );
         }
         else if ( !user.getExtraDataInHandshake().isEmpty() )
         {
-            // Only restore the extra data if IP forwarding is off. 
-            // TODO: Add support for this data with IP forwarding.
+            // Restore the extra data
             copiedHandshake.setHost( copiedHandshake.getHost() + user.getExtraDataInHandshake() );
         }
 


### PR DESCRIPTION
FML adds a \00FML\00 marker to the host field, so Forge can determine whether or not to start a Forge handshake, making way to allow vanilla clients to connect to Forge servers that don't need a client modification. However, Bungee also uses the field, and the two implementations collide when using Spigot.

The original fix was to not send the FML information at the same time as the IP forwarding, you could have one or the other, but not both. This was OK, as no FML servers supported IP forwarding as of time of the patch. This was implemented in commit 4809f1f80ace9ae87b91453c8887c70f5e098bd0.

However, there is now at least one Forge coremod that intends to support IP forwarding. To be able to support Forge with IP forwarding, a way to be able to support the FML token (and any other host data) is needed. This patch adds the extra data onto the end of the IP Forwarding host field, separating the IP forwarding data from the other data using the character combination of "\00|" - the pipe being chosen as it will not appear at the beginning of any IP forwarding field and so will leave the IP forwarding fields intact.

The host packet thus becomes "[host]\0[IP]\0[UUID]\0[JSON encoded GameProfile]\0|[Extra Data]".

**Implementations MUST be aware of this as this is potentially a breaking change for FML clients that wish to connect - and should split on this marker (but only the first time it's seen) before doing IP forwarding processing.** 

This will break FML clients connecting to Spigot without a patch (again), however, the patch is trivial and I have PRd the required change into the Spigot codebase, see https://hub.spigotmc.org/stash/projects/SPIGOT/repos/spigot/pull-requests/43/overview. 

A working version for Sponge has also been written - see https://github.com/SpongePowered/SpongeCommon/blob/738c5125280198783d89b111a6410f488e3fcfdc/src/main/java/org/spongepowered/common/mixin/bungee/network/MixinNetHandlerHandshakeTCP.java#L52
