### PR TITLE
chat: Correct placeholder handling in translatable

### DIFF
--- a/chat/src/main/java/net/md_5/bungee/api/chat/TranslatableComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/TranslatableComponent.java
@@ -130,41 +130,42 @@ public class TranslatableComponent extends BaseComponent
     @Override
     protected void toPlainText(StringBuilder builder)
     {
+        String trans;
         try
         {
-            String trans = locales.getString( translate );
-            Matcher matcher = format.matcher( trans );
-            int position = 0;
-            int i = 0;
-            while ( matcher.find( position ) )
-            {
-                int pos = matcher.start();
-                if ( pos != position )
-                {
-                    builder.append( trans.substring( position, pos ) );
-                }
-                position = matcher.end();
+            trans = locales.getString( translate );
+        } catch ( MissingResourceException e ) {
+            trans = translate;
+        }
 
-                String formatCode = matcher.group( 2 );
-                switch ( formatCode.charAt( 0 ) )
-                {
-                    case 's':
-                    case 'd':
-                        String withIndex = matcher.group( 1 );
-                        with.get( withIndex != null ? Integer.parseInt( withIndex ) - 1 : i++ ).toPlainText( builder );
-                        break;
-                    case '%':
-                        builder.append( '%' );
-                        break;
-                }
-            }
-            if ( trans.length() != position )
-            {
-                builder.append( trans.substring( position, trans.length() ) );
-            }
-        } catch ( MissingResourceException e )
+        Matcher matcher = format.matcher( trans );
+        int position = 0;
+        int i = 0;
+        while ( matcher.find( position ) )
         {
-            builder.append( translate );
+            int pos = matcher.start();
+            if ( pos != position )
+            {
+                builder.append( trans.substring( position, pos ) );
+            }
+            position = matcher.end();
+
+            String formatCode = matcher.group( 2 );
+            switch ( formatCode.charAt( 0 ) )
+            {
+                case 's':
+                case 'd':
+                    String withIndex = matcher.group( 1 );
+                    with.get( withIndex != null ? Integer.parseInt( withIndex ) - 1 : i++ ).toPlainText( builder );
+                    break;
+                case '%':
+                    builder.append( '%' );
+                    break;
+            }
+        }
+        if ( trans.length() != position )
+        {
+            builder.append( trans.substring( position, trans.length() ) );
         }
 
         super.toPlainText( builder );
@@ -173,45 +174,45 @@ public class TranslatableComponent extends BaseComponent
     @Override
     protected void toLegacyText(StringBuilder builder)
     {
+        String trans;
         try
         {
-            String trans = locales.getString( translate );
-            Matcher matcher = format.matcher( trans );
-            int position = 0;
-            int i = 0;
-            while ( matcher.find( position ) )
-            {
-                int pos = matcher.start();
-                if ( pos != position )
-                {
-                    addFormat( builder );
-                    builder.append( trans.substring( position, pos ) );
-                }
-                position = matcher.end();
+            trans = locales.getString( translate );
+        } catch ( MissingResourceException e ) {
+            trans = translate;
+        }
 
-                String formatCode = matcher.group( 2 );
-                switch ( formatCode.charAt( 0 ) )
-                {
-                    case 's':
-                    case 'd':
-                        String withIndex = matcher.group( 1 );
-                        with.get( withIndex != null ? Integer.parseInt( withIndex ) - 1 : i++ ).toLegacyText( builder );
-                        break;
-                    case '%':
-                        addFormat( builder );
-                        builder.append( '%' );
-                        break;
-                }
-            }
-            if ( trans.length() != position )
+        Matcher matcher = format.matcher( trans );
+        int position = 0;
+        int i = 0;
+        while ( matcher.find( position ) )
+        {
+            int pos = matcher.start();
+            if ( pos != position )
             {
                 addFormat( builder );
-                builder.append( trans.substring( position, trans.length() ) );
+                builder.append( trans.substring( position, pos ) );
             }
-        } catch ( MissingResourceException e )
+            position = matcher.end();
+
+            String formatCode = matcher.group( 2 );
+            switch ( formatCode.charAt( 0 ) )
+            {
+                case 's':
+                case 'd':
+                    String withIndex = matcher.group( 1 );
+                    with.get( withIndex != null ? Integer.parseInt( withIndex ) - 1 : i++ ).toLegacyText( builder );
+                    break;
+                case '%':
+                    addFormat( builder );
+                    builder.append( '%' );
+                    break;
+            }
+        }
+        if ( trans.length() != position )
         {
             addFormat( builder );
-            builder.append( translate );
+            builder.append( trans.substring( position, trans.length() ) );
         }
         super.toLegacyText( builder );
     }

--- a/chat/src/test/java/net/md_5/bungee/api/chat/TranslatableComponentTest.java
+++ b/chat/src/test/java/net/md_5/bungee/api/chat/TranslatableComponentTest.java
@@ -1,0 +1,16 @@
+package net.md_5.bungee.api.chat;
+
+import net.md_5.bungee.api.chat.TranslatableComponent;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class TranslatableComponentTest {
+    @Test
+    public void testMissingPlaceholdersAdded()
+    {
+        TranslatableComponent testComponent = new TranslatableComponent( "Test string with %s placeholders: %s", "2", "aoeu" );
+        assertEquals( "Test string with 2 placeholders: aoeu", testComponent.toPlainText() );
+        assertEquals( "§fTest string with §f2§f placeholders: §faoeu", testComponent.toLegacyText() );
+    }
+}


### PR DESCRIPTION
This change makes TranslatableComponent still scan a
translation string for placeholders, even if the translation string
itself is being used (rather than a value found from the
ResourceBundle). This matches vanilla behavior and allows plugins that
use this system with serverside translations and other custom
translation systems to send output to the server console correctly.

PermissionsEx 2 builds were pretty much unusable on the console 
before this change, since we use a gettext-based translation system 
with formatted text output pretty extensively.