### PR TITLE
Allow configuration of the log file path/filename

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/log/BungeeLogger.java
+++ b/proxy/src/main/java/net/md_5/bungee/log/BungeeLogger.java
@@ -27,7 +27,7 @@ public class BungeeLogger extends Logger
 
         try
         {
-            FileHandler fileHandler = new FileHandler( "proxy.log", 1 << 24, 8, true );
+            FileHandler fileHandler = new FileHandler( System.getProperty("bungee.log-file", "proxy.log"), 1 << 24, 8, true );
             fileHandler.setFormatter( formatter );
             addHandler( fileHandler );
 


### PR DESCRIPTION
Allow server owners to put bungeecord log files in a different location (ie: when running bungee on an SSD, to put logs on non ssd)