### PR TITLE
Set a more reasonable Recycler Capacity

### DIFF
--- a/bootstrap/src/main/java/net/md_5/bungee/BungeeCordLauncher.java
+++ b/bootstrap/src/main/java/net/md_5/bungee/BungeeCordLauncher.java
@@ -20,6 +20,12 @@ public class BungeeCordLauncher
         Security.setProperty( "networkaddress.cache.ttl", "30" );
         Security.setProperty( "networkaddress.cache.negative.ttl", "10" );
 
+        // TODO: remove .default for netty 5!
+        if ( System.getProperty( "io.netty.recycler.maxCapacity.default" ) == null )
+        {
+            System.setProperty( "io.netty.recycler.maxCapacity.default", "50000" );
+        }
+
         OptionParser parser = new OptionParser();
         parser.allowsUnrecognizedOptions();
         parser.acceptsAll( Arrays.asList( "v", "version" ) );


### PR DESCRIPTION
Default Netty Recycler capacity is 262k~, resulting in major memory consumption over long runtimes that will never free.

Potentially a netty leak, more info here:
https://github.com/netty/netty/issues/3166

after 2 weeks of uptime I started noticing more frequent old gen garbage collections, and realized it was near full and GC's were not bringing it down. Grabbed a heap dump and found the cause.

Class Name                                                                       | Shallow Heap | Retained Heap | Percentage
-----------------------------------------------------------------------------------------------------------------------------
java.lang.Thread @ 0x80086cc0  Netty IO Thread #0 Thread                         |          176 |   122,427,232 |      6.68%
|- java.lang.ThreadLocal$ThreadLocalMap @ 0x80183f18                             |           32 |   122,426,616 |      6.68%
|  '- java.lang.ThreadLocal$ThreadLocalMap$Entry[16] @ 0x80183f30                |          152 |   122,426,584 |      6.68%
|     |- java.lang.ThreadLocal$ThreadLocalMap$Entry @ 0x80183fa0                 |           56 |   122,425,472 |      6.68%
|     |  '- io.netty.util.internal.InternalThreadLocalMap @ 0x80183fc0           |          168 |   122,425,416 |      6.68%
|     |     |- java.lang.Object[32] @ 0x80184040                                 |          280 |   122,419,288 |      6.68%
|     |     |  |- io.netty.util.Recycler$Stack @ 0x801841b0                      |           72 |    67,831,360 |      3.70%
|     |     |  |  '- io.netty.util.Recycler$DefaultHandle[262144] @ 0xaaa9c2e0   |    2,097,176 |    67,831,288 |      3.70%
|     |     |  |     |- io.netty.buffer.PoolChunk @ 0xa944d278                   |          120 |       385,216 |      0.02%
|     |     |  |     |- io.netty.buffer.PoolChunk @ 0xa95281e0                   |          120 |       385,216 |      0.02%
|     |     |  |     |- io.netty.util.Recycler$DefaultHandle @ 0xa79c0ed8        |           40 |           248 |      0.00%
|     |     |  |     |  '- io.netty.buffer.PooledUnsafeDirectByteBuf @ 0xa79c0ef8|          128 |           208 |      0.00%
|     |     |  |     |- io.netty.util.Recycler$DefaultHandle @ 0xa79c0f50        |           40 |           248 |      0.00%
|     |     |  |     |  '- io.netty.buffer.PooledUnsafeDirectByteBuf @ 0xa79c0f70|          128 |           208 |      0.00%
|     |     |  |     |- io.netty.util.Recycler$DefaultHandle @ 0xa79c0fc8        |           40 |           248 |      0.00%
|     |     |  |     |- io.netty.util.Recycler$DefaultHandle @ 0xa79c1040        |           40 |           248 |      0.00%
|     |     |  |     |- io.netty.util.Recycler$DefaultHandle @ 0xa79c10b8        |           40 |           248 |      0.00%
|     |     |  |     |- io.netty.util.Recycler$DefaultHandle @ 0xa79c1130        |           40 |           248 |      0.00%
|     |     |  |     |- io.netty.util.Recycler$DefaultHandle @ 0xa79c11a8        |           40 |           248 |      0.00%
|     |     |  |     |- io.netty.util.Recycler$DefaultHandle @ 0xa79c1220        |           40 |           248 |      0.00%
|     |     |  |     |  '- io.netty.buffer.PooledUnsafeDirectByteBuf @ 0xa79c1240|          128 |           208 |      0.00%
|     |     |  |     |- io.netty.util.Recycler$DefaultHandle @ 0xa79c1298        |           40 |           248 |      0.00%
|     |     |  |     |- io.netty.util.Recycler$DefaultHandle @ 0xa79c1310        |           40 |           248 |      0.00%
|     |     |  |     |- io.netty.util.Recycler$DefaultHandle @ 0xa79c1388        |           40 |           248 |      0.00%
|     |     |  |     |  '- io.netty.buffer.PooledUnsafeDirectByteBuf @ 0xa79c13a8|          128 |           208 |      0.00%
|     |     |  |     |- io.netty.util.Recycler$DefaultHandle @ 0xa79c1400        |           40 |           248 |      0.00%
|     |     |  |     |- io.netty.util.Recycler$DefaultHandle @ 0xa79c1478        |           40 |           248 |      0.00%
|     |     |  |     |- io.netty.util.Recycler$DefaultHandle @ 0xa79c14f0        |           40 |           248 |      0.00%
|     |     |  |     |- io.netty.util.Recycler$DefaultHandle @ 0xa79c1568        |           40 |           248 |      0.00%
|     |     |  |     |- io.netty.util.Recycler$DefaultHandle @ 0xa79c15e0        |           40 |           248 |      0.00%
|     |     |  |     |  '- io.netty.buffer.PooledUnsafeDirectByteBuf @ 0xa79c1600|          128 |           208 |      0.00%
|     |     |  |     |- io.netty.util.Recycler$DefaultHandle @ 0xa79c1658        |           40 |           248 |      0.00%
|     |     |  |     |- io.netty.util.Recycler$DefaultHandle @ 0xa79c16d0        |           40 |           248 |      0.00%
|     |     |  |     |- io.netty.util.Recycler$DefaultHandle @ 0xa79c1748        |           40 |           248 |      0.00%
|     |     |  |     |  '- io.netty.buffer.PooledUnsafeDirectByteBuf @ 0xa79c1768|          128 |           208 |      0.00%
|     |     |  |     |- io.netty.util.Recycler$DefaultHandle @ 0xa79c17c0        |           40 |           248 |      0.00%
|     |     |  |     |  '- io.netty.buffer.PooledUnsafeDirectByteBuf @ 0xa79c17e0|          128 |           208 |      0.00%
|     |     |  |     |- io.netty.util.Recycler$DefaultHandle @ 0xa79c1838        |           40 |           248 |      0.00%
|     |     |  |     |- io.netty.util.Recycler$DefaultHandle @ 0xa79c18b0        |           40 |           248 |      0.00%
|     |     |  |     |- io.netty.util.Recycler$DefaultHandle @ 0xa79c1928        |           40 |           248 |      0.00%
|     |     |  |     '- Total: 25 of 262,146 entries                             |              |               |           
-----------------------------------------------------------------------------------------------------------------------------
