### PR TITLE
Added an alternative teleport possibility between servers

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/connection/ProxiedPlayer.java
+++ b/api/src/main/java/net/md_5/bungee/api/connection/ProxiedPlayer.java
@@ -1,8 +1,5 @@
 package net.md_5.bungee.api.connection;
 
-import java.util.Locale;
-import java.util.Map;
-import java.util.UUID;
 import net.md_5.bungee.api.Callback;
 import net.md_5.bungee.api.ChatMessageType;
 import net.md_5.bungee.api.CommandSender;
@@ -10,12 +7,18 @@ import net.md_5.bungee.api.Title;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.config.ServerInfo;
 
+import java.util.Locale;
+import java.util.Map;
+import java.util.UUID;
+
 /**
  * Represents a player who's connection is being connected to somewhere else,
  * whether it be a remote or embedded server.
  */
 public interface ProxiedPlayer extends Connection, CommandSender
 {
+    int METHOD_DIMENSION_CHANGE = 0x00;
+    int METHOD_CHUNK_UPDATE = 0x01;
 
     /**
      * Gets this player's display name.
@@ -68,6 +71,19 @@ public interface ProxiedPlayer extends Connection, CommandSender
      * or failure.
      */
     void connect(ServerInfo target, Callback<Boolean> callback);
+
+    /**
+     * Connects / transfers this user to the specified connection, gracefully
+     * closing the current one. Depending on the implementation, this method
+     * might return before the user has been connected.
+     *
+     * @param target the new server to connect to
+     * @param callback the method called when the connection is complete, or
+     * when an exception is encountered. The boolean parameter denotes success
+     * or failure.
+     * @param method the method that used to connect to the server
+     */
+    void connect(ServerInfo target, Callback<Boolean> callback, int method);
 
     /**
      * Gets the server this player is connected to.

--- a/api/src/main/java/net/md_5/bungee/api/event/ServerConnectEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/ServerConnectEvent.java
@@ -34,10 +34,15 @@ public class ServerConnectEvent extends Event implements Cancellable
      * Cancelled state.
      */
     private boolean cancelled;
+    /**
+     * Method used to reconnect the player.
+     */
+    private int method;
 
-    public ServerConnectEvent(ProxiedPlayer player, ServerInfo target)
+    public ServerConnectEvent(ProxiedPlayer player, ServerInfo target, int method)
     {
         this.player = player;
         this.target = target;
+        this.method = method;
     }
 }


### PR DESCRIPTION
Hey,
when I developed a customized BungeeCord for our server project with some
improvements, I have found another way to teleport clients between servers without
telling the client to switch the dimension.

It works like the normal way with the dimension change packets but just without
sending them. So the player never sees a teleport screen and only sees that
his chunks and stuff like health is updating. This makes it easier to create
server networks with a big map splitted up into multiple instances.