### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/api/src/main/java/net/md_5/bungee/Util.java
+++ b/api/src/main/java/net/md_5/bungee/Util.java
@@ -7,11 +7,15 @@ import java.util.UUID;
 /**
  * Series of utility classes to perform various operations.
  */
-public class Util
+public final class Util
 {
 
     private static final int DEFAULT_PORT = 25565;
 
+    private Util()
+    {
+        throw new InstantiationError( "Must not instantiate this class" );
+    }
     /**
      * Method to transform human readable addresses into usable address objects.
      *

--- a/bootstrap/src/main/java/net/md_5/bungee/Bootstrap.java
+++ b/bootstrap/src/main/java/net/md_5/bungee/Bootstrap.java
@@ -1,7 +1,11 @@
 package net.md_5.bungee;
 
-public class Bootstrap
+public final class Bootstrap
 {
+    private Bootstrap()
+    {
+        throw new InstantiationError( "Must not instantiate this class" );
+    }
 
     public static void main(String[] args) throws Exception
     {

--- a/bootstrap/src/main/java/net/md_5/bungee/BungeeCordLauncher.java
+++ b/bootstrap/src/main/java/net/md_5/bungee/BungeeCordLauncher.java
@@ -12,8 +12,12 @@ import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.command.ConsoleCommandSender;
 
-public class BungeeCordLauncher
+public final class BungeeCordLauncher
 {
+    private BungeeCordLauncher()
+    {
+        throw new InstantiationError( "Must not instantiate this class" );
+    }
 
     public static void main(String[] args) throws Exception
     {

--- a/proxy/src/main/java/Test.java
+++ b/proxy/src/main/java/Test.java
@@ -12,8 +12,12 @@ import net.md_5.bungee.command.ConsoleCommandSender;
  *
  * @author michael
  */
-public class Test
+public final class Test
 {
+    private Test()
+    {
+        throw new InstantiationError( "Must not instantiate this class" );
+    }
 
     public static void main(String[] args) throws Exception
     {

--- a/proxy/src/main/java/net/md_5/bungee/EncryptionUtil.java
+++ b/proxy/src/main/java/net/md_5/bungee/EncryptionUtil.java
@@ -24,7 +24,7 @@ import net.md_5.bungee.protocol.packet.EncryptionRequest;
 /**
  * Class containing all encryption related methods for the proxy.
  */
-public class EncryptionUtil
+public final class EncryptionUtil
 {
 
     private static final Random random = new Random();
@@ -42,6 +42,11 @@ public class EncryptionUtil
         {
             throw new ExceptionInInitializerError( ex );
         }
+    }
+
+    private EncryptionUtil()
+    {
+        throw new InstantiationError( "Must not instantiate this class" );
     }
 
     public static EncryptionRequest encryptRequest()

--- a/proxy/src/main/java/net/md_5/bungee/PacketConstants.java
+++ b/proxy/src/main/java/net/md_5/bungee/PacketConstants.java
@@ -4,7 +4,7 @@ import net.md_5.bungee.protocol.packet.ClientStatus;
 import net.md_5.bungee.protocol.packet.PluginMessage;
 import net.md_5.bungee.protocol.packet.Respawn;
 
-public class PacketConstants
+public final class PacketConstants
 {
 
     public static final Respawn DIM1_SWITCH = new Respawn( (byte) 1, (byte) 0, (byte) 0, "default" );
@@ -15,4 +15,10 @@ public class PacketConstants
         0, 0, 0, 0, 0, 2
     }, false );
     public static final PluginMessage I_AM_BUNGEE = new PluginMessage( "BungeeCord", new byte[ 0 ], false );
+
+    private PacketConstants()
+    {
+        throw new InstantiationError( "Must not instantiate this class" );
+    }
+
 }

--- a/proxy/src/main/java/net/md_5/bungee/compress/CompressFactory.java
+++ b/proxy/src/main/java/net/md_5/bungee/compress/CompressFactory.java
@@ -5,8 +5,14 @@ import net.md_5.bungee.jni.zlib.BungeeZlib;
 import net.md_5.bungee.jni.zlib.JavaZlib;
 import net.md_5.bungee.jni.zlib.NativeZlib;
 
-public class CompressFactory
+public final class CompressFactory
 {
 
     public static final NativeCode<BungeeZlib> zlib = new NativeCode( "native-compress", JavaZlib.class, NativeZlib.class );
+    
+    private CompressFactory()
+    {
+        throw new InstantiationError( "Must not instantiate this class" );
+    }
+
 }

--- a/proxy/src/main/java/net/md_5/bungee/forge/ForgeConstants.java
+++ b/proxy/src/main/java/net/md_5/bungee/forge/ForgeConstants.java
@@ -3,7 +3,7 @@ package net.md_5.bungee.forge;
 import java.util.regex.Pattern;
 import net.md_5.bungee.protocol.packet.PluginMessage;
 
-public class ForgeConstants
+public final class ForgeConstants
 {
 
     // Forge
@@ -18,6 +18,11 @@ public class ForgeConstants
      * The FML 1.8 handshake token.
      */
     public static final String FML_HANDSHAKE_TOKEN = "\0FML\0";
+
+    private ForgeConstants()
+    {
+        throw new InstantiationError( "Must not instantiate this class" );
+    }
 
     public static final PluginMessage FML_RESET_HANDSHAKE = new PluginMessage( FML_HANDSHAKE_TAG, new byte[]
     {

--- a/proxy/src/main/java/net/md_5/bungee/forge/ForgeUtils.java
+++ b/proxy/src/main/java/net/md_5/bungee/forge/ForgeUtils.java
@@ -11,9 +11,13 @@ import java.util.regex.Matcher;
 import net.md_5.bungee.protocol.DefinedPacket;
 import net.md_5.bungee.protocol.packet.PluginMessage;
 
-public class ForgeUtils
+public final class ForgeUtils
 {
 
+    private ForgeUtils()
+    {
+        throw new InstantiationError( "Must not instantiate this class" );
+    }
     /**
      * Gets the registered FML channels from the packet.
      *

--- a/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java
+++ b/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java
@@ -38,7 +38,7 @@ import net.md_5.bungee.protocol.Protocol;
 import net.md_5.bungee.protocol.Varint21FrameDecoder;
 import net.md_5.bungee.protocol.Varint21LengthFieldPrepender;
 
-public class PipelineUtils
+public final class PipelineUtils
 {
 
     public static final AttributeKey<ListenerInfo> LISTENER = new AttributeKey<>( "ListerInfo" );
@@ -93,6 +93,11 @@ public class PipelineUtils
                 ProxyServer.getInstance().getLogger().log( Level.WARNING, "Epoll is not working, falling back to NIO: {0}", Util.exception( Epoll.unavailabilityCause() ) );
             }
         }
+    }
+
+    private PipelineUtils()
+    {
+        throw new InstantiationError( "Must not instantiate this class" );
     }
 
     public static EventLoopGroup newEventLoopGroup(int threads, ThreadFactory factory)


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - Utility classes should not have public constructors
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118
Please let me know if you have any questions.
M-Ezzat