### PR TITLE
Don't let UpstreamBridge bypass the plugin messaging channel registration limit.

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
@@ -190,6 +190,7 @@ public class UpstreamBridge extends PacketHandler
         // TODO: Unregister as well?
         if ( pluginMessage.getTag().equals( "REGISTER" ) )
         {
+            Preconditions.checkState( con.getPendingConnection().getRegisterMessages().size() < 128, "Too many channels registered" );
             con.getPendingConnection().getRegisterMessages().add( pluginMessage );
         }
     }


### PR DESCRIPTION
Fixes #1695