### PR TITLE
Massive EventBus speed-up.

### DIFF
--- a/event/src/main/java/net/md_5/bungee/event/EventBus.java
+++ b/event/src/main/java/net/md_5/bungee/event/EventBus.java
@@ -9,8 +9,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -18,8 +19,8 @@ public class EventBus
 {
 
     private final Map<Class<?>, Map<Byte, Map<Object, Method[]>>> byListenerAndPriority = new HashMap<>();
-    private final Map<Class<?>, EventHandlerMethod[]> byEventBaked = new HashMap<>();
-    private final ReadWriteLock lock = new ReentrantReadWriteLock();
+    private final Map<Class<?>, EventHandlerMethod[]> byEventBaked = new ConcurrentHashMap<>( 16, 0.75f, 1 );
+    private final Lock lock = new ReentrantLock();
     private final Logger logger;
 
     public EventBus()
@@ -34,15 +35,7 @@ public class EventBus
 
     public void post(Object event)
     {
-        EventHandlerMethod[] handlers;
-        lock.readLock().lock();
-        try
-        {
-            handlers = byEventBaked.get( event.getClass() );
-        } finally
-        {
-            lock.readLock().unlock();
-        }
+        EventHandlerMethod[] handlers = byEventBaked.get( event.getClass() );
 
         if ( handlers != null )
         {
@@ -77,9 +70,9 @@ public class EventBus
                 if ( params.length != 1 )
                 {
                     logger.log( Level.INFO, "Method {0} in class {1} annotated with {2} does not have single argument", new Object[]
-                    {
-                        m, listener.getClass(), annotation
-                    } );
+                            {
+                                    m, listener.getClass(), annotation
+                            } );
                     continue;
                 }
                 Map<Byte, Set<Method>> prioritiesMap = handler.get( params[0] );
@@ -103,7 +96,7 @@ public class EventBus
     public void register(Object listener)
     {
         Map<Class<?>, Map<Byte, Set<Method>>> handler = findHandlers( listener );
-        lock.writeLock().lock();
+        lock.lock();
         try
         {
             for ( Map.Entry<Class<?>, Map<Byte, Set<Method>>> e : handler.entrySet() )
@@ -129,14 +122,14 @@ public class EventBus
             }
         } finally
         {
-            lock.writeLock().unlock();
+            lock.unlock();
         }
     }
 
     public void unregister(Object listener)
     {
         Map<Class<?>, Map<Byte, Set<Method>>> handler = findHandlers( listener );
-        lock.writeLock().lock();
+        lock.lock();
         try
         {
             for ( Map.Entry<Class<?>, Map<Byte, Set<Method>>> e : handler.entrySet() )
@@ -165,7 +158,7 @@ public class EventBus
             }
         } finally
         {
-            lock.writeLock().unlock();
+            lock.unlock();
         }
     }
 
@@ -202,7 +195,7 @@ public class EventBus
             byEventBaked.put( eventClass, handlersList.toArray( new EventHandlerMethod[ handlersList.size() ] ) );
         } else
         {
-            byEventBaked.put( eventClass, null );
+            byEventBaked.remove( eventClass );
         }
     }
 }


### PR DESCRIPTION
This is primarily done by using ConcurrentHashMap, which has lock-free reads and thread-contention-based writes. However, only one thread at a time can register handlers, as baking events isn't thread safe (and there's no reason to make it thread-safe anyway).

At first I tried implementing a COW version (like #1495) but found that the gain was largely negated with a large number of event listeners and with average execution times increasing exponentially.

Of course, we need some benchmarks, so here's a run with 4 concurrent threads posting events (JVM is Oracle 1.8.0_60 x64 on Linux, thread count should be representative of most BungeeCord servers):
```
Benchmark                             (registeredHandlers)   Mode  Samples        Score  Score error   Units
i.m.m.MyBenchmark.newEventBusThrpt                       1  thrpt       15  1880483.356    39847.542  ops/ms
i.m.m.MyBenchmark.newEventBusThrpt                       2  thrpt       15  1899544.702    14122.657  ops/ms
i.m.m.MyBenchmark.newEventBusThrpt                       4  thrpt       15  1950326.631    17618.759  ops/ms
i.m.m.MyBenchmark.newEventBusThrpt                       8  thrpt       15  1954169.049     9183.920  ops/ms
i.m.m.MyBenchmark.newEventBusThrpt                      16  thrpt       15  1939123.333    59729.868  ops/ms
i.m.m.MyBenchmark.oldEventBusThrpt                       1  thrpt       15     5874.098      228.146  ops/ms
i.m.m.MyBenchmark.oldEventBusThrpt                       2  thrpt       15     6005.608      186.881  ops/ms
i.m.m.MyBenchmark.oldEventBusThrpt                       4  thrpt       15     5988.826      233.528  ops/ms
i.m.m.MyBenchmark.oldEventBusThrpt                       8  thrpt       15     6046.589      179.110  ops/ms
i.m.m.MyBenchmark.oldEventBusThrpt                      16  thrpt       15     6049.030      219.490  ops/ms
i.m.m.MyBenchmark.newEventBusAvgt                        1   avgt       15        2.077        0.067   ns/op
i.m.m.MyBenchmark.newEventBusAvgt                        2   avgt       15        2.065        0.036   ns/op
i.m.m.MyBenchmark.newEventBusAvgt                        4   avgt       15        2.046        0.010   ns/op
i.m.m.MyBenchmark.newEventBusAvgt                        8   avgt       15        2.059        0.024   ns/op
i.m.m.MyBenchmark.newEventBusAvgt                       16   avgt       15        2.049        0.007   ns/op
i.m.m.MyBenchmark.oldEventBusAvgt                        1   avgt       15      662.002       12.187   ns/op
i.m.m.MyBenchmark.oldEventBusAvgt                        2   avgt       15      680.389       40.732   ns/op
i.m.m.MyBenchmark.oldEventBusAvgt                        4   avgt       15      635.017       25.201   ns/op
i.m.m.MyBenchmark.oldEventBusAvgt                        8   avgt       15      653.627       44.405   ns/op
i.m.m.MyBenchmark.oldEventBusAvgt                       16   avgt       15      632.241       63.072   ns/op
```

I will provide benchmark results for one thread posting events soon.

I am actually quite skeptical if this will work as intended (and indeed, I was skeptical that it was doing _anything_!) The unit tests do pass, however. I invite all interested parties to try it out and see if things work as intended.

_pinging @ninja- as he is interested in BungeeCord performance_