### PR TITLE
Fix Team Packet

### DIFF
--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/Team.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/Team.java
@@ -51,7 +51,10 @@ public class Team extends DefinedPacket
             suffix = readString( buf );
             friendlyFire = buf.readByte();
             nameTagVisibility = readString( buf );
-            collisionRule = readString( buf );
+            if ( protocolVersion >= ProtocolConstants.MINECRAFT_SNAPSHOT )
+            {
+                collisionRule = readString(buf);
+            }
             color = buf.readByte();
         }
         if ( mode == 0 || mode == 3 || mode == 4 )
@@ -77,7 +80,10 @@ public class Team extends DefinedPacket
             writeString( suffix, buf );
             buf.writeByte( friendlyFire );
             writeString( nameTagVisibility, buf );
-            writeString( collisionRule, buf);
+            if ( protocolVersion >= ProtocolConstants.MINECRAFT_SNAPSHOT )
+            {
+                writeString( collisionRule, buf);
+            }
             buf.writeByte( color );
         }
         if ( mode == 0 || mode == 3 || mode == 4 )


### PR DESCRIPTION
```
io.netty.handler.codec.DecoderException: java.lang.IndexOutOfBoundsException: readerIndex(24) + length(127) exceeds writerIndex(24): PooledUnsafeDirectByteBuf(ridx: 24, widx: 24, cap: 24)
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:99)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:308)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:294)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:244)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:308)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:294)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:244)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:308)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:294)
	at io.netty.handler.timeout.ReadTimeoutHandler.channelRead(ReadTimeoutHandler.java:152)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:308)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:294)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:846)
	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:131)
	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:511)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:468)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:382)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:354)
	at io.netty.util.concurrent.SingleThreadEventExecutor$2.run(SingleThreadEventExecutor.java:112)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.IndexOutOfBoundsException: readerIndex(24) + length(127) exceeds writerIndex(24): PooledUnsafeDirectByteBuf(ridx: 24, widx: 24, cap: 24)
	at io.netty.buffer.AbstractByteBuf.checkReadableBytes(AbstractByteBuf.java:1166)
	at io.netty.buffer.AbstractByteBuf.readBytes(AbstractByteBuf.java:676)
	at io.netty.buffer.AbstractByteBuf.readBytes(AbstractByteBuf.java:684)
	at net.md_5.bungee.protocol.DefinedPacket.readString(DefinedPacket.java:31)
	at net.md_5.bungee.protocol.packet.Team.read(Team.java:54)
	at net.md_5.bungee.protocol.MinecraftDecoder.decode(MinecraftDecoder.java:34)
	at net.md_5.bungee.protocol.MinecraftDecoder.decode(MinecraftDecoder.java:10)
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:89)
	... 19 more
```