### PR TITLE
Add support for FML with IP Forwarding enabled using the LoginProfile.

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
+++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
@@ -94,8 +94,7 @@ public class ServerConnector extends PacketHandler
         }
         else if ( !user.getExtraDataInHandshake().isEmpty() )
         {
-            // Only restore the extra data if IP forwarding is off. 
-            // TODO: Add support for this data with IP forwarding.
+            // Restore the extra data
             copiedHandshake.setHost( copiedHandshake.getHost() + user.getExtraDataInHandshake() );
         }
 

--- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
@@ -11,6 +11,7 @@ import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.util.internal.PlatformDependent;
 import java.net.InetSocketAddress;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -36,6 +37,8 @@ import net.md_5.bungee.api.event.ServerConnectEvent;
 import net.md_5.bungee.api.score.Scoreboard;
 import net.md_5.bungee.chat.ComponentSerializer;
 import net.md_5.bungee.connection.InitialHandler;
+import net.md_5.bungee.connection.LoginResult;
+import net.md_5.bungee.connection.LoginResult.Property;
 import net.md_5.bungee.entitymap.EntityMap;
 import net.md_5.bungee.forge.ForgeClientHandler;
 import net.md_5.bungee.forge.ForgeConstants;
@@ -169,8 +172,32 @@ public final class UserConnection implements ProxiedPlayer
 
         forgeClientHandler = new ForgeClientHandler( this );
 
+        // No-config FML handshake marker.
         // Set whether the connection has a 1.8 FML marker in the handshake.
-        forgeClientHandler.setFmlTokenInHandshake( this.getPendingConnection().getExtraDataInHandshake().contains( ForgeConstants.FML_HANDSHAKE_TOKEN ) );
+        if (this.getPendingConnection().getExtraDataInHandshake().contains( ForgeConstants.FML_HANDSHAKE_TOKEN )) 
+        {
+            forgeClientHandler.setFmlTokenInHandshake( true );
+
+            // If we IP forward, add the a FML marker to the game profile.
+            if ( BungeeCord.getInstance().config.isIpForward() ) 
+            {
+                // Get the user profile.
+                LoginResult profile = pendingConnection.getLoginProfile();
+
+                // Get the current properties and copy them into a slightly bigger array.
+                Property[] oldp = profile.getProperties();
+                Property[] newp = Arrays.copyOf( oldp, oldp.length + 2 );
+
+                // Add a new profile property that specifies that this user is a Forge user.
+                newp[newp.length - 2] = new Property( ForgeConstants.FML_LOGIN_PROFILE, "true", null );
+
+                // If we do not perform the replacement, then the IP Forwarding code in Spigot et. al. will try to split on this prematurely.
+                newp[newp.length - 1] = new Property( ForgeConstants.EXTRA_DATA, pendingConnection.getExtraDataInHandshake().replaceAll( "\0", "\1"), "" );
+
+                // Set the properties in the profile. All done.
+                profile.setProperties( newp );
+            }
+        }
     }
 
     public void sendPacket(PacketWrapper packet)

--- a/proxy/src/main/java/net/md_5/bungee/forge/ForgeConstants.java
+++ b/proxy/src/main/java/net/md_5/bungee/forge/ForgeConstants.java
@@ -14,6 +14,10 @@ public class ForgeConstants
     public static final String FML_HANDSHAKE_TAG = "FML|HS";
     public static final String FML_REGISTER = "REGISTER";
 
+    // Game profile key
+    public static final String FML_LOGIN_PROFILE = "forgeClient";
+    public static final String EXTRA_DATA = "extraData";
+
     /**
      * The FML 1.8 handshake token.
      */


### PR DESCRIPTION
This is an alternative to PR #1557, that allows FML clients to perform IP Forwarding **without breaking any previous builds**. This is simply an additive extension to the IP Forwarding protocol. This is being created as there seems to be no response to #1557 to my requests for comments, and it would be easier to see how this works differently in a PR.

We would really appreciate this in Bungee so that Sponge/FML servers can connect using IP Forwarding natively, with zero config, alongside Spigot servers without requiring any extra steps.

This PR adds two properties to the user Game Profile to forward on whether the user is a FML client, and any extra data that was sent from the client that was separated by `\0` characters. Note that for data moved from the handshake packet to the login profile, all `\0` characters become `\1`, to avoid conflicts with IP Forwarding.

For more discussion, please see PR #1557.
