### PR TITLE
DNS IPs should only be cached for 1 minute.

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/http/HttpClient.java
+++ b/proxy/src/main/java/net/md_5/bungee/http/HttpClient.java
@@ -27,7 +27,7 @@ public class HttpClient
 {
 
     public static final int TIMEOUT = 5000;
-    private static final Cache<String, InetAddress> addressCache = CacheBuilder.newBuilder().expireAfterWrite( 5, TimeUnit.MINUTES ).build();
+    private static final Cache<String, InetAddress> addressCache = CacheBuilder.newBuilder().expireAfterWrite( 1, TimeUnit.MINUTES ).build();
 
     @SuppressWarnings("UnusedAssignment")
     public static void get(String url, EventLoop eventLoop, final Callback<String> callback)


### PR DESCRIPTION
The Mojang session servers are set to a TTL of 60 seconds, as shown by the following DNS query. The trace flag forces a fresh DNS entry, causing the TTL to be the true TTL for the entry.

     joe@ibj  ~  dig +nocmd +noall +answer +ttlid +trace sessionserver.mojang.com
    .                       189252  IN      NS      l.root-servers.net.
    .                       189252  IN      NS      a.root-servers.net.
    .                       189252  IN      NS      h.root-servers.net.
    .                       189252  IN      NS      j.root-servers.net.
    .                       189252  IN      NS      d.root-servers.net.
    .                       189252  IN      NS      c.root-servers.net.
    .                       189252  IN      NS      f.root-servers.net.
    .                       189252  IN      NS      b.root-servers.net.
    .                       189252  IN      NS      k.root-servers.net.
    .                       189252  IN      NS      i.root-servers.net.
    .                       189252  IN      NS      m.root-servers.net.
    .                       189252  IN      NS      e.root-servers.net.
    .                       189252  IN      NS      g.root-servers.net.
    .                       383055  IN      RRSIG   NS 8 0 518400 20151114170000     201                                                                                                                                                             51104160000 62530 .     GLPSuqfvAQLVIDdfNaQCtr9rtpPFCN5TbY3PrGn49j4NNHOrVmuOjmBy     +EA                                                                                                                                                             WTJlpP171n4qNWnj/jI6mqqmwXyFY2S/itXR8GuAz9hqnoGxaV+Yx     Hy0caYUuRXT92QtQMzqAvZq7S0                                                                                                                                                             ii1jwIHWBhJ2E84g1hBA+Oeo6AzFz/     Ujs=
    ;; Received 913 bytes from 213.186.33.99#53(213.186.33.99) in 633 ms
    
    com.                    172800  IN      NS      b.gtld-servers.net.
    com.                    172800  IN      NS      i.gtld-servers.net.
    com.                    172800  IN      NS      k.gtld-servers.net.
    com.                    172800  IN      NS      m.gtld-servers.net.
    com.                    172800  IN      NS      f.gtld-servers.net.
    com.                    172800  IN      NS      a.gtld-servers.net.
    com.                    172800  IN      NS      d.gtld-servers.net.
    com.                    172800  IN      NS      c.gtld-servers.net.
    com.                    172800  IN      NS      j.gtld-servers.net.
    com.                    172800  IN      NS      g.gtld-servers.net.
    com.                    172800  IN      NS      h.gtld-servers.net.
    com.                    172800  IN      NS      e.gtld-servers.net.
    com.                    172800  IN      NS      l.gtld-servers.net.
    com.                    86400   IN      DS      30909 8 2     E2D3C916F6DEEAC73294E8                                                                                                                                                             268FB5885044A833FC5459588F4A9184CF     C41A5766
    com.                    86400   IN      RRSIG   DS 8 1 86400 20151116170000     2015                                                                                                                                                             1106160000 62530 . ij2Epw/    Fhs5l/1Y07lkM1SosuNqhIeza8iMkWacye/ORRM2W5BooPPxy kKZy                                                                                                                                                                 idsLk4ajrEfjpLvJT+T2VFverC+Fpe9WSe7pTETo/Fm8w9ZSViBy     1h2NghlQIn0sT1v9KQg7VlWA7Ff                                                                                                                                                             YxC7tom9aInsS+W5AsxumGZ/ly4YO     67o=
    ;; Received 748 bytes from 192.36.148.17#53(i.root-servers.net) in 1687 ms
    
    mojang.com.             172800  IN      NS      ns-625.awsdns-14.net.
    mojang.com.             172800  IN      NS      ns-434.awsdns-54.com.
    mojang.com.             172800  IN      NS      ns-1789.awsdns-31.co.uk.
    mojang.com.             172800  IN      NS      ns-1297.awsdns-34.org.
    CK0POJMG874LJREF7EFN8430QVIT8BSM.com. 86400 IN NSEC3 1 1 0 -     CK0Q1GIN43N1ARRC9OS                                                                                                                                                             M6QPQR81H5M9A NS SOA RRSIG DNSKEY     NSEC3PARAM
    CK0POJMG874LJREF7EFN8430QVIT8BSM.com. 86400 IN RRSIG NSEC3 8 2 86400     20151111131                                                                                                                                                             845 20151104120845 51797 com.     VfIq9YEI0NKmewSnnJ1xF6Z6bbgXtjT7dKoARtsVEcplqbXatJ                                                                                                                                                             XjYWFY     3pDiv/FcLT7hMtlsRNJA9PgD8EsIOe4BYv5TIBVVJUIA1Wn/EjCXpaGP     kWfbBmS2CBKgluMt                                                                                                                                                             eFQe4MYHZMMKhuCMwfVJLGApWMhOF4mcorQGwcsr     EXE=
    ESDEH5O4OB3I8199NU3O90NVD6AF5PS9.com. 86400 IN NSEC3 1 1 0 -     ESDICVFVUK6E8IUNGEJ                                                                                                                                                             76LC6JMTH5I0U NS DS RRSIG
    ESDEH5O4OB3I8199NU3O90NVD6AF5PS9.com. 86400 IN RRSIG NSEC3 8 2 86400     20151113054                                                                                                                                                             344 20151106043344 51797 com. K5dGVi8vuvxJS/    ZyXKCfUokepfbPgUQUq8ZY4nOShe1eFs5uaY                                                                                                                                                             us25dV vB0PAg/    P5KIm2WWem+V40ssAXRDN93shp1lrJglIGpen8GOM6TLKD15f     1s5Ua49d+o5nVwR+                                                                                                                                                             qGyevlPkY1ovpfPcBZaLnkJLE/jEU0T68L/Dc8lY     qCo=
    ;; Received 707 bytes from 192.55.83.30#53(m.gtld-servers.net) in 1235 ms
    
    sessionserver.mojang.com. 60    IN      A       50.19.241.171
    sessionserver.mojang.com. 60    IN      A       54.243.177.191
    mojang.com.             172800  IN      NS      ns-1297.awsdns-34.org.
    mojang.com.             172800  IN      NS      ns-1789.awsdns-31.co.uk.
    mojang.com.             172800  IN      NS      ns-434.awsdns-54.com.
    mojang.com.             172800  IN      NS      ns-625.awsdns-14.net.
    ;; Received 222 bytes from 205.251.198.253#53(ns-1789.awsdns-31.co.uk) in 161 ms

This commit message changes the internal HttpClient IP cache from 5 minutes (which would cause 4 minutes of a bad IP in the case of a total DNS flop) to 1 minute (respecting Mojang's TTL)