### PR TITLE
Placing the PlayerJoinEvent in front of the Upstream Bridge handling …

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -485,10 +485,8 @@ public class InitialHandler extends PacketHandler implements PendingConnection
                             UserConnection userCon = new UserConnection( bungee, ch, getName(), InitialHandler.this );
                             userCon.init();
 
-                            bungee.getPluginManager().callEvent( new PostLoginEvent( userCon ) );
-
                             ch.getHandle().pipeline().get( HandlerBoss.class ).setHandler( new UpstreamBridge( bungee, userCon ) );
-
+                            bungee.getPluginManager().callEvent( new PostLoginEvent( userCon ) );
                             ServerInfo server;
                             if ( bungee.getReconnectHandler() != null )
                             {


### PR DESCRIPTION
…prevents us from actually accessing the target server in PostJoinEvent handlers

This is a minimal fix that allows teleporting of the player to his last location to his last used server when connecting to the bungee network.

We could not witness any regression in our system after using this patch.