### PR TITLE
Remove stored address after exception

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/http/HttpClient.java
+++ b/proxy/src/main/java/net/md_5/bungee/http/HttpClient.java
@@ -86,6 +86,7 @@ public class HttpClient
                     future.channel().writeAndFlush( request );
                 } else
                 {
+                    addressCache.invalidate( uri.getHost() );
                     callback.done( null, future.cause() );
                 }
             }


### PR DESCRIPTION
When mojang's session server is down and change address, bungee can't connect them and has to wait until the key expire.