### PR TITLE
Add a way to load plugins from the update folder after restarts

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/ProxyServer.java
+++ b/api/src/main/java/net/md_5/bungee/api/ProxyServer.java
@@ -50,6 +50,14 @@ public abstract class ProxyServer
     public abstract String getVersion();
 
     /**
+     * Gets the update folder. The update folder is used to safely update
+     * plugins at the right moment on a plugin load.
+     *
+     * @return the update folder
+     */
+    public abstract File getUpdateFolderFile();
+
+    /**
      * Gets a localized string from the .properties file.
      *
      * @return the localized string

--- a/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
@@ -10,9 +10,6 @@ import java.io.InputStream;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.nio.file.StandardCopyOption;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -27,6 +24,8 @@ import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.logging.Level;
 import java.util.regex.Pattern;
+
+import com.google.common.io.Files;
 import lombok.RequiredArgsConstructor;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.CommandSender;
@@ -331,7 +330,7 @@ public class PluginManager
         {
             try
             {
-                Files.move( Paths.get( updateFile.getAbsolutePath() ), Paths.get( file.getAbsolutePath() ), StandardCopyOption.REPLACE_EXISTING );
+                Files.move( updateFile, file );
             } catch ( IOException ex )
             {
                 ex.printStackTrace();

--- a/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
@@ -5,10 +5,14 @@ import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.eventbus.Subscribe;
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -314,6 +318,27 @@ public class PluginManager
         return status;
     }
 
+    private void checkUpdate( File file )
+    {
+        File updateDirectory = proxy.getUpdateFolderFile();
+        if ( updateDirectory == null || !updateDirectory.isDirectory() )
+        {
+            return;
+        }
+
+        File updateFile = new File( updateDirectory, file.getName() );
+        if ( updateFile.isFile() )
+        {
+            try
+            {
+                Files.move( Paths.get( updateFile.getAbsolutePath() ), Paths.get( file.getAbsolutePath() ), StandardCopyOption.REPLACE_EXISTING );
+            } catch ( IOException ex )
+            {
+                ex.printStackTrace();
+            }
+        }
+    }
+
     /**
      * Load all plugins from the specified folder.
      *
@@ -326,6 +351,8 @@ public class PluginManager
 
         for ( File file : folder.listFiles() )
         {
+            checkUpdate(file);
+
             if ( file.isFile() && file.getName().endsWith( ".jar" ) )
             {
                 try ( JarFile jar = new JarFile( file ) )

--- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
@@ -453,6 +453,12 @@ public class BungeeCord extends ProxyServer
     }
 
     @Override
+    public File getUpdateFolderFile()
+    {
+        return new File(pluginsFolder, config.getPluginUpdateFolderFileName() );
+    }
+
+    @Override
     public String getTranslation(String name, Object... args)
     {
         String translation = "<translation '" + name + "' missing>";

--- a/proxy/src/main/java/net/md_5/bungee/conf/Configuration.java
+++ b/proxy/src/main/java/net/md_5/bungee/conf/Configuration.java
@@ -53,6 +53,7 @@ public class Configuration implements ProxyConfig
     private boolean ipForward;
     private Favicon favicon;
     private int compressionThreshold = 256;
+    private String pluginUpdateFolderFileName = "update";
 
     public void load()
     {
@@ -79,6 +80,7 @@ public class Configuration implements ProxyConfig
         throttle = adapter.getInt( "connection_throttle", throttle );
         ipForward = adapter.getBoolean( "ip_forward", ipForward );
         compressionThreshold = adapter.getInt( "network_compression_threshold", compressionThreshold );
+        pluginUpdateFolderFileName = adapter.getString( "plugin_update_folder", pluginUpdateFolderFileName );
 
         disabledCommands = new CaseInsensitiveSet( (Collection<String>) adapter.getList( "disabled_commands", Arrays.asList( "disabledcommandhere" ) ) );
 


### PR DESCRIPTION
This adds a way for plugins to be updated through a folder defined in configuration safely whilst the proxy is running because hotwiring directly into the plugins folder can cause NoClassDefFoundErrors.

When an update is found, the file is deleted from the update folder and moved into the plugins folder.
