### PR TITLE
Fix pinging whilst netty event loops are shutting down

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/BungeeServerInfo.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeServerInfo.java
@@ -140,13 +140,16 @@ public class BungeeServerInfo implements ServerInfo
                 }
             }
         };
-        new Bootstrap()
-                .channel( PipelineUtils.getChannel() )
-                .group( BungeeCord.getInstance().eventLoops )
-                .handler( PipelineUtils.BASE )
-                .option( ChannelOption.CONNECT_TIMEOUT_MILLIS, 5000 ) // TODO: Configurable
-                .remoteAddress( getAddress() )
-                .connect()
-                .addListener( listener );
+        if ( !BungeeCord.getInstance().eventLoops.isShuttingDown() )
+        {
+            new Bootstrap()
+                    .channel( PipelineUtils.getChannel() )
+                    .group( BungeeCord.getInstance().eventLoops )
+                    .handler( PipelineUtils.BASE )
+                    .option( ChannelOption.CONNECT_TIMEOUT_MILLIS, 5000 ) // TODO: Configurable
+                    .remoteAddress( getAddress() )
+                    .connect()
+                    .addListener( listener );
+        }
     }
 }


### PR DESCRIPTION
After BungeeCord#stop() calls eventLoops#shutdownGracefully(), when a ping is attempted before completed, an exception will be thrown.

The following checks if the loop has been shutdown gracefully:
http://netty.io/4.0/api/io/netty/util/concurrent/EventExecutorGroup.html#isShuttingDown(),
and if it has, doesn't allow the connection and suppresses the error.

This has fixed issue #1403 for me