### PR TITLE
Log proxy commands

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/ProxyConfig.java
+++ b/api/src/main/java/net/md_5/bungee/api/ProxyConfig.java
@@ -41,6 +41,11 @@ public interface ProxyConfig
     boolean isOnlineMode();
 
     /**
+     * Whether proxy commands are logged to the proxy log
+     */
+    boolean isLogCommands();
+
+    /**
      * Returns the player max.
      */
     int getPlayerLimit();

--- a/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
@@ -159,6 +159,10 @@ public class PluginManager
         {
             if ( tabResults == null )
             {
+                proxy.getLogger().log( Level.INFO, "{0} executed proxy command: /{1}", new Object[]
+                        {
+                                sender.getName(), commandLine
+                        } );
                 command.execute( sender, args );
             } else if ( commandLine.contains( " " ) && command instanceof TabExecutor )
             {

--- a/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
@@ -159,10 +159,12 @@ public class PluginManager
         {
             if ( tabResults == null )
             {
-                proxy.getLogger().log( Level.INFO, "{0} executed proxy command: /{1}", new Object[]
-                        {
-                                sender.getName(), commandLine
-                        } );
+                if ( proxy.getConfig().isLogCommands() ) {
+                    proxy.getLogger().log( Level.INFO, "{0} executed proxy command: /{1}", new Object[]
+                            {
+                                    sender.getName(), commandLine
+                            } );
+                }
                 command.execute( sender, args );
             } else if ( commandLine.contains( " " ) && command instanceof TabExecutor )
             {

--- a/proxy/src/main/java/net/md_5/bungee/conf/Configuration.java
+++ b/proxy/src/main/java/net/md_5/bungee/conf/Configuration.java
@@ -47,6 +47,10 @@ public class Configuration implements ProxyConfig
      * Should we check minecraft.net auth.
      */
     private boolean onlineMode = true;
+    /**
+     * Whether we log proxy commands to the proxy log
+     */
+    private boolean logCommands = false;
     private int playerLimit = -1;
     private Collection<String> disabledCommands;
     private int throttle = 4000;
@@ -75,6 +79,7 @@ public class Configuration implements ProxyConfig
         timeout = adapter.getInt( "timeout", timeout );
         uuid = adapter.getString( "stats", uuid );
         onlineMode = adapter.getBoolean( "online_mode", onlineMode );
+        logCommands = adapter.getBoolean( "log_commands", logCommands );
         playerLimit = adapter.getInt( "player_limit", playerLimit );
         throttle = adapter.getInt( "connection_throttle", throttle );
         ipForward = adapter.getBoolean( "ip_forward", ipForward );


### PR DESCRIPTION
**The issue**
Currently, BungeeCord does not log proxy commands. For several reasons, it might be useful to log them, especially if your staff are people that like to poke fun at others and do unreasonable stuff, you, as a server owner, might want to know exactly what they did, so that you can undo it. Additionally, as a developer, knowing what commands were executed exactly, so that you can better improve your code and know error conditions. 

~~The only possible argument against this change I can currently imagine is that some people might argue that this could add additional noise to their logs. While this is true, I think that the impact is lower than, for example, ping connection spam by InitialHandler. For those log messages, the solution presented by the development team is to create a custom log filter. This solution can also be applied to this message, should it be an issue.~~

Of course, this behaviour can be configured. By default, it is turned off to mimic current behaviour, even though some people could find it more intuitive to log commands per default. (this mostly applies to those who don't check the config before putting their proxy into Production)

**The solution:**
This commit solves aforementioned problem by introducing a simple log message in the form of:

````
Literallie executed proxy command: /alert good thing this is not logged lol
````

No message is printed for commands that are not handled by the proxy, such as backend commands, which are logged by the backend anyways.

I have tested this PR on the current master branch and it works just as intended on my test server. It correctly handles player commands, console commands and unhandled commands.

Thanks!
