### PR TITLE
squid:S00118 - Abstract class names should comply with a naming conve…

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/AbstractProxyServer.java
+++ b/api/src/main/java/net/md_5/bungee/api/AbstractProxyServer.java
@@ -1,6 +1,6 @@
 package net.md_5.bungee.api;
 
-import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.api.chat.AbstractBaseComponent;
 import net.md_5.bungee.api.plugin.PluginManager;
 import com.google.common.base.Preconditions;
 import java.io.File;
@@ -16,11 +16,11 @@ import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.plugin.Plugin;
 import net.md_5.bungee.api.scheduler.TaskScheduler;
 
-public abstract class ProxyServer
+public abstract class AbstractProxyServer
 {
 
     @Getter
-    private static ProxyServer instance;
+    private static AbstractProxyServer instance;
 
     /**
      * Sets the proxy instance. This method may only be called once per an
@@ -28,11 +28,11 @@ public abstract class ProxyServer
      *
      * @param instance the new instance to set
      */
-    public static void setInstance(ProxyServer instance)
+    public static void setInstance(AbstractProxyServer instance)
     {
         Preconditions.checkNotNull( instance, "instance" );
-        Preconditions.checkArgument( ProxyServer.instance == null, "Instance already set" );
-        ProxyServer.instance = instance;
+        Preconditions.checkArgument( AbstractProxyServer.instance == null, "Instance already set" );
+        AbstractProxyServer.instance = instance;
     }
 
     /**
@@ -257,14 +257,14 @@ public abstract class ProxyServer
      *
      * @param message the message to broadcast
      */
-    public abstract void broadcast(BaseComponent... message);
+    public abstract void broadcast(AbstractBaseComponent... message);
 
     /**
      * Send the specified message to the console and all connected players.
      *
      * @param message the message to broadcast
      */
-    public abstract void broadcast(BaseComponent message);
+    public abstract void broadcast(AbstractBaseComponent message);
 
     /**
      * Gets the commands which are disabled and will not be run on this proxy.

--- a/api/src/main/java/net/md_5/bungee/api/AbstractReconnectHandler.java
+++ b/api/src/main/java/net/md_5/bungee/api/AbstractReconnectHandler.java
@@ -17,7 +17,7 @@ public abstract class AbstractReconnectHandler implements ReconnectHandler
             server = getStoredServer( player );
             if ( server == null )
             {
-                server = ProxyServer.getInstance().getServerInfo( player.getPendingConnection().getListener().getDefaultServer() );
+                server = AbstractProxyServer.getInstance().getServerInfo( player.getPendingConnection().getListener().getDefaultServer() );
             }
 
             Preconditions.checkState( server != null, "Default server not defined" );
@@ -39,7 +39,7 @@ public abstract class AbstractReconnectHandler implements ReconnectHandler
         {
             forced = con.getListener().getDefaultServer();
         }
-        return ProxyServer.getInstance().getServerInfo( forced );
+        return AbstractProxyServer.getInstance().getServerInfo( forced );
     }
 
     protected abstract ServerInfo getStoredServer(ProxiedPlayer player);

--- a/api/src/main/java/net/md_5/bungee/api/CommandSender.java
+++ b/api/src/main/java/net/md_5/bungee/api/CommandSender.java
@@ -1,6 +1,6 @@
 package net.md_5.bungee.api;
 
-import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.api.chat.AbstractBaseComponent;
 
 import java.util.Collection;
 
@@ -36,14 +36,14 @@ public interface CommandSender
      *
      * @param message the message to send
      */
-    public void sendMessage(BaseComponent... message);
+    public void sendMessage(AbstractBaseComponent... message);
 
     /**
      * Send a message to this sender.
      *
      * @param message the message to send
      */
-    public void sendMessage(BaseComponent message);
+    public void sendMessage(AbstractBaseComponent message);
 
     /**
      * Get all groups this user is part of. This returns an unmodifiable

--- a/api/src/main/java/net/md_5/bungee/api/Title.java
+++ b/api/src/main/java/net/md_5/bungee/api/Title.java
@@ -1,6 +1,6 @@
 package net.md_5.bungee.api;
 
-import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.api.chat.AbstractBaseComponent;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 
 /**
@@ -11,7 +11,7 @@ import net.md_5.bungee.api.connection.ProxiedPlayer;
  * affected by a previous one.
  * <p>
  * You can create a new configuration by calling
- * {@link ProxyServer#createTitle()}.
+ * {@link AbstractProxyServer#createTitle()}.
  */
 public interface Title
 {
@@ -22,7 +22,7 @@ public interface Title
      * @param text The text to use as the title.
      * @return This title configuration.
      */
-    public Title title(BaseComponent text);
+    public Title title(AbstractBaseComponent text);
 
     /**
      * Set the title to send to the player.
@@ -30,7 +30,7 @@ public interface Title
      * @param text The text to use as the title.
      * @return This title configuration.
      */
-    public Title title(BaseComponent... text);
+    public Title title(AbstractBaseComponent... text);
 
     /**
      * Set the subtitle to send to the player.
@@ -38,7 +38,7 @@ public interface Title
      * @param text The text to use as the subtitle.
      * @return This title configuration.
      */
-    public Title subTitle(BaseComponent text);
+    public Title subTitle(AbstractBaseComponent text);
 
     /**
      * Set the subtitle to send to the player.
@@ -46,7 +46,7 @@ public interface Title
      * @param text The text to use as the subtitle.
      * @return This title configuration.
      */
-    public Title subTitle(BaseComponent... text);
+    public Title subTitle(AbstractBaseComponent... text);
 
     /**
      * Set the duration in ticks of the fade in effect of the title. Once this

--- a/api/src/main/java/net/md_5/bungee/api/connection/Connection.java
+++ b/api/src/main/java/net/md_5/bungee/api/connection/Connection.java
@@ -2,8 +2,8 @@ package net.md_5.bungee.api.connection;
 
 import java.net.InetSocketAddress;
 
-import net.md_5.bungee.api.chat.BaseComponent;
-import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.api.chat.AbstractBaseComponent;
+import net.md_5.bungee.protocol.AbstractDefinedPacket;
 
 /**
  * A proxy connection is defined as a connection directly connected to a socket.
@@ -39,7 +39,7 @@ public interface Connection
      * @param reason the reason shown to the player / sent to the server on
      * disconnect
      */
-    void disconnect(BaseComponent... reason);
+    void disconnect(AbstractBaseComponent... reason);
 
     /**
      * Disconnects this end of the connection for the specified reason. If this
@@ -49,7 +49,7 @@ public interface Connection
      * @param reason the reason shown to the player / sent to the server on
      * disconnect
      */
-    void disconnect(BaseComponent reason);
+    void disconnect(AbstractBaseComponent reason);
 
     /**
      * Get the unsafe methods of this class.
@@ -66,6 +66,6 @@ public interface Connection
          *
          * @param packet the packet to send
          */
-        void sendPacket(DefinedPacket packet);
+        void sendPacket(AbstractDefinedPacket packet);
     }
 }

--- a/api/src/main/java/net/md_5/bungee/api/connection/ProxiedPlayer.java
+++ b/api/src/main/java/net/md_5/bungee/api/connection/ProxiedPlayer.java
@@ -7,7 +7,7 @@ import net.md_5.bungee.api.Callback;
 import net.md_5.bungee.api.ChatMessageType;
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.Title;
-import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.api.chat.AbstractBaseComponent;
 import net.md_5.bungee.api.config.ServerInfo;
 
 /**
@@ -38,7 +38,7 @@ public interface ProxiedPlayer extends Connection, CommandSender
      * @param position the screen position
      * @param message the message to send
      */
-    public void sendMessage(ChatMessageType position, BaseComponent... message);
+    public void sendMessage(ChatMessageType position, AbstractBaseComponent... message);
 
     /**
      * Send a message to the specified screen position of this player.
@@ -46,7 +46,7 @@ public interface ProxiedPlayer extends Connection, CommandSender
      * @param position the screen position
      * @param message the message to send
      */
-    public void sendMessage(ChatMessageType position, BaseComponent message);
+    public void sendMessage(ChatMessageType position, AbstractBaseComponent message);
 
     /**
      * Connects / transfers this user to the specified connection, gracefully
@@ -148,7 +148,7 @@ public interface ProxiedPlayer extends Connection, CommandSender
      * @param header The header for the tab player list, null to clear it.
      * @param footer The footer for the tab player list, null to clear it.
      */
-    void setTabHeader(BaseComponent header, BaseComponent footer);
+    void setTabHeader(AbstractBaseComponent header, AbstractBaseComponent footer);
 
     /**
      * Set the header and footer displayed in the tab player list.
@@ -156,7 +156,7 @@ public interface ProxiedPlayer extends Connection, CommandSender
      * @param header The header for the tab player list, null to clear it.
      * @param footer The footer for the tab player list, null to clear it.
      */
-    void setTabHeader(BaseComponent[] header, BaseComponent[] footer);
+    void setTabHeader(AbstractBaseComponent[] header, AbstractBaseComponent[] footer);
 
     /**
      * Clears the header and footer displayed in the tab player list.

--- a/api/src/main/java/net/md_5/bungee/api/event/AbstractTargetedEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/AbstractTargetedEvent.java
@@ -4,7 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import net.md_5.bungee.api.connection.Connection;
-import net.md_5.bungee.api.plugin.Event;
+import net.md_5.bungee.api.plugin.AbstractEvent;
 
 /**
  * An event which occurs in the communication between two nodes.
@@ -12,7 +12,7 @@ import net.md_5.bungee.api.plugin.Event;
 @Data
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = false)
-public abstract class TargetedEvent extends Event
+public abstract class AbstractTargetedEvent extends AbstractEvent
 {
 
     /**

--- a/api/src/main/java/net/md_5/bungee/api/event/AsyncEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/AsyncEvent.java
@@ -10,7 +10,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import net.md_5.bungee.api.Callback;
-import net.md_5.bungee.api.plugin.Event;
+import net.md_5.bungee.api.plugin.AbstractEvent;
 import net.md_5.bungee.api.plugin.Plugin;
 
 /**
@@ -21,7 +21,7 @@ import net.md_5.bungee.api.plugin.Plugin;
 @Data
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public class AsyncEvent<T> extends Event
+public class AsyncEvent<T> extends AbstractEvent
 {
 
     private final Callback<T> done;

--- a/api/src/main/java/net/md_5/bungee/api/event/ChatEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/ChatEvent.java
@@ -12,7 +12,7 @@ import net.md_5.bungee.api.plugin.Cancellable;
 @Data
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public class ChatEvent extends TargetedEvent implements Cancellable
+public class ChatEvent extends AbstractTargetedEvent implements Cancellable
 {
 
     /**

--- a/api/src/main/java/net/md_5/bungee/api/event/PermissionCheckEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/PermissionCheckEvent.java
@@ -7,7 +7,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 import net.md_5.bungee.api.CommandSender;
-import net.md_5.bungee.api.plugin.Event;
+import net.md_5.bungee.api.plugin.AbstractEvent;
 
 /**
  * Called when the permission of a CommandSender is checked.
@@ -16,7 +16,7 @@ import net.md_5.bungee.api.plugin.Event;
 @AllArgsConstructor
 @ToString(callSuper = false)
 @EqualsAndHashCode(callSuper = false)
-public class PermissionCheckEvent extends Event
+public class PermissionCheckEvent extends AbstractEvent
 {
 
     /**

--- a/api/src/main/java/net/md_5/bungee/api/event/PlayerDisconnectEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/PlayerDisconnectEvent.java
@@ -4,7 +4,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
-import net.md_5.bungee.api.plugin.Event;
+import net.md_5.bungee.api.plugin.AbstractEvent;
 
 /**
  * Called when a player has left the proxy, it is not safe to call any methods
@@ -13,7 +13,7 @@ import net.md_5.bungee.api.plugin.Event;
 @Data
 @ToString(callSuper = false)
 @EqualsAndHashCode(callSuper = false)
-public class PlayerDisconnectEvent extends Event
+public class PlayerDisconnectEvent extends AbstractEvent
 {
 
     /**

--- a/api/src/main/java/net/md_5/bungee/api/event/PlayerHandshakeEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/PlayerHandshakeEvent.java
@@ -4,7 +4,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import net.md_5.bungee.api.connection.PendingConnection;
-import net.md_5.bungee.api.plugin.Event;
+import net.md_5.bungee.api.plugin.AbstractEvent;
 import net.md_5.bungee.protocol.packet.Handshake;
 
 /**
@@ -14,7 +14,7 @@ import net.md_5.bungee.protocol.packet.Handshake;
 @Data
 @ToString(callSuper = false)
 @EqualsAndHashCode(callSuper = false)
-public class PlayerHandshakeEvent extends Event
+public class PlayerHandshakeEvent extends AbstractEvent
 {
 
     /**

--- a/api/src/main/java/net/md_5/bungee/api/event/PluginMessageEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/PluginMessageEvent.java
@@ -12,7 +12,7 @@ import net.md_5.bungee.api.plugin.Cancellable;
 @Data
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public class PluginMessageEvent extends TargetedEvent implements Cancellable
+public class PluginMessageEvent extends AbstractTargetedEvent implements Cancellable
 {
 
     /**

--- a/api/src/main/java/net/md_5/bungee/api/event/PostLoginEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/PostLoginEvent.java
@@ -4,7 +4,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
-import net.md_5.bungee.api.plugin.Event;
+import net.md_5.bungee.api.plugin.AbstractEvent;
 
 /**
  * Event called as soon as a connection has a {@link ProxiedPlayer} and is ready
@@ -13,7 +13,7 @@ import net.md_5.bungee.api.plugin.Event;
 @Data
 @ToString(callSuper = false)
 @EqualsAndHashCode(callSuper = false)
-public class PostLoginEvent extends Event
+public class PostLoginEvent extends AbstractEvent
 {
 
     /**

--- a/api/src/main/java/net/md_5/bungee/api/event/ProxyPingEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/ProxyPingEvent.java
@@ -6,7 +6,6 @@ import lombok.ToString;
 import net.md_5.bungee.api.Callback;
 import net.md_5.bungee.api.ServerPing;
 import net.md_5.bungee.api.connection.PendingConnection;
-import net.md_5.bungee.api.plugin.Event;
 
 /**
  * Called when the proxy is pinged with packet 0xFE from the server list.

--- a/api/src/main/java/net/md_5/bungee/api/event/ProxyReloadEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/ProxyReloadEvent.java
@@ -4,7 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.EqualsAndHashCode;
 import net.md_5.bungee.api.CommandSender;
-import net.md_5.bungee.api.plugin.Event;
+import net.md_5.bungee.api.plugin.AbstractEvent;
 
 /**
  * Called when somebody reloads BungeeCord
@@ -12,7 +12,7 @@ import net.md_5.bungee.api.plugin.Event;
 @Getter
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = false)
-public class ProxyReloadEvent extends Event
+public class ProxyReloadEvent extends AbstractEvent
 {
 
     /**

--- a/api/src/main/java/net/md_5/bungee/api/event/ServerConnectEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/ServerConnectEvent.java
@@ -7,7 +7,7 @@ import lombok.ToString;
 import net.md_5.bungee.api.config.ServerInfo;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.plugin.Cancellable;
-import net.md_5.bungee.api.plugin.Event;
+import net.md_5.bungee.api.plugin.AbstractEvent;
 
 /**
  * Called when deciding to connect to a server. At the time when this event is
@@ -18,7 +18,7 @@ import net.md_5.bungee.api.plugin.Event;
 @Data
 @ToString(callSuper = false)
 @EqualsAndHashCode(callSuper = false)
-public class ServerConnectEvent extends Event implements Cancellable
+public class ServerConnectEvent extends AbstractEvent implements Cancellable
 {
 
     /**

--- a/api/src/main/java/net/md_5/bungee/api/event/ServerConnectedEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/ServerConnectedEvent.java
@@ -5,7 +5,7 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.connection.Server;
-import net.md_5.bungee.api.plugin.Event;
+import net.md_5.bungee.api.plugin.AbstractEvent;
 
 /**
  * Not to be confused with {@link ServerConnectEvent}, this event is called once
@@ -16,7 +16,7 @@ import net.md_5.bungee.api.plugin.Event;
 @Data
 @ToString(callSuper = false)
 @EqualsAndHashCode(callSuper = false)
-public class ServerConnectedEvent extends Event
+public class ServerConnectedEvent extends AbstractEvent
 {
 
     /**

--- a/api/src/main/java/net/md_5/bungee/api/event/ServerDisconnectEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/ServerDisconnectEvent.java
@@ -7,13 +7,13 @@ import lombok.NonNull;
 import lombok.ToString;
 import net.md_5.bungee.api.config.ServerInfo;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
-import net.md_5.bungee.api.plugin.Event;
+import net.md_5.bungee.api.plugin.AbstractEvent;
 
 @Data
 @AllArgsConstructor
 @ToString(callSuper = false)
 @EqualsAndHashCode(callSuper = false)
-public class ServerDisconnectEvent extends Event
+public class ServerDisconnectEvent extends AbstractEvent
 {
 
     /**

--- a/api/src/main/java/net/md_5/bungee/api/event/ServerKickEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/ServerKickEvent.java
@@ -3,12 +3,12 @@ package net.md_5.bungee.api.event;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
-import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.api.chat.AbstractBaseComponent;
 import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.api.config.ServerInfo;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.plugin.Cancellable;
-import net.md_5.bungee.api.plugin.Event;
+import net.md_5.bungee.api.plugin.AbstractEvent;
 
 /**
  * Represents a player getting kicked from a server.
@@ -16,7 +16,7 @@ import net.md_5.bungee.api.plugin.Event;
 @Data
 @ToString(callSuper = false)
 @EqualsAndHashCode(callSuper = false)
-public class ServerKickEvent extends Event implements Cancellable
+public class ServerKickEvent extends AbstractEvent implements Cancellable
 {
 
     /**
@@ -35,7 +35,7 @@ public class ServerKickEvent extends Event implements Cancellable
     /**
      * Kick reason.
      */
-    private BaseComponent[] kickReasonComponent;
+    private AbstractBaseComponent[] kickReasonComponent;
     /**
      * Server to send player to if this event is cancelled.
      */
@@ -52,18 +52,18 @@ public class ServerKickEvent extends Event implements Cancellable
     }
 
     @Deprecated
-    public ServerKickEvent(ProxiedPlayer player, BaseComponent[] kickReasonComponent, ServerInfo cancelServer)
+    public ServerKickEvent(ProxiedPlayer player, AbstractBaseComponent[] kickReasonComponent, ServerInfo cancelServer)
     {
         this( player, kickReasonComponent, cancelServer, State.UNKNOWN );
     }
 
     @Deprecated
-    public ServerKickEvent(ProxiedPlayer player, BaseComponent[] kickReasonComponent, ServerInfo cancelServer, State state)
+    public ServerKickEvent(ProxiedPlayer player, AbstractBaseComponent[] kickReasonComponent, ServerInfo cancelServer, State state)
     {
         this( player, player.getServer().getInfo(), kickReasonComponent, cancelServer, state );
     }
 
-    public ServerKickEvent(ProxiedPlayer player, ServerInfo kickedFrom, BaseComponent[] kickReasonComponent, ServerInfo cancelServer, State state)
+    public ServerKickEvent(ProxiedPlayer player, ServerInfo kickedFrom, AbstractBaseComponent[] kickReasonComponent, ServerInfo cancelServer, State state)
     {
         this.player = player;
         this.kickedFrom = kickedFrom;
@@ -75,7 +75,7 @@ public class ServerKickEvent extends Event implements Cancellable
     @Deprecated
     public String getKickReason()
     {
-        return BaseComponent.toLegacyText( kickReasonComponent );
+        return AbstractBaseComponent.toLegacyText( kickReasonComponent );
     }
 
     @Deprecated

--- a/api/src/main/java/net/md_5/bungee/api/event/ServerSwitchEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/ServerSwitchEvent.java
@@ -4,7 +4,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
-import net.md_5.bungee.api.plugin.Event;
+import net.md_5.bungee.api.plugin.AbstractEvent;
 
 /**
  * Called when a player has changed servers.
@@ -12,7 +12,7 @@ import net.md_5.bungee.api.plugin.Event;
 @Data
 @ToString(callSuper = false)
 @EqualsAndHashCode(callSuper = false)
-public class ServerSwitchEvent extends Event
+public class ServerSwitchEvent extends AbstractEvent
 {
 
     /**

--- a/api/src/main/java/net/md_5/bungee/api/event/TabCompleteEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/TabCompleteEvent.java
@@ -13,7 +13,7 @@ import net.md_5.bungee.api.plugin.Cancellable;
 @Data
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public class TabCompleteEvent extends TargetedEvent implements Cancellable
+public class TabCompleteEvent extends AbstractTargetedEvent implements Cancellable
 {
 
     /**

--- a/api/src/main/java/net/md_5/bungee/api/event/TabCompleteResponseEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/TabCompleteResponseEvent.java
@@ -16,7 +16,7 @@ import java.util.List;
 @Data
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public class TabCompleteResponseEvent extends TargetedEvent implements Cancellable
+public class TabCompleteResponseEvent extends AbstractTargetedEvent implements Cancellable
 {
 
     /**

--- a/api/src/main/java/net/md_5/bungee/api/plugin/AbstractCommand.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/AbstractCommand.java
@@ -11,7 +11,7 @@ import net.md_5.bungee.api.CommandSender;
  */
 @Data
 @RequiredArgsConstructor(access = AccessLevel.NONE)
-public abstract class Command
+public abstract class AbstractCommand
 {
 
     private final String name;
@@ -23,7 +23,7 @@ public abstract class Command
      *
      * @param name the name of this command
      */
-    public Command(String name)
+    public AbstractCommand(String name)
     {
         this( name, null );
     }
@@ -36,7 +36,7 @@ public abstract class Command
      * null or empty string allows it to be executed by everyone
      * @param aliases aliases which map back to this command
      */
-    public Command(String name, String permission, String... aliases)
+    public AbstractCommand(String name, String permission, String... aliases)
     {
         Preconditions.checkArgument( name != null, "name" );
         this.name = name;

--- a/api/src/main/java/net/md_5/bungee/api/plugin/AbstractEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/AbstractEvent.java
@@ -3,7 +3,7 @@ package net.md_5.bungee.api.plugin;
 /**
  * Dummy class which all callable events must extend.
  */
-public abstract class Event
+public abstract class AbstractEvent
 {
 
     /**

--- a/api/src/main/java/net/md_5/bungee/api/plugin/Plugin.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/Plugin.java
@@ -7,7 +7,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.logging.Logger;
 import lombok.Getter;
-import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.AbstractProxyServer;
 import net.md_5.bungee.api.config.ConfigurationAdapter;
 import net.md_5.bungee.api.scheduler.GroupedThreadFactory;
 
@@ -21,7 +21,7 @@ public class Plugin
     @Getter
     private PluginDescription description;
     @Getter
-    private ProxyServer proxy;
+    private AbstractProxyServer proxy;
     @Getter
     private File file;
     @Getter
@@ -52,7 +52,7 @@ public class Plugin
 
     /**
      * Gets the data folder where this plugin may store arbitrary data. It will
-     * be a child of {@link ProxyServer#getPluginsFolder()}.
+     * be a child of {@link AbstractProxyServer#getPluginsFolder()}.
      *
      * @return the data folder of this plugin
      */
@@ -80,7 +80,7 @@ public class Plugin
      * @param description the description that describes this plugin
      * @param jarfile this plugins jar or container
      */
-    final void init(ProxyServer proxy, PluginDescription description)
+    final void init(AbstractProxyServer proxy, PluginDescription description)
     {
         this.proxy = proxy;
         this.description = description;

--- a/api/src/main/java/net/md_5/bungee/command/AbstractPlayerCommand.java
+++ b/api/src/main/java/net/md_5/bungee/command/AbstractPlayerCommand.java
@@ -4,24 +4,24 @@ import com.google.common.base.Function;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 import net.md_5.bungee.api.CommandSender;
-import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.AbstractProxyServer;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
-import net.md_5.bungee.api.plugin.Command;
+import net.md_5.bungee.api.plugin.AbstractCommand;
 import net.md_5.bungee.api.plugin.TabExecutor;
 
 /**
  * @deprecated internal use only
  */
 @Deprecated
-public abstract class PlayerCommand extends Command implements TabExecutor
+public abstract class AbstractPlayerCommand extends AbstractCommand implements TabExecutor
 {
 
-    public PlayerCommand(String name)
+    public AbstractPlayerCommand(String name)
     {
         super( name );
     }
 
-    public PlayerCommand(String name, String permission, String... aliases)
+    public AbstractPlayerCommand(String name, String permission, String... aliases)
     {
         super( name, permission, aliases );
     }
@@ -30,7 +30,7 @@ public abstract class PlayerCommand extends Command implements TabExecutor
     public Iterable<String> onTabComplete(CommandSender sender, String[] args)
     {
         final String lastArg = ( args.length > 0 ) ? args[args.length - 1].toLowerCase() : "";
-        return Iterables.transform( Iterables.filter( ProxyServer.getInstance().getPlayers(), new Predicate<ProxiedPlayer>()
+        return Iterables.transform( Iterables.filter( AbstractProxyServer.getInstance().getPlayers(), new Predicate<ProxiedPlayer>()
         {
             @Override
             public boolean apply(ProxiedPlayer player)

--- a/bootstrap/src/main/java/net/md_5/bungee/BungeeCordLauncher.java
+++ b/bootstrap/src/main/java/net/md_5/bungee/BungeeCordLauncher.java
@@ -9,7 +9,7 @@ import java.util.concurrent.TimeUnit;
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
 import net.md_5.bungee.api.ChatColor;
-import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.AbstractProxyServer;
 import net.md_5.bungee.command.ConsoleCommandSender;
 
 public class BungeeCordLauncher
@@ -50,7 +50,7 @@ public class BungeeCordLauncher
         }
 
         BungeeCord bungee = new BungeeCord();
-        ProxyServer.setInstance( bungee );
+        AbstractProxyServer.setInstance( bungee );
         bungee.getLogger().info( "Enabled BungeeCord version " + bungee.getVersion() );
         bungee.start();
 

--- a/chat/src/main/java/net/md_5/bungee/api/chat/AbstractBaseComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/AbstractBaseComponent.java
@@ -13,11 +13,11 @@ import lombok.ToString;
 @Setter
 @ToString(exclude = "parent")
 @NoArgsConstructor
-public abstract class BaseComponent
+public abstract class AbstractBaseComponent
 {
 
     @Setter(AccessLevel.NONE)
-    BaseComponent parent;
+    AbstractBaseComponent parent;
 
     /**
      * The color of this component and any child components (unless overridden)
@@ -53,7 +53,7 @@ public abstract class BaseComponent
      * Appended components that inherit this component's formatting and events
      */
     @Getter
-    private List<BaseComponent> extra;
+    private List<AbstractBaseComponent> extra;
 
     /**
      * The action to preform when this component (and child components) are
@@ -68,7 +68,7 @@ public abstract class BaseComponent
     @Getter
     private HoverEvent hoverEvent;
 
-    BaseComponent(BaseComponent old)
+    AbstractBaseComponent(AbstractBaseComponent old)
     {
         setColor( old.getColorRaw() );
         setBold( old.isBoldRaw() );
@@ -80,7 +80,7 @@ public abstract class BaseComponent
         setHoverEvent( old.getHoverEvent() );
         if ( old.getExtra() != null )
         {
-            for ( BaseComponent component : old.getExtra() )
+            for ( AbstractBaseComponent component : old.getExtra() )
             {
                 addExtra( component.duplicate() );
             }
@@ -92,7 +92,7 @@ public abstract class BaseComponent
      *
      * @return The duplicate of this BaseComponent
      */
-    public abstract BaseComponent duplicate();
+    public abstract AbstractBaseComponent duplicate();
 
     /**
      * Converts the components to a string that uses the old formatting codes
@@ -101,10 +101,10 @@ public abstract class BaseComponent
      * @param components the components to convert
      * @return the string in the old format
      */
-    public static String toLegacyText(BaseComponent... components)
+    public static String toLegacyText(AbstractBaseComponent... components)
     {
         StringBuilder builder = new StringBuilder();
-        for ( BaseComponent msg : components )
+        for ( AbstractBaseComponent msg : components )
         {
             builder.append( msg.toLegacyText() );
         }
@@ -117,10 +117,10 @@ public abstract class BaseComponent
      * @param components the components to convert
      * @return the string as plain text
      */
-    public static String toPlainText(BaseComponent... components)
+    public static String toPlainText(AbstractBaseComponent... components)
     {
         StringBuilder builder = new StringBuilder();
-        for ( BaseComponent msg : components )
+        for ( AbstractBaseComponent msg : components )
         {
             builder.append( msg.toPlainText() );
         }
@@ -293,9 +293,9 @@ public abstract class BaseComponent
         return obfuscated;
     }
 
-    public void setExtra(List<BaseComponent> components)
+    public void setExtra(List<AbstractBaseComponent> components)
     {
-        for ( BaseComponent component : components )
+        for ( AbstractBaseComponent component : components )
         {
             component.parent = this;
         }
@@ -319,11 +319,11 @@ public abstract class BaseComponent
      *
      * @param component the component to append
      */
-    public void addExtra(BaseComponent component)
+    public void addExtra(AbstractBaseComponent component)
     {
         if ( extra == null )
         {
-            extra = new ArrayList<BaseComponent>();
+            extra = new ArrayList<AbstractBaseComponent>();
         }
         component.parent = this;
         extra.add( component );
@@ -358,7 +358,7 @@ public abstract class BaseComponent
     {
         if ( extra != null )
         {
-            for ( BaseComponent e : extra )
+            for ( AbstractBaseComponent e : extra )
             {
                 e.toPlainText( builder );
             }
@@ -382,7 +382,7 @@ public abstract class BaseComponent
     {
         if ( extra != null )
         {
-            for ( BaseComponent e : extra )
+            for ( AbstractBaseComponent e : extra )
             {
                 e.toLegacyText( builder );
             }

--- a/chat/src/main/java/net/md_5/bungee/api/chat/ComponentBuilder.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/ComponentBuilder.java
@@ -26,7 +26,7 @@ public class ComponentBuilder
 {
 
     private TextComponent current;
-    private final List<BaseComponent> parts = new ArrayList<BaseComponent>();
+    private final List<AbstractBaseComponent> parts = new ArrayList<AbstractBaseComponent>();
 
     /**
      * Creates a ComponentBuilder from the other given ComponentBuilder to clone
@@ -37,7 +37,7 @@ public class ComponentBuilder
     public ComponentBuilder(ComponentBuilder original)
     {
         current = new TextComponent( original.current );
-        for ( BaseComponent baseComponent : original.parts )
+        for ( AbstractBaseComponent baseComponent : original.parts )
         {
             parts.add( baseComponent.duplicate() );
         }
@@ -198,7 +198,7 @@ public class ComponentBuilder
      */
     public ComponentBuilder retain(FormatRetention retention)
     {
-        BaseComponent previous = current;
+        AbstractBaseComponent previous = current;
 
         switch ( retention )
         {
@@ -227,10 +227,10 @@ public class ComponentBuilder
      *
      * @return the created components
      */
-    public BaseComponent[] create()
+    public AbstractBaseComponent[] create()
     {
         parts.add( current );
-        return parts.toArray( new BaseComponent[ parts.size() ] );
+        return parts.toArray( new AbstractBaseComponent[ parts.size() ] );
     }
 
     public static enum FormatRetention

--- a/chat/src/main/java/net/md_5/bungee/api/chat/HoverEvent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/HoverEvent.java
@@ -11,7 +11,7 @@ final public class HoverEvent
 {
 
     private final Action action;
-    private final BaseComponent[] value;
+    private final AbstractBaseComponent[] value;
 
     public enum Action
     {

--- a/chat/src/main/java/net/md_5/bungee/api/chat/TextComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/TextComponent.java
@@ -15,7 +15,7 @@ import java.util.regex.Pattern;
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
-public class TextComponent extends BaseComponent
+public class TextComponent extends AbstractBaseComponent
 {
 
     private static final Pattern url = Pattern.compile( "^(?:(https?)://)?([-\\w_\\.]{2,}\\.[a-z]{2,4})(/\\S*)?$" );
@@ -28,9 +28,9 @@ public class TextComponent extends BaseComponent
      * @param message the text to convert
      * @return the components needed to print the message to the client
      */
-    public static BaseComponent[] fromLegacyText(String message)
+    public static AbstractBaseComponent[] fromLegacyText(String message)
     {
-        ArrayList<BaseComponent> components = new ArrayList<BaseComponent>();
+        ArrayList<AbstractBaseComponent> components = new ArrayList<AbstractBaseComponent>();
         StringBuilder builder = new StringBuilder();
         TextComponent component = new TextComponent();
         Matcher matcher = url.matcher( message );
@@ -127,7 +127,7 @@ public class TextComponent extends BaseComponent
             components.add( new TextComponent( "" ) );
         }
 
-        return components.toArray( new BaseComponent[ components.size() ] );
+        return components.toArray( new AbstractBaseComponent[ components.size() ] );
     }
 
     /**
@@ -153,10 +153,10 @@ public class TextComponent extends BaseComponent
      *
      * @param extras the extras to set
      */
-    public TextComponent(BaseComponent... extras)
+    public TextComponent(AbstractBaseComponent... extras)
     {
         setText( "" );
-        setExtra( new ArrayList<BaseComponent>( Arrays.asList( extras ) ) );
+        setExtra( new ArrayList<AbstractBaseComponent>( Arrays.asList( extras ) ) );
     }
 
     /**
@@ -165,7 +165,7 @@ public class TextComponent extends BaseComponent
      * @return the duplicate of this TextComponent.
      */
     @Override
-    public BaseComponent duplicate()
+    public AbstractBaseComponent duplicate()
     {
         return new TextComponent( this );
     }

--- a/chat/src/main/java/net/md_5/bungee/api/chat/TranslatableComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/TranslatableComponent.java
@@ -16,7 +16,7 @@ import lombok.ToString;
 @Setter
 @ToString
 @NoArgsConstructor
-public class TranslatableComponent extends BaseComponent
+public class TranslatableComponent extends AbstractBaseComponent
 {
 
     private final ResourceBundle locales = ResourceBundle.getBundle( "mojang-translations/en_US" );
@@ -30,7 +30,7 @@ public class TranslatableComponent extends BaseComponent
     /**
      * The components to substitute into the translation
      */
-    private List<BaseComponent> with;
+    private List<AbstractBaseComponent> with;
 
     /**
      * Creates a translatable component from the original to clone it.
@@ -41,7 +41,7 @@ public class TranslatableComponent extends BaseComponent
     {
         super( original );
         setTranslate( original.getTranslate() );
-        for ( BaseComponent baseComponent : original.getWith() )
+        for ( AbstractBaseComponent baseComponent : original.getWith() )
         {
             with.add( baseComponent.duplicate() );
         }
@@ -54,13 +54,13 @@ public class TranslatableComponent extends BaseComponent
      * @see #setWith(java.util.List)
      * @param translate the translation key
      * @param with the {@link java.lang.String}s and
-     * {@link net.md_5.bungee.api.chat.BaseComponent}s to use into the
+     * {@link AbstractBaseComponent}s to use into the
      * translation
      */
     public TranslatableComponent(String translate, Object... with)
     {
         setTranslate( translate );
-        List<BaseComponent> temp = new ArrayList<BaseComponent>();
+        List<AbstractBaseComponent> temp = new ArrayList<AbstractBaseComponent>();
         for ( Object w : with )
         {
             if ( w instanceof String )
@@ -68,7 +68,7 @@ public class TranslatableComponent extends BaseComponent
                 temp.add( new TextComponent( (String) w ) );
             } else
             {
-                temp.add( (BaseComponent) w );
+                temp.add( (AbstractBaseComponent) w );
             }
         }
         setWith( temp );
@@ -80,7 +80,7 @@ public class TranslatableComponent extends BaseComponent
      * @return the duplicate of this TranslatableComponent.
      */
     @Override
-    public BaseComponent duplicate()
+    public AbstractBaseComponent duplicate()
     {
         return new TranslatableComponent( this );
     }
@@ -91,9 +91,9 @@ public class TranslatableComponent extends BaseComponent
      *
      * @param components the components to substitute
      */
-    public void setWith(List<BaseComponent> components)
+    public void setWith(List<AbstractBaseComponent> components)
     {
-        for ( BaseComponent component : components )
+        for ( AbstractBaseComponent component : components )
         {
             component.parent = this;
         }
@@ -117,11 +117,11 @@ public class TranslatableComponent extends BaseComponent
      *
      * @param component the component to substitute
      */
-    public void addWith(BaseComponent component)
+    public void addWith(AbstractBaseComponent component)
     {
         if ( with == null )
         {
-            with = new ArrayList<BaseComponent>();
+            with = new ArrayList<AbstractBaseComponent>();
         }
         component.parent = this;
         with.add( component );

--- a/chat/src/main/java/net/md_5/bungee/chat/BaseComponentSerializer.java
+++ b/chat/src/main/java/net/md_5/bungee/chat/BaseComponentSerializer.java
@@ -5,7 +5,7 @@ import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonSerializationContext;
 import net.md_5.bungee.api.ChatColor;
-import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.api.chat.AbstractBaseComponent;
 import net.md_5.bungee.api.chat.ClickEvent;
 import net.md_5.bungee.api.chat.HoverEvent;
 
@@ -15,7 +15,7 @@ import java.util.HashSet;
 public class BaseComponentSerializer
 {
 
-    protected void deserialize(JsonObject object, BaseComponent component, JsonDeserializationContext context)
+    protected void deserialize(JsonObject object, AbstractBaseComponent component, JsonDeserializationContext context)
     {
         if ( object.has( "color" ) )
         {
@@ -43,7 +43,7 @@ public class BaseComponentSerializer
         }
         if ( object.has( "extra" ) )
         {
-            component.setExtra( Arrays.<BaseComponent>asList( context.<BaseComponent[]>deserialize( object.get( "extra" ), BaseComponent[].class ) ) );
+            component.setExtra( Arrays.<AbstractBaseComponent>asList( context.<AbstractBaseComponent[]>deserialize( object.get( "extra" ), AbstractBaseComponent[].class ) ) );
         }
 
         //Events
@@ -57,28 +57,28 @@ public class BaseComponentSerializer
         if ( object.has( "hoverEvent" ) )
         {
             JsonObject event = object.getAsJsonObject( "hoverEvent" );
-            BaseComponent[] res;
+            AbstractBaseComponent[] res;
             if ( event.get( "value" ).isJsonArray() )
             {
-                res = context.deserialize( event.get( "value" ), BaseComponent[].class );
+                res = context.deserialize( event.get( "value" ), AbstractBaseComponent[].class );
             } else
             {
-                res = new BaseComponent[]
+                res = new AbstractBaseComponent[]
                 {
-                    context.<BaseComponent>deserialize( event.get( "value" ), BaseComponent.class )
+                    context.<AbstractBaseComponent>deserialize( event.get( "value" ), AbstractBaseComponent.class )
                 };
             }
             component.setHoverEvent( new HoverEvent( HoverEvent.Action.valueOf( event.get( "action" ).getAsString().toUpperCase() ), res ) );
         }
     }
 
-    protected void serialize(JsonObject object, BaseComponent component, JsonSerializationContext context)
+    protected void serialize(JsonObject object, AbstractBaseComponent component, JsonSerializationContext context)
     {
         boolean first = false;
         if ( ComponentSerializer.serializedComponents.get() == null )
         {
             first = true;
-            ComponentSerializer.serializedComponents.set( new HashSet<BaseComponent>() );
+            ComponentSerializer.serializedComponents.set( new HashSet<AbstractBaseComponent>() );
         }
         try
         {

--- a/chat/src/main/java/net/md_5/bungee/chat/ComponentSerializer.java
+++ b/chat/src/main/java/net/md_5/bungee/chat/ComponentSerializer.java
@@ -7,48 +7,48 @@ import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
-import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.api.chat.AbstractBaseComponent;
 import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.api.chat.TranslatableComponent;
 
 import java.lang.reflect.Type;
 import java.util.HashSet;
 
-public class ComponentSerializer implements JsonDeserializer<BaseComponent>
+public class ComponentSerializer implements JsonDeserializer<AbstractBaseComponent>
 {
 
     private final static Gson gson = new GsonBuilder().
-            registerTypeAdapter( BaseComponent.class, new ComponentSerializer() ).
+            registerTypeAdapter( AbstractBaseComponent.class, new ComponentSerializer() ).
             registerTypeAdapter( TextComponent.class, new TextComponentSerializer() ).
             registerTypeAdapter( TranslatableComponent.class, new TranslatableComponentSerializer() ).
             create();
 
-    public final static ThreadLocal<HashSet<BaseComponent>> serializedComponents = new ThreadLocal<HashSet<BaseComponent>>();
+    public final static ThreadLocal<HashSet<AbstractBaseComponent>> serializedComponents = new ThreadLocal<HashSet<AbstractBaseComponent>>();
 
-    public static BaseComponent[] parse(String json)
+    public static AbstractBaseComponent[] parse(String json)
     {
         if ( json.startsWith( "[" ) )
         { //Array
-            return gson.fromJson( json, BaseComponent[].class );
+            return gson.fromJson( json, AbstractBaseComponent[].class );
         }
-        return new BaseComponent[]
+        return new AbstractBaseComponent[]
         {
-            gson.fromJson( json, BaseComponent.class )
+            gson.fromJson( json, AbstractBaseComponent.class )
         };
     }
 
-    public static String toString(BaseComponent component)
+    public static String toString(AbstractBaseComponent component)
     {
         return gson.toJson( component );
     }
 
-    public static String toString(BaseComponent... components)
+    public static String toString(AbstractBaseComponent... components)
     {
         return gson.toJson( new TextComponent( components ) );
     }
 
     @Override
-    public BaseComponent deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException
+    public AbstractBaseComponent deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException
     {
         if ( json.isJsonPrimitive() )
         {

--- a/chat/src/main/java/net/md_5/bungee/chat/TextComponentSerializer.java
+++ b/chat/src/main/java/net/md_5/bungee/chat/TextComponentSerializer.java
@@ -8,7 +8,7 @@ import com.google.gson.JsonParseException;
 import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
-import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.api.chat.AbstractBaseComponent;
 import net.md_5.bungee.api.chat.TextComponent;
 
 import java.lang.reflect.Type;
@@ -30,7 +30,7 @@ public class TextComponentSerializer extends BaseComponentSerializer implements 
     @Override
     public JsonElement serialize(TextComponent src, Type typeOfSrc, JsonSerializationContext context)
     {
-        List<BaseComponent> extra = src.getExtra();
+        List<AbstractBaseComponent> extra = src.getExtra();
         if ( !src.hasFormatting() && ( extra == null || extra.isEmpty() ) )
         {
             return new JsonPrimitive( src.getText() );

--- a/chat/src/main/java/net/md_5/bungee/chat/TranslatableComponentSerializer.java
+++ b/chat/src/main/java/net/md_5/bungee/chat/TranslatableComponentSerializer.java
@@ -7,7 +7,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
-import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.api.chat.AbstractBaseComponent;
 import net.md_5.bungee.api.chat.TranslatableComponent;
 
 import java.lang.reflect.Type;
@@ -25,7 +25,7 @@ public class TranslatableComponentSerializer extends BaseComponentSerializer imp
         component.setTranslate( object.get( "translate" ).getAsString() );
         if ( object.has( "with" ) )
         {
-            component.setWith( Arrays.asList( (BaseComponent[]) context.deserialize( object.get( "with" ), BaseComponent[].class ) ) );
+            component.setWith( Arrays.asList( (AbstractBaseComponent[]) context.deserialize( object.get( "with" ), AbstractBaseComponent[].class ) ) );
         }
         return component;
     }

--- a/config/src/main/java/net/md_5/bungee/config/AbstractConfigurationProvider.java
+++ b/config/src/main/java/net/md_5/bungee/config/AbstractConfigurationProvider.java
@@ -8,17 +8,17 @@ import java.io.Writer;
 import java.util.HashMap;
 import java.util.Map;
 
-public abstract class ConfigurationProvider
+public abstract class AbstractConfigurationProvider
 {
 
-    private static final Map<Class<? extends ConfigurationProvider>, ConfigurationProvider> providers = new HashMap<>();
+    private static final Map<Class<? extends AbstractConfigurationProvider>, AbstractConfigurationProvider> providers = new HashMap<>();
 
     static
     {
         providers.put( YamlConfiguration.class, new YamlConfiguration() );
     }
 
-    public static ConfigurationProvider getProvider(Class<? extends ConfigurationProvider> provider)
+    public static AbstractConfigurationProvider getProvider(Class<? extends AbstractConfigurationProvider> provider)
     {
         return providers.get( provider );
     }

--- a/config/src/main/java/net/md_5/bungee/config/YamlConfiguration.java
+++ b/config/src/main/java/net/md_5/bungee/config/YamlConfiguration.java
@@ -15,7 +15,7 @@ import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
 
 @NoArgsConstructor(access = AccessLevel.PACKAGE)
-public class YamlConfiguration extends ConfigurationProvider
+public class YamlConfiguration extends AbstractConfigurationProvider
 {
 
     private final ThreadLocal<Yaml> yaml = new ThreadLocal<Yaml>()

--- a/config/src/test/java/net/md_5/bungee/config/YamlConfigurationTest.java
+++ b/config/src/test/java/net/md_5/bungee/config/YamlConfigurationTest.java
@@ -47,16 +47,16 @@ public class YamlConfigurationTest
     @Test
     public void testConfig() throws Exception
     {
-        Configuration conf = ConfigurationProvider.getProvider( YamlConfiguration.class ).load( document );
+        Configuration conf = AbstractConfigurationProvider.getProvider( YamlConfiguration.class ).load( document );
         testSection( conf );
 
         StringWriter sw = new StringWriter();
-        ConfigurationProvider.getProvider( YamlConfiguration.class ).save( conf, sw );
+        AbstractConfigurationProvider.getProvider( YamlConfiguration.class ).save( conf, sw );
 
         // Check nulls were saved, see #1094
         Assert.assertFalse( "Config contains null", sw.toString().contains( "null" ) );
 
-        conf = ConfigurationProvider.getProvider( YamlConfiguration.class ).load( new StringReader( sw.toString() ) );
+        conf = AbstractConfigurationProvider.getProvider( YamlConfiguration.class ).load( new StringReader( sw.toString() ) );
         conf.set( "receipt", "Oz-Ware Purchase Invoice" ); // Add it back
         testSection( conf );
     }

--- a/module/cmd-alert/src/main/java/net/md_5/bungee/module/cmd/alert/CommandAlert.java
+++ b/module/cmd-alert/src/main/java/net/md_5/bungee/module/cmd/alert/CommandAlert.java
@@ -2,10 +2,10 @@ package net.md_5.bungee.module.cmd.alert;
 
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.CommandSender;
-import net.md_5.bungee.api.ProxyServer;
-import net.md_5.bungee.api.plugin.Command;
+import net.md_5.bungee.api.AbstractProxyServer;
+import net.md_5.bungee.api.plugin.AbstractCommand;
 
-public class CommandAlert extends Command
+public class CommandAlert extends AbstractCommand
 {
 
     public CommandAlert()
@@ -28,7 +28,7 @@ public class CommandAlert extends Command
                 args[0] = args[0].substring( 2, args[0].length() );
             } else
             {
-                builder.append( ProxyServer.getInstance().getTranslation( "alert" ) );
+                builder.append( AbstractProxyServer.getInstance().getTranslation( "alert" ) );
             }
 
             for ( String s : args )
@@ -39,7 +39,7 @@ public class CommandAlert extends Command
 
             String message = builder.substring( 0, builder.length() - 1 );
 
-            ProxyServer.getInstance().broadcast( message );
+            AbstractProxyServer.getInstance().broadcast( message );
         }
     }
 }

--- a/module/cmd-alert/src/main/java/net/md_5/bungee/module/cmd/alert/CommandAlertRaw.java
+++ b/module/cmd-alert/src/main/java/net/md_5/bungee/module/cmd/alert/CommandAlertRaw.java
@@ -3,14 +3,14 @@ package net.md_5.bungee.module.cmd.alert;
 import com.google.common.base.Joiner;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.CommandSender;
-import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.AbstractProxyServer;
 import net.md_5.bungee.api.chat.ComponentBuilder;
 import net.md_5.bungee.api.chat.HoverEvent;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
-import net.md_5.bungee.api.plugin.Command;
+import net.md_5.bungee.api.plugin.AbstractCommand;
 import net.md_5.bungee.chat.ComponentSerializer;
 
-public class CommandAlertRaw extends Command
+public class CommandAlertRaw extends AbstractCommand
 {
 
     public CommandAlertRaw()
@@ -30,7 +30,7 @@ public class CommandAlertRaw extends Command
 
             try
             {
-                ProxyServer.getInstance().broadcast( ComponentSerializer.parse( message ) );
+                AbstractProxyServer.getInstance().broadcast( ComponentSerializer.parse( message ) );
             } catch ( Exception e )
             {
                 Throwable error = e;

--- a/module/cmd-find/src/main/java/net/md_5/bungee/module/cmd/find/CommandFind.java
+++ b/module/cmd-find/src/main/java/net/md_5/bungee/module/cmd/find/CommandFind.java
@@ -2,11 +2,11 @@ package net.md_5.bungee.module.cmd.find;
 
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.CommandSender;
-import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.AbstractProxyServer;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
-import net.md_5.bungee.command.PlayerCommand;
+import net.md_5.bungee.command.AbstractPlayerCommand;
 
-public class CommandFind extends PlayerCommand
+public class CommandFind extends AbstractPlayerCommand
 {
 
     public CommandFind()
@@ -22,7 +22,7 @@ public class CommandFind extends PlayerCommand
             sender.sendMessage( ChatColor.RED + "Please follow this command by a user name" );
         } else
         {
-            ProxiedPlayer player = ProxyServer.getInstance().getPlayer( args[0] );
+            ProxiedPlayer player = AbstractProxyServer.getInstance().getPlayer( args[0] );
             if ( player == null || player.getServer() == null )
             {
                 sender.sendMessage( ChatColor.RED + "That user is not online" );

--- a/module/cmd-list/src/main/java/net/md_5/bungee/module/cmd/list/CommandList.java
+++ b/module/cmd-list/src/main/java/net/md_5/bungee/module/cmd/list/CommandList.java
@@ -6,15 +6,15 @@ import java.util.List;
 import net.md_5.bungee.Util;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.CommandSender;
-import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.AbstractProxyServer;
 import net.md_5.bungee.api.config.ServerInfo;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
-import net.md_5.bungee.api.plugin.Command;
+import net.md_5.bungee.api.plugin.AbstractCommand;
 
 /**
  * Command to list all players connected to the proxy.
  */
-public class CommandList extends Command
+public class CommandList extends AbstractCommand
 {
 
     public CommandList()
@@ -25,7 +25,7 @@ public class CommandList extends Command
     @Override
     public void execute(CommandSender sender, String[] args)
     {
-        for ( ServerInfo server : ProxyServer.getInstance().getServers().values() )
+        for ( ServerInfo server : AbstractProxyServer.getInstance().getServers().values() )
         {
             if ( !server.canAccess( sender ) )
             {
@@ -39,9 +39,9 @@ public class CommandList extends Command
             }
             Collections.sort( players, String.CASE_INSENSITIVE_ORDER );
 
-            sender.sendMessage( ProxyServer.getInstance().getTranslation( "command_list", server.getName(), server.getPlayers().size(), Util.format( players, ChatColor.RESET + ", " ) ) );
+            sender.sendMessage( AbstractProxyServer.getInstance().getTranslation( "command_list", server.getName(), server.getPlayers().size(), Util.format( players, ChatColor.RESET + ", " ) ) );
         }
 
-        sender.sendMessage( ProxyServer.getInstance().getTranslation( "total_players", ProxyServer.getInstance().getOnlineCount() ) );
+        sender.sendMessage( AbstractProxyServer.getInstance().getTranslation( "total_players", AbstractProxyServer.getInstance().getOnlineCount() ) );
     }
 }

--- a/module/cmd-send/src/main/java/net/md_5/bungee/module/cmd/send/CommandSend.java
+++ b/module/cmd-send/src/main/java/net/md_5/bungee/module/cmd/send/CommandSend.java
@@ -3,17 +3,16 @@ package net.md_5.bungee.module.cmd.send;
 import com.google.common.collect.ImmutableSet;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.CommandSender;
-import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.AbstractProxyServer;
 import net.md_5.bungee.api.config.ServerInfo;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
-import net.md_5.bungee.api.plugin.Command;
+import net.md_5.bungee.api.plugin.AbstractCommand;
 import net.md_5.bungee.api.plugin.TabExecutor;
 
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
-public class CommandSend extends Command implements TabExecutor
+public class CommandSend extends AbstractCommand implements TabExecutor
 {
 
     public CommandSend()
@@ -29,16 +28,16 @@ public class CommandSend extends Command implements TabExecutor
             sender.sendMessage( ChatColor.RED + "Not enough arguments, usage: /send <server|player|all|current> <target>" );
             return;
         }
-        ServerInfo target = ProxyServer.getInstance().getServerInfo( args[1] );
+        ServerInfo target = AbstractProxyServer.getInstance().getServerInfo( args[1] );
         if ( target == null )
         {
-            sender.sendMessage( ProxyServer.getInstance().getTranslation( "no_server" ) );
+            sender.sendMessage( AbstractProxyServer.getInstance().getTranslation( "no_server" ) );
             return;
         }
 
         if ( args[0].equalsIgnoreCase( "all" ) )
         {
-            for ( ProxiedPlayer p : ProxyServer.getInstance().getPlayers() )
+            for ( ProxiedPlayer p : AbstractProxyServer.getInstance().getPlayers() )
             {
                 summon( p, target, sender );
             }
@@ -57,7 +56,7 @@ public class CommandSend extends Command implements TabExecutor
         } else
         {
             // If we use a server name, send the entire server. This takes priority over players.
-            ServerInfo serverTarget = ProxyServer.getInstance().getServerInfo( args[0] );
+            ServerInfo serverTarget = AbstractProxyServer.getInstance().getServerInfo( args[0] );
             if ( serverTarget != null )
             {
                 for ( ProxiedPlayer p : serverTarget.getPlayers() )
@@ -66,7 +65,7 @@ public class CommandSend extends Command implements TabExecutor
                 }
             } else
             {
-                ProxiedPlayer player = ProxyServer.getInstance().getPlayer( args[0] );
+                ProxiedPlayer player = AbstractProxyServer.getInstance().getPlayer( args[0] );
                 if ( player == null )
                 {
                     sender.sendMessage( ChatColor.RED + "That player is not online" );
@@ -99,7 +98,7 @@ public class CommandSend extends Command implements TabExecutor
         if ( args.length == 1 )
         {
             String search = args[0].toLowerCase();
-            for ( ProxiedPlayer player : ProxyServer.getInstance().getPlayers() )
+            for ( ProxiedPlayer player : AbstractProxyServer.getInstance().getPlayers() )
             {
                 if ( player.getName().toLowerCase().startsWith( search ) )
                 {
@@ -117,7 +116,7 @@ public class CommandSend extends Command implements TabExecutor
         } else
         {
             String search = args[1].toLowerCase();
-            for ( String server : ProxyServer.getInstance().getServers().keySet() )
+            for ( String server : AbstractProxyServer.getInstance().getServers().keySet() )
             {
                 if ( server.toLowerCase().startsWith( search ) )
                 {

--- a/module/cmd-server/src/main/java/net/md_5/bungee/module/cmd/server/CommandServer.java
+++ b/module/cmd-server/src/main/java/net/md_5/bungee/module/cmd/server/CommandServer.java
@@ -6,10 +6,10 @@ import com.google.common.collect.Iterables;
 import java.util.Collections;
 import java.util.Map;
 import net.md_5.bungee.api.CommandSender;
-import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.AbstractProxyServer;
 import net.md_5.bungee.api.config.ServerInfo;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
-import net.md_5.bungee.api.plugin.Command;
+import net.md_5.bungee.api.plugin.AbstractCommand;
 import net.md_5.bungee.api.plugin.TabExecutor;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.chat.ClickEvent;
@@ -20,7 +20,7 @@ import net.md_5.bungee.api.chat.TextComponent;
 /**
  * Command to list and switch a player between available servers.
  */
-public class CommandServer extends Command implements TabExecutor
+public class CommandServer extends AbstractCommand implements TabExecutor
 {
 
     public CommandServer()
@@ -36,11 +36,11 @@ public class CommandServer extends Command implements TabExecutor
             return;
         }
         ProxiedPlayer player = (ProxiedPlayer) sender;
-        Map<String, ServerInfo> servers = ProxyServer.getInstance().getServers();
+        Map<String, ServerInfo> servers = AbstractProxyServer.getInstance().getServers();
         if ( args.length == 0 )
         {
-            player.sendMessage( ProxyServer.getInstance().getTranslation( "current_server", player.getServer().getInfo().getName() ) );
-            TextComponent serverList = new TextComponent( ProxyServer.getInstance().getTranslation( "server_list" ) );
+            player.sendMessage( AbstractProxyServer.getInstance().getTranslation( "current_server", player.getServer().getInfo().getName() ) );
+            TextComponent serverList = new TextComponent( AbstractProxyServer.getInstance().getTranslation( "server_list" ) );
             serverList.setColor( ChatColor.GOLD );
             boolean first = true;
             for ( ServerInfo server : servers.values() )
@@ -64,10 +64,10 @@ public class CommandServer extends Command implements TabExecutor
             ServerInfo server = servers.get( args[0] );
             if ( server == null )
             {
-                player.sendMessage( ProxyServer.getInstance().getTranslation( "no_server" ) );
+                player.sendMessage( AbstractProxyServer.getInstance().getTranslation( "no_server" ) );
             } else if ( !server.canAccess( player ) )
             {
-                player.sendMessage( ProxyServer.getInstance().getTranslation( "no_server_permission" ) );
+                player.sendMessage( AbstractProxyServer.getInstance().getTranslation( "no_server_permission" ) );
             } else
             {
                 player.connect( server );
@@ -78,7 +78,7 @@ public class CommandServer extends Command implements TabExecutor
     @Override
     public Iterable<String> onTabComplete(final CommandSender sender, final String[] args)
     {
-        return ( args.length > 1 ) ? Collections.EMPTY_LIST : Iterables.transform( Iterables.filter( ProxyServer.getInstance().getServers().values(), new Predicate<ServerInfo>()
+        return ( args.length > 1 ) ? Collections.EMPTY_LIST : Iterables.transform( Iterables.filter( AbstractProxyServer.getInstance().getServers().values(), new Predicate<ServerInfo>()
         {
             private final String lower = ( args.length == 0 ) ? "" : args[0].toLowerCase();
 

--- a/module/reconnect-yaml/src/main/java/net/md_5/bungee/module/reconnect/yaml/YamlReconnectHandler.java
+++ b/module/reconnect-yaml/src/main/java/net/md_5/bungee/module/reconnect/yaml/YamlReconnectHandler.java
@@ -11,7 +11,7 @@ import java.util.Map;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.logging.Level;
-import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.AbstractProxyServer;
 import net.md_5.bungee.api.config.ServerInfo;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.util.CaseInsensitiveMap;
@@ -43,7 +43,7 @@ public class YamlReconnectHandler extends AbstractReconnectHandler
         } catch ( Exception ex )
         {
             file.renameTo( new File( "locations.yml.old" ) );
-            ProxyServer.getInstance().getLogger().log( Level.WARNING, "Could not load reconnect locations, resetting them" );
+            AbstractProxyServer.getInstance().getLogger().log( Level.WARNING, "Could not load reconnect locations, resetting them" );
         }
 
         if ( data == null )
@@ -59,7 +59,7 @@ public class YamlReconnectHandler extends AbstractReconnectHandler
         lock.readLock().lock();
         try
         {
-            server = ProxyServer.getInstance().getServerInfo( data.get( key( player ) ) );
+            server = AbstractProxyServer.getInstance().getServerInfo( data.get( key( player ) ) );
         } finally
         {
             lock.readLock().unlock();
@@ -104,7 +104,7 @@ public class YamlReconnectHandler extends AbstractReconnectHandler
             yaml.dump( copy, wr );
         } catch ( IOException ex )
         {
-            ProxyServer.getInstance().getLogger().log( Level.WARNING, "Could not save reconnect locations", ex );
+            AbstractProxyServer.getInstance().getLogger().log( Level.WARNING, "Could not save reconnect locations", ex );
         }
     }
 

--- a/protocol/src/main/java/net/md_5/bungee/protocol/AbstractDefinedPacket.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/AbstractDefinedPacket.java
@@ -10,7 +10,7 @@ import lombok.RequiredArgsConstructor;
 import java.util.UUID;
 
 @RequiredArgsConstructor
-public abstract class DefinedPacket
+public abstract class AbstractDefinedPacket
 {
 
     public static void writeString(String s, ByteBuf buf)

--- a/protocol/src/main/java/net/md_5/bungee/protocol/MinecraftDecoder.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/MinecraftDecoder.java
@@ -25,9 +25,9 @@ public class MinecraftDecoder extends MessageToMessageDecoder<ByteBuf>
 
         try
         {
-            int packetId = DefinedPacket.readVarInt( in );
+            int packetId = AbstractDefinedPacket.readVarInt( in );
 
-            DefinedPacket packet = null;
+            AbstractDefinedPacket packet = null;
             if ( prot.hasPacket( packetId ) )
             {
                 packet = prot.createPacket( packetId );

--- a/protocol/src/main/java/net/md_5/bungee/protocol/MinecraftEncoder.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/MinecraftEncoder.java
@@ -7,7 +7,7 @@ import lombok.AllArgsConstructor;
 import lombok.Setter;
 
 @AllArgsConstructor
-public class MinecraftEncoder extends MessageToByteEncoder<DefinedPacket>
+public class MinecraftEncoder extends MessageToByteEncoder<AbstractDefinedPacket>
 {
 
     @Setter
@@ -17,10 +17,10 @@ public class MinecraftEncoder extends MessageToByteEncoder<DefinedPacket>
     private int protocolVersion;
 
     @Override
-    protected void encode(ChannelHandlerContext ctx, DefinedPacket msg, ByteBuf out) throws Exception
+    protected void encode(ChannelHandlerContext ctx, AbstractDefinedPacket msg, ByteBuf out) throws Exception
     {
         Protocol.DirectionData prot = ( server ) ? protocol.TO_CLIENT : protocol.TO_SERVER;
-        DefinedPacket.writeVarInt( prot.getId( msg.getClass() ), out );
+        AbstractDefinedPacket.writeVarInt( prot.getId( msg.getClass() ), out );
         msg.write( out, prot.getDirection(), protocolVersion );
     }
 }

--- a/protocol/src/main/java/net/md_5/bungee/protocol/PacketWrapper.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/PacketWrapper.java
@@ -8,7 +8,7 @@ import lombok.Setter;
 public class PacketWrapper
 {
 
-    public final DefinedPacket packet;
+    public final AbstractDefinedPacket packet;
     public final ByteBuf buf;
     @Setter
     private boolean released;

--- a/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java
@@ -116,16 +116,16 @@ public enum Protocol
 
         @Getter
         private final ProtocolConstants.Direction direction;
-        private final TObjectIntMap<Class<? extends DefinedPacket>> packetMap = new TObjectIntHashMap<>( MAX_PACKET_ID );
-        private final Class<? extends DefinedPacket>[] packetClasses = new Class[ MAX_PACKET_ID ];
-        private final Constructor<? extends DefinedPacket>[] packetConstructors = new Constructor[ MAX_PACKET_ID ];
+        private final TObjectIntMap<Class<? extends AbstractDefinedPacket>> packetMap = new TObjectIntHashMap<>( MAX_PACKET_ID );
+        private final Class<? extends AbstractDefinedPacket>[] packetClasses = new Class[ MAX_PACKET_ID ];
+        private final Constructor<? extends AbstractDefinedPacket>[] packetConstructors = new Constructor[ MAX_PACKET_ID ];
 
         public boolean hasPacket(int id)
         {
             return id < MAX_PACKET_ID && packetConstructors[id] != null;
         }
 
-        public final DefinedPacket createPacket(int id)
+        public final AbstractDefinedPacket createPacket(int id)
         {
             if ( id > MAX_PACKET_ID )
             {
@@ -145,7 +145,7 @@ public enum Protocol
             }
         }
 
-        protected final void registerPacket(int id, Class<? extends DefinedPacket> packetClass)
+        protected final void registerPacket(int id, Class<? extends AbstractDefinedPacket> packetClass)
         {
             try
             {
@@ -165,7 +165,7 @@ public enum Protocol
             packetConstructors[id] = null;
         }
 
-        final int getId(Class<? extends DefinedPacket> packet)
+        final int getId(Class<? extends AbstractDefinedPacket> packet)
         {
             Preconditions.checkArgument( packetMap.containsKey( packet ), "Cannot get ID for packet " + packet );
 

--- a/protocol/src/main/java/net/md_5/bungee/protocol/Varint21FrameDecoder.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/Varint21FrameDecoder.java
@@ -28,7 +28,7 @@ public class Varint21FrameDecoder extends ByteToMessageDecoder
             buf[i] = in.readByte();
             if ( buf[i] >= 0 )
             {
-                int length = DefinedPacket.readVarInt( Unpooled.wrappedBuffer( buf ) );
+                int length = AbstractDefinedPacket.readVarInt( Unpooled.wrappedBuffer( buf ) );
                 if ( length == 0 )
                 {
                     throw new CorruptedFrameException( "Empty Packet!" );

--- a/protocol/src/main/java/net/md_5/bungee/protocol/Varint21LengthFieldPrepender.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/Varint21LengthFieldPrepender.java
@@ -16,7 +16,7 @@ public class Varint21LengthFieldPrepender extends MessageToByteEncoder<ByteBuf>
         int headerLen = varintSize( bodyLen );
         out.ensureWritable( headerLen + bodyLen );
 
-        DefinedPacket.writeVarInt( bodyLen, out );
+        AbstractDefinedPacket.writeVarInt( bodyLen, out );
         out.writeBytes( msg );
     }
 

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/Chat.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/Chat.java
@@ -1,6 +1,6 @@
 package net.md_5.bungee.protocol.packet;
 
-import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.protocol.AbstractDefinedPacket;
 import io.netty.buffer.ByteBuf;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -13,7 +13,7 @@ import net.md_5.bungee.protocol.ProtocolConstants;
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = false)
-public class Chat extends DefinedPacket
+public class Chat extends AbstractDefinedPacket
 {
 
     private String message;

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/ClientSettings.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/ClientSettings.java
@@ -1,6 +1,6 @@
 package net.md_5.bungee.protocol.packet;
 
-import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.protocol.AbstractDefinedPacket;
 import io.netty.buffer.ByteBuf;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -13,7 +13,7 @@ import net.md_5.bungee.protocol.ProtocolConstants;
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = false)
-public class ClientSettings extends DefinedPacket
+public class ClientSettings extends AbstractDefinedPacket
 {
 
     private String locale;

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/ClientStatus.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/ClientStatus.java
@@ -1,6 +1,6 @@
 package net.md_5.bungee.protocol.packet;
 
-import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.protocol.AbstractDefinedPacket;
 import io.netty.buffer.ByteBuf;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -12,7 +12,7 @@ import net.md_5.bungee.protocol.AbstractPacketHandler;
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = false)
-public class ClientStatus extends DefinedPacket
+public class ClientStatus extends AbstractDefinedPacket
 {
 
     private byte payload;

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/EncryptionRequest.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/EncryptionRequest.java
@@ -6,14 +6,14 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import net.md_5.bungee.protocol.AbstractPacketHandler;
-import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.protocol.AbstractDefinedPacket;
 import net.md_5.bungee.protocol.ProtocolConstants;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = false)
-public class EncryptionRequest extends DefinedPacket
+public class EncryptionRequest extends AbstractDefinedPacket
 {
 
     private String serverId;

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/EncryptionResponse.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/EncryptionResponse.java
@@ -1,6 +1,6 @@
 package net.md_5.bungee.protocol.packet;
 
-import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.protocol.AbstractDefinedPacket;
 import io.netty.buffer.ByteBuf;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -13,7 +13,7 @@ import net.md_5.bungee.protocol.ProtocolConstants;
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = false)
-public class EncryptionResponse extends DefinedPacket
+public class EncryptionResponse extends AbstractDefinedPacket
 {
 
     private byte[] sharedSecret;

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/Handshake.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/Handshake.java
@@ -5,14 +5,14 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
-import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.protocol.AbstractDefinedPacket;
 import net.md_5.bungee.protocol.AbstractPacketHandler;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = false)
-public class Handshake extends DefinedPacket
+public class Handshake extends AbstractDefinedPacket
 {
 
     private int protocolVersion;

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/KeepAlive.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/KeepAlive.java
@@ -1,6 +1,6 @@
 package net.md_5.bungee.protocol.packet;
 
-import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.protocol.AbstractDefinedPacket;
 import io.netty.buffer.ByteBuf;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -13,7 +13,7 @@ import net.md_5.bungee.protocol.ProtocolConstants;
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = false)
-public class KeepAlive extends DefinedPacket
+public class KeepAlive extends AbstractDefinedPacket
 {
 
     private int randomId;

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/Kick.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/Kick.java
@@ -1,6 +1,6 @@
 package net.md_5.bungee.protocol.packet;
 
-import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.protocol.AbstractDefinedPacket;
 import io.netty.buffer.ByteBuf;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -12,7 +12,7 @@ import net.md_5.bungee.protocol.AbstractPacketHandler;
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = false)
-public class Kick extends DefinedPacket
+public class Kick extends AbstractDefinedPacket
 {
 
     private String message;

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/LegacyHandshake.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/LegacyHandshake.java
@@ -5,12 +5,12 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import net.md_5.bungee.protocol.AbstractPacketHandler;
-import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.protocol.AbstractDefinedPacket;
 
 @Data
 @NoArgsConstructor
 @EqualsAndHashCode(callSuper = false)
-public class LegacyHandshake extends DefinedPacket
+public class LegacyHandshake extends AbstractDefinedPacket
 {
 
     @Override

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/LegacyPing.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/LegacyPing.java
@@ -6,12 +6,12 @@ import lombok.RequiredArgsConstructor;
 
 import io.netty.buffer.ByteBuf;
 import net.md_5.bungee.protocol.AbstractPacketHandler;
-import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.protocol.AbstractDefinedPacket;
 
 @Data
 @RequiredArgsConstructor
 @EqualsAndHashCode(callSuper = false)
-public class LegacyPing extends DefinedPacket
+public class LegacyPing extends AbstractDefinedPacket
 {
 
     private final boolean v1_5;

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/Login.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/Login.java
@@ -1,6 +1,6 @@
 package net.md_5.bungee.protocol.packet;
 
-import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.protocol.AbstractDefinedPacket;
 import io.netty.buffer.ByteBuf;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -13,7 +13,7 @@ import net.md_5.bungee.protocol.ProtocolConstants;
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = false)
-public class Login extends DefinedPacket
+public class Login extends AbstractDefinedPacket
 {
 
     private int entityId;

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/LoginRequest.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/LoginRequest.java
@@ -10,13 +10,13 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import net.md_5.bungee.protocol.AbstractPacketHandler;
-import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.protocol.AbstractDefinedPacket;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = false)
-public class LoginRequest extends DefinedPacket
+public class LoginRequest extends AbstractDefinedPacket
 {
 
     private String data;

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/LoginSuccess.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/LoginSuccess.java
@@ -5,14 +5,14 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
-import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.protocol.AbstractDefinedPacket;
 import net.md_5.bungee.protocol.AbstractPacketHandler;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = false)
-public class LoginSuccess extends DefinedPacket
+public class LoginSuccess extends AbstractDefinedPacket
 {
 
     private String uuid;

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/PingPacket.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/PingPacket.java
@@ -6,13 +6,13 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import net.md_5.bungee.protocol.AbstractPacketHandler;
-import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.protocol.AbstractDefinedPacket;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = false)
-public class PingPacket extends DefinedPacket
+public class PingPacket extends AbstractDefinedPacket
 {
 
     private long time;

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/PlayerListHeaderFooter.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/PlayerListHeaderFooter.java
@@ -7,14 +7,14 @@ import lombok.NoArgsConstructor;
 
 import io.netty.buffer.ByteBuf;
 import net.md_5.bungee.protocol.AbstractPacketHandler;
-import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.protocol.AbstractDefinedPacket;
 import net.md_5.bungee.protocol.ProtocolConstants;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = false)
-public class PlayerListHeaderFooter extends DefinedPacket
+public class PlayerListHeaderFooter extends AbstractDefinedPacket
 {
 
     private String header;

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/PlayerListItem.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/PlayerListItem.java
@@ -1,6 +1,6 @@
 package net.md_5.bungee.protocol.packet;
 
-import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.protocol.AbstractDefinedPacket;
 import io.netty.buffer.ByteBuf;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -13,7 +13,7 @@ import java.util.UUID;
 @Data
 @NoArgsConstructor
 @EqualsAndHashCode(callSuper = false)
-public class PlayerListItem extends DefinedPacket
+public class PlayerListItem extends AbstractDefinedPacket
 {
 
     private Action action;
@@ -31,26 +31,26 @@ public class PlayerListItem extends DefinedPacket
             item.ping = buf.readShort();
         } else
         {
-            action = Action.values()[ DefinedPacket.readVarInt( buf )];
-            items = new Item[ DefinedPacket.readVarInt( buf ) ];
+            action = Action.values()[ AbstractDefinedPacket.readVarInt( buf )];
+            items = new Item[ AbstractDefinedPacket.readVarInt( buf ) ];
             for ( int i = 0; i < items.length; i++ )
             {
                 Item item = items[ i ] = new Item();
-                item.setUuid( DefinedPacket.readUUID( buf ) );
+                item.setUuid( AbstractDefinedPacket.readUUID( buf ) );
                 switch ( action )
                 {
                     case ADD_PLAYER:
-                        item.username = DefinedPacket.readString( buf );
-                        item.properties = new String[ DefinedPacket.readVarInt( buf ) ][];
+                        item.username = AbstractDefinedPacket.readString( buf );
+                        item.properties = new String[ AbstractDefinedPacket.readVarInt( buf ) ][];
                         for ( int j = 0; j < item.properties.length; j++ )
                         {
-                            String name = DefinedPacket.readString( buf );
-                            String value = DefinedPacket.readString( buf );
+                            String name = AbstractDefinedPacket.readString( buf );
+                            String value = AbstractDefinedPacket.readString( buf );
                             if ( buf.readBoolean() )
                             {
                                 item.properties[ j] = new String[]
                                 {
-                                    name, value, DefinedPacket.readString( buf )
+                                    name, value, AbstractDefinedPacket.readString( buf )
                                 };
                             } else
                             {
@@ -60,23 +60,23 @@ public class PlayerListItem extends DefinedPacket
                                 };
                             }
                         }
-                        item.gamemode = DefinedPacket.readVarInt( buf );
-                        item.ping = DefinedPacket.readVarInt( buf );
+                        item.gamemode = AbstractDefinedPacket.readVarInt( buf );
+                        item.ping = AbstractDefinedPacket.readVarInt( buf );
                         if ( buf.readBoolean() )
                         {
-                            item.displayName = DefinedPacket.readString( buf );
+                            item.displayName = AbstractDefinedPacket.readString( buf );
                         }
                         break;
                     case UPDATE_GAMEMODE:
-                        item.gamemode = DefinedPacket.readVarInt( buf );
+                        item.gamemode = AbstractDefinedPacket.readVarInt( buf );
                         break;
                     case UPDATE_LATENCY:
-                        item.ping = DefinedPacket.readVarInt( buf );
+                        item.ping = AbstractDefinedPacket.readVarInt( buf );
                         break;
                     case UPDATE_DISPLAY_NAME:
                         if ( buf.readBoolean() )
                         {
-                            item.displayName = DefinedPacket.readString( buf );
+                            item.displayName = AbstractDefinedPacket.readString( buf );
                         }
                 }
             }
@@ -94,48 +94,48 @@ public class PlayerListItem extends DefinedPacket
             buf.writeShort( item.ping );
         } else
         {
-            DefinedPacket.writeVarInt( action.ordinal(), buf );
-            DefinedPacket.writeVarInt( items.length, buf );
+            AbstractDefinedPacket.writeVarInt( action.ordinal(), buf );
+            AbstractDefinedPacket.writeVarInt( items.length, buf );
             for ( Item item : items )
             {
-                DefinedPacket.writeUUID( item.uuid, buf );
+                AbstractDefinedPacket.writeUUID( item.uuid, buf );
                 switch ( action )
                 {
                     case ADD_PLAYER:
-                        DefinedPacket.writeString( item.username, buf );
-                        DefinedPacket.writeVarInt( item.properties.length, buf );
+                        AbstractDefinedPacket.writeString( item.username, buf );
+                        AbstractDefinedPacket.writeVarInt( item.properties.length, buf );
                         for ( String[] prop : item.properties )
                         {
-                            DefinedPacket.writeString( prop[ 0], buf );
-                            DefinedPacket.writeString( prop[ 1], buf );
+                            AbstractDefinedPacket.writeString( prop[ 0], buf );
+                            AbstractDefinedPacket.writeString( prop[ 1], buf );
                             if ( prop.length >= 3 )
                             {
                                 buf.writeBoolean( true );
-                                DefinedPacket.writeString( prop[ 2], buf );
+                                AbstractDefinedPacket.writeString( prop[ 2], buf );
                             } else
                             {
                                 buf.writeBoolean( false );
                             }
                         }
-                        DefinedPacket.writeVarInt( item.gamemode, buf );
-                        DefinedPacket.writeVarInt( item.ping, buf );
+                        AbstractDefinedPacket.writeVarInt( item.gamemode, buf );
+                        AbstractDefinedPacket.writeVarInt( item.ping, buf );
                         buf.writeBoolean( item.displayName != null );
                         if ( item.displayName != null )
                         {
-                            DefinedPacket.writeString( item.displayName, buf );
+                            AbstractDefinedPacket.writeString( item.displayName, buf );
                         }
                         break;
                     case UPDATE_GAMEMODE:
-                        DefinedPacket.writeVarInt( item.gamemode, buf );
+                        AbstractDefinedPacket.writeVarInt( item.gamemode, buf );
                         break;
                     case UPDATE_LATENCY:
-                        DefinedPacket.writeVarInt( item.ping, buf );
+                        AbstractDefinedPacket.writeVarInt( item.ping, buf );
                         break;
                     case UPDATE_DISPLAY_NAME:
                         buf.writeBoolean( item.displayName != null );
                         if ( item.displayName != null )
                         {
-                            DefinedPacket.writeString( item.displayName, buf );
+                            AbstractDefinedPacket.writeString( item.displayName, buf );
                         }
                         break;
                 }

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/PluginMessage.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/PluginMessage.java
@@ -1,7 +1,7 @@
 package net.md_5.bungee.protocol.packet;
 
 import com.google.common.base.Preconditions;
-import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.protocol.AbstractDefinedPacket;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import java.io.ByteArrayInputStream;
@@ -19,7 +19,7 @@ import net.md_5.bungee.protocol.ProtocolConstants;
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = false)
-public class PluginMessage extends DefinedPacket
+public class PluginMessage extends AbstractDefinedPacket
 {
 
     private String tag;

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/Respawn.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/Respawn.java
@@ -1,6 +1,6 @@
 package net.md_5.bungee.protocol.packet;
 
-import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.protocol.AbstractDefinedPacket;
 import io.netty.buffer.ByteBuf;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -12,7 +12,7 @@ import net.md_5.bungee.protocol.AbstractPacketHandler;
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = false)
-public class Respawn extends DefinedPacket
+public class Respawn extends AbstractDefinedPacket
 {
 
     private int dimension;

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/ScoreboardDisplay.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/ScoreboardDisplay.java
@@ -1,6 +1,6 @@
 package net.md_5.bungee.protocol.packet;
 
-import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.protocol.AbstractDefinedPacket;
 import io.netty.buffer.ByteBuf;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -12,7 +12,7 @@ import net.md_5.bungee.protocol.AbstractPacketHandler;
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = false)
-public class ScoreboardDisplay extends DefinedPacket
+public class ScoreboardDisplay extends AbstractDefinedPacket
 {
 
     /**

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/ScoreboardObjective.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/ScoreboardObjective.java
@@ -1,6 +1,6 @@
 package net.md_5.bungee.protocol.packet;
 
-import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.protocol.AbstractDefinedPacket;
 import io.netty.buffer.ByteBuf;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -13,7 +13,7 @@ import net.md_5.bungee.protocol.ProtocolConstants;
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = false)
-public class ScoreboardObjective extends DefinedPacket
+public class ScoreboardObjective extends AbstractDefinedPacket
 {
 
     private String name;

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/ScoreboardScore.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/ScoreboardScore.java
@@ -1,6 +1,6 @@
 package net.md_5.bungee.protocol.packet;
 
-import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.protocol.AbstractDefinedPacket;
 import io.netty.buffer.ByteBuf;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -13,7 +13,7 @@ import net.md_5.bungee.protocol.ProtocolConstants;
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = false)
-public class ScoreboardScore extends DefinedPacket
+public class ScoreboardScore extends AbstractDefinedPacket
 {
 
     private String itemName;

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/SetCompression.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/SetCompression.java
@@ -6,14 +6,14 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import net.md_5.bungee.protocol.AbstractPacketHandler;
-import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.protocol.AbstractDefinedPacket;
 import net.md_5.bungee.protocol.ProtocolConstants;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = false)
-public class SetCompression extends DefinedPacket
+public class SetCompression extends AbstractDefinedPacket
 {
 
     private int threshold;
@@ -21,13 +21,13 @@ public class SetCompression extends DefinedPacket
     @Override
     public void read(ByteBuf buf, ProtocolConstants.Direction direction, int protocolVersion)
     {
-        threshold = DefinedPacket.readVarInt( buf );
+        threshold = AbstractDefinedPacket.readVarInt( buf );
     }
 
     @Override
     public void write(ByteBuf buf, ProtocolConstants.Direction direction, int protocolVersion)
     {
-        DefinedPacket.writeVarInt( threshold, buf );
+        AbstractDefinedPacket.writeVarInt( threshold, buf );
     }
 
     @Override

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/StatusRequest.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/StatusRequest.java
@@ -5,12 +5,12 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import net.md_5.bungee.protocol.AbstractPacketHandler;
-import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.protocol.AbstractDefinedPacket;
 
 @Data
 @NoArgsConstructor
 @EqualsAndHashCode(callSuper = false)
-public class StatusRequest extends DefinedPacket
+public class StatusRequest extends AbstractDefinedPacket
 {
 
     @Override

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/StatusResponse.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/StatusResponse.java
@@ -6,13 +6,13 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import net.md_5.bungee.protocol.AbstractPacketHandler;
-import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.protocol.AbstractDefinedPacket;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = false)
-public class StatusResponse extends DefinedPacket
+public class StatusResponse extends AbstractDefinedPacket
 {
 
     private String response;

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/TabCompleteRequest.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/TabCompleteRequest.java
@@ -1,6 +1,6 @@
 package net.md_5.bungee.protocol.packet;
 
-import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.protocol.AbstractDefinedPacket;
 import io.netty.buffer.ByteBuf;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -13,7 +13,7 @@ import net.md_5.bungee.protocol.ProtocolConstants;
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = false)
-public class TabCompleteRequest extends DefinedPacket
+public class TabCompleteRequest extends AbstractDefinedPacket
 {
 
     private String cursor;

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/TabCompleteResponse.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/TabCompleteResponse.java
@@ -1,6 +1,6 @@
 package net.md_5.bungee.protocol.packet;
 
-import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.protocol.AbstractDefinedPacket;
 import io.netty.buffer.ByteBuf;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -13,7 +13,7 @@ import net.md_5.bungee.protocol.AbstractPacketHandler;
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = false)
-public class TabCompleteResponse extends DefinedPacket
+public class TabCompleteResponse extends AbstractDefinedPacket
 {
 
     private List<String> commands;

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/Team.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/Team.java
@@ -1,6 +1,6 @@
 package net.md_5.bungee.protocol.packet;
 
-import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.protocol.AbstractDefinedPacket;
 import io.netty.buffer.ByteBuf;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -13,7 +13,7 @@ import net.md_5.bungee.protocol.ProtocolConstants;
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = false)
-public class Team extends DefinedPacket
+public class Team extends AbstractDefinedPacket
 {
 
     private String name;

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/Title.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/Title.java
@@ -6,13 +6,13 @@ import lombok.NoArgsConstructor;
 
 import io.netty.buffer.ByteBuf;
 import net.md_5.bungee.protocol.AbstractPacketHandler;
-import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.protocol.AbstractDefinedPacket;
 import net.md_5.bungee.protocol.ProtocolConstants;
 
 @Data
 @NoArgsConstructor
 @EqualsAndHashCode(callSuper = false)
-public class Title extends DefinedPacket
+public class Title extends AbstractDefinedPacket
 {
 
     private Action action;

--- a/proxy/src/main/java/Test.java
+++ b/proxy/src/main/java/Test.java
@@ -1,7 +1,7 @@
 
 import net.md_5.bungee.BungeeCord;
 import net.md_5.bungee.api.ChatColor;
-import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.AbstractProxyServer;
 import net.md_5.bungee.command.ConsoleCommandSender;
 
 /*
@@ -18,7 +18,7 @@ public class Test
     public static void main(String[] args) throws Exception
     {
         BungeeCord bungee = new BungeeCord();
-        ProxyServer.setInstance( bungee );
+        AbstractProxyServer.setInstance( bungee );
         bungee.getLogger().info( "Enabled BungeeCord version " + bungee.getVersion() );
         bungee.start();
 

--- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
@@ -11,8 +11,7 @@ import net.md_5.bungee.api.Favicon;
 import net.md_5.bungee.api.ServerPing;
 import net.md_5.bungee.api.Title;
 import net.md_5.bungee.module.ModuleManager;
-import com.google.common.io.ByteStreams;
-import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.api.chat.AbstractBaseComponent;
 import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.chat.ComponentSerializer;
 import net.md_5.bungee.log.BungeeLogger;
@@ -52,14 +51,13 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import jline.UnsupportedTerminal;
+
 import jline.console.ConsoleReader;
-import jline.internal.Log;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.Synchronized;
 import net.md_5.bungee.api.CommandSender;
-import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.AbstractProxyServer;
 import net.md_5.bungee.api.ReconnectHandler;
 import net.md_5.bungee.api.config.ConfigurationAdapter;
 import net.md_5.bungee.api.config.ListenerInfo;
@@ -73,7 +71,7 @@ import net.md_5.bungee.conf.YamlConfig;
 import net.md_5.bungee.forge.ForgeConstants;
 import net.md_5.bungee.log.LoggingOutputStream;
 import net.md_5.bungee.netty.PipelineUtils;
-import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.protocol.AbstractDefinedPacket;
 import net.md_5.bungee.protocol.Protocol;
 import net.md_5.bungee.protocol.ProtocolConstants;
 import net.md_5.bungee.protocol.packet.Chat;
@@ -85,7 +83,7 @@ import org.fusesource.jansi.AnsiConsole;
 /**
  * Main BungeeCord proxy class.
  */
-public class BungeeCord extends ProxyServer
+public class BungeeCord extends AbstractProxyServer
 {
 
     /**
@@ -162,7 +160,7 @@ public class BungeeCord extends ProxyServer
 
     public static BungeeCord getInstance()
     {
-        return (BungeeCord) ProxyServer.getInstance();
+        return (BungeeCord) AbstractProxyServer.getInstance();
     }
 
     @SuppressFBWarnings("DM_DEFAULT_ENCODING")
@@ -425,7 +423,7 @@ public class BungeeCord extends ProxyServer
      *
      * @param packet the packet to send
      */
-    public void broadcast(DefinedPacket packet)
+    public void broadcast(AbstractDefinedPacket packet)
     {
         connectionLock.readLock().lock();
         try
@@ -600,14 +598,14 @@ public class BungeeCord extends ProxyServer
     }
 
     @Override
-    public void broadcast(BaseComponent... message)
+    public void broadcast(AbstractBaseComponent... message)
     {
-        getConsole().sendMessage( BaseComponent.toLegacyText( message ) );
+        getConsole().sendMessage( AbstractBaseComponent.toLegacyText( message ) );
         broadcast( new Chat( ComponentSerializer.toString( message ) ) );
     }
 
     @Override
-    public void broadcast(BaseComponent message)
+    public void broadcast(AbstractBaseComponent message)
     {
         getConsole().sendMessage( message.toLegacyText() );
         broadcast( new Chat( ComponentSerializer.toString( message ) ) );

--- a/proxy/src/main/java/net/md_5/bungee/BungeeSecurityManager.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeSecurityManager.java
@@ -3,7 +3,7 @@ package net.md_5.bungee;
 import java.security.AccessControlException;
 import java.security.Permission;
 import java.util.logging.Level;
-import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.AbstractProxyServer;
 import net.md_5.bungee.api.scheduler.GroupedThreadFactory;
 
 public class BungeeSecurityManager extends SecurityManager
@@ -42,7 +42,7 @@ public class BungeeSecurityManager extends SecurityManager
                     throw ex;
                 }
 
-                ProxyServer.getInstance().getLogger().log( Level.WARNING, "Plugin performed restricted action, please inform them to use proper API methods: " + text, ex );
+                AbstractProxyServer.getInstance().getLogger().log( Level.WARNING, "Plugin performed restricted action, please inform them to use proper API methods: " + text, ex );
                 break;
             }
         }

--- a/proxy/src/main/java/net/md_5/bungee/BungeeServerInfo.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeServerInfo.java
@@ -19,7 +19,7 @@ import lombok.Synchronized;
 import lombok.ToString;
 import net.md_5.bungee.api.Callback;
 import net.md_5.bungee.api.CommandSender;
-import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.AbstractProxyServer;
 import net.md_5.bungee.api.ServerPing;
 import net.md_5.bungee.api.config.ServerInfo;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
@@ -27,7 +27,7 @@ import net.md_5.bungee.api.connection.Server;
 import net.md_5.bungee.connection.PingHandler;
 import net.md_5.bungee.netty.HandlerBoss;
 import net.md_5.bungee.netty.PipelineUtils;
-import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.protocol.AbstractDefinedPacket;
 import net.md_5.bungee.protocol.packet.PluginMessage;
 
 @RequiredArgsConstructor
@@ -48,7 +48,7 @@ public class BungeeServerInfo implements ServerInfo
     @Getter
     private final boolean restricted;
     @Getter
-    private final Queue<DefinedPacket> packetQueue = new LinkedList<>();
+    private final Queue<AbstractDefinedPacket> packetQueue = new LinkedList<>();
 
     @Synchronized("players")
     public void addPlayer(ProxiedPlayer player)
@@ -119,7 +119,7 @@ public class BungeeServerInfo implements ServerInfo
     @Override
     public void ping(final Callback<ServerPing> callback)
     {
-        ping( callback, ProxyServer.getInstance().getProtocolVersion() );
+        ping( callback, AbstractProxyServer.getInstance().getProtocolVersion() );
     }
 
     public void ping(final Callback<ServerPing> callback, final int protocolVersion)

--- a/proxy/src/main/java/net/md_5/bungee/BungeeTitle.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeTitle.java
@@ -1,10 +1,10 @@
 package net.md_5.bungee;
 
 import net.md_5.bungee.api.Title;
-import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.api.chat.AbstractBaseComponent;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.chat.ComponentSerializer;
-import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.protocol.AbstractDefinedPacket;
 import net.md_5.bungee.protocol.ProtocolConstants;
 import net.md_5.bungee.protocol.packet.Title.Action;
 
@@ -29,7 +29,7 @@ public class BungeeTitle implements Title
     }
 
     @Override
-    public Title title(BaseComponent text)
+    public Title title(AbstractBaseComponent text)
     {
         if ( title == null )
         {
@@ -41,7 +41,7 @@ public class BungeeTitle implements Title
     }
 
     @Override
-    public Title title(BaseComponent... text)
+    public Title title(AbstractBaseComponent... text)
     {
         if ( title == null )
         {
@@ -53,7 +53,7 @@ public class BungeeTitle implements Title
     }
 
     @Override
-    public Title subTitle(BaseComponent text)
+    public Title subTitle(AbstractBaseComponent text)
     {
         if ( subtitle == null )
         {
@@ -65,7 +65,7 @@ public class BungeeTitle implements Title
     }
 
     @Override
-    public Title subTitle(BaseComponent... text)
+    public Title subTitle(AbstractBaseComponent... text)
     {
         if ( subtitle == null )
         {
@@ -141,7 +141,7 @@ public class BungeeTitle implements Title
         return this;
     }
 
-    private static void sendPacket(ProxiedPlayer player, DefinedPacket packet)
+    private static void sendPacket(ProxiedPlayer player, AbstractDefinedPacket packet)
     {
         if ( packet != null )
         {

--- a/proxy/src/main/java/net/md_5/bungee/Metrics.java
+++ b/proxy/src/main/java/net/md_5/bungee/Metrics.java
@@ -9,7 +9,7 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLEncoder;
 import java.util.TimerTask;
-import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.AbstractProxyServer;
 
 public class Metrics extends TimerTask
 {
@@ -59,9 +59,9 @@ public class Metrics extends TimerTask
         // Construct the post data
         final StringBuilder data = new StringBuilder();
         data.append( encode( "guid" ) ).append( '=' ).append( encode( BungeeCord.getInstance().config.getUuid() ) );
-        encodeDataPair( data, "version", ProxyServer.getInstance().getVersion() );
+        encodeDataPair( data, "version", AbstractProxyServer.getInstance().getVersion() );
         encodeDataPair( data, "server", "0" );
-        encodeDataPair( data, "players", Integer.toString( ProxyServer.getInstance().getOnlineCount() ) );
+        encodeDataPair( data, "players", Integer.toString( AbstractProxyServer.getInstance().getOnlineCount() ) );
         encodeDataPair( data, "revision", String.valueOf( REVISION ) );
 
         // If we're pinging, append it

--- a/proxy/src/main/java/net/md_5/bungee/ServerConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/ServerConnection.java
@@ -6,10 +6,10 @@ import java.util.concurrent.TimeUnit;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
-import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.api.chat.AbstractBaseComponent;
 import net.md_5.bungee.api.connection.Server;
 import net.md_5.bungee.netty.ChannelWrapper;
-import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.protocol.AbstractDefinedPacket;
 import net.md_5.bungee.protocol.packet.PluginMessage;
 
 @RequiredArgsConstructor
@@ -29,7 +29,7 @@ public class ServerConnection implements Server
     private final Unsafe unsafe = new Unsafe()
     {
         @Override
-        public void sendPacket(DefinedPacket packet)
+        public void sendPacket(AbstractDefinedPacket packet)
         {
             ch.write( packet );
         }
@@ -48,7 +48,7 @@ public class ServerConnection implements Server
     }
 
     @Override
-    public void disconnect(BaseComponent... reason)
+    public void disconnect(AbstractBaseComponent... reason)
     {
         Preconditions.checkArgument( reason.length == 0, "Server cannot have disconnect reason" );
 
@@ -66,7 +66,7 @@ public class ServerConnection implements Server
     }
 
     @Override
-    public void disconnect(BaseComponent reason)
+    public void disconnect(AbstractBaseComponent reason)
     {
         disconnect();
     }

--- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
+++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
@@ -9,7 +9,7 @@ import java.util.Set;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import net.md_5.bungee.api.ChatColor;
-import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.AbstractProxyServer;
 import net.md_5.bungee.api.config.ServerInfo;
 import net.md_5.bungee.api.event.ServerConnectedEvent;
 import net.md_5.bungee.api.event.ServerKickEvent;
@@ -26,8 +26,8 @@ import net.md_5.bungee.forge.ForgeServerHandler;
 import net.md_5.bungee.forge.ForgeUtils;
 import net.md_5.bungee.netty.ChannelWrapper;
 import net.md_5.bungee.netty.HandlerBoss;
-import net.md_5.bungee.netty.PacketHandler;
-import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.netty.AbstractPacketHandler;
+import net.md_5.bungee.protocol.AbstractDefinedPacket;
 import net.md_5.bungee.protocol.MinecraftOutput;
 import net.md_5.bungee.protocol.Protocol;
 import net.md_5.bungee.protocol.ProtocolConstants;
@@ -42,10 +42,10 @@ import net.md_5.bungee.protocol.packet.ScoreboardObjective;
 import net.md_5.bungee.protocol.packet.SetCompression;
 
 @RequiredArgsConstructor
-public class ServerConnector extends PacketHandler
+public class ServerConnector extends AbstractPacketHandler
 {
 
-    private final ProxyServer bungee;
+    private final AbstractProxyServer bungee;
     private ChannelWrapper ch;
     private final UserConnection user;
     private final BungeeServerInfo target;
@@ -157,7 +157,7 @@ public class ServerConnector extends PacketHandler
         bungee.getPluginManager().callEvent( event );
 
         ch.write( BungeeCord.getInstance().registerChannels() );
-        Queue<DefinedPacket> packetQueue = target.getPacketQueue();
+        Queue<AbstractDefinedPacket> packetQueue = target.getPacketQueue();
         synchronized ( packetQueue )
         {
             while ( !packetQueue.isEmpty() )
@@ -196,12 +196,12 @@ public class ServerConnector extends PacketHandler
             if ( user.getPendingConnection().getVersion() < ProtocolConstants.MINECRAFT_1_8 )
             {
                 MinecraftOutput out = new MinecraftOutput();
-                out.writeStringUTF8WithoutLengthHeaderBecauseDinnerboneStuffedUpTheMCBrandPacket( ProxyServer.getInstance().getName() + " (" + ProxyServer.getInstance().getVersion() + ")" );
+                out.writeStringUTF8WithoutLengthHeaderBecauseDinnerboneStuffedUpTheMCBrandPacket( AbstractProxyServer.getInstance().getName() + " (" + AbstractProxyServer.getInstance().getVersion() + ")" );
                 user.unsafe().sendPacket( new PluginMessage( "MC|Brand", out.toArray(), handshakeHandler.isServerForge() ) );
             } else
             {
                 ByteBuf brand = ByteBufAllocator.DEFAULT.heapBuffer();
-                DefinedPacket.writeString( bungee.getName() + " (" + bungee.getVersion() + ")", brand );
+                AbstractDefinedPacket.writeString( bungee.getName() + " (" + bungee.getVersion() + ")", brand );
                 user.unsafe().sendPacket( new PluginMessage( "MC|Brand", brand.array().clone(), handshakeHandler.isServerForge() ) );
                 brand.release();
             }

--- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
@@ -25,9 +25,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import net.md_5.bungee.api.Callback;
 import net.md_5.bungee.api.ChatMessageType;
-import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.AbstractProxyServer;
 import net.md_5.bungee.api.Title;
-import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.api.chat.AbstractBaseComponent;
 import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.api.config.ServerInfo;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
@@ -36,14 +36,14 @@ import net.md_5.bungee.api.event.ServerConnectEvent;
 import net.md_5.bungee.api.score.Scoreboard;
 import net.md_5.bungee.chat.ComponentSerializer;
 import net.md_5.bungee.connection.InitialHandler;
-import net.md_5.bungee.entitymap.EntityMap;
+import net.md_5.bungee.entitymap.AbstractEntityMap;
 import net.md_5.bungee.forge.ForgeClientHandler;
 import net.md_5.bungee.forge.ForgeConstants;
 import net.md_5.bungee.forge.ForgeServerHandler;
 import net.md_5.bungee.netty.ChannelWrapper;
 import net.md_5.bungee.netty.HandlerBoss;
 import net.md_5.bungee.netty.PipelineUtils;
-import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.protocol.AbstractDefinedPacket;
 import net.md_5.bungee.protocol.MinecraftDecoder;
 import net.md_5.bungee.protocol.MinecraftEncoder;
 import net.md_5.bungee.protocol.PacketWrapper;
@@ -56,7 +56,7 @@ import net.md_5.bungee.protocol.packet.PlayerListHeaderFooter;
 import net.md_5.bungee.protocol.packet.PluginMessage;
 import net.md_5.bungee.protocol.packet.SetCompression;
 import net.md_5.bungee.tab.ServerUnique;
-import net.md_5.bungee.tab.TabList;
+import net.md_5.bungee.tab.AbstractTabList;
 import net.md_5.bungee.util.CaseInsensitiveSet;
 
 @RequiredArgsConstructor
@@ -65,7 +65,7 @@ public final class UserConnection implements ProxiedPlayer
 
     /*========================================================================*/
     @NonNull
-    private final ProxyServer bungee;
+    private final AbstractProxyServer bungee;
     @NonNull
     private final ChannelWrapper ch;
     @Getter
@@ -96,7 +96,7 @@ public final class UserConnection implements ProxiedPlayer
     @Setter
     private ServerInfo reconnectServer;
     @Getter
-    private TabList tabListHandler;
+    private AbstractTabList tabListHandler;
     @Getter
     @Setter
     private int gamemode;
@@ -120,7 +120,7 @@ public final class UserConnection implements ProxiedPlayer
     @Getter
     private String displayName;
     @Getter
-    private EntityMap entityRewrite;
+    private AbstractEntityMap entityRewrite;
     private Locale locale;
     /*========================================================================*/
     @Getter
@@ -133,7 +133,7 @@ public final class UserConnection implements ProxiedPlayer
     private final Unsafe unsafe = new Unsafe()
     {
         @Override
-        public void sendPacket(DefinedPacket packet)
+        public void sendPacket(AbstractDefinedPacket packet)
         {
             ch.write( packet );
         }
@@ -141,7 +141,7 @@ public final class UserConnection implements ProxiedPlayer
 
     public void init()
     {
-        this.entityRewrite = EntityMap.getEntityMap( getPendingConnection().getVersion() );
+        this.entityRewrite = AbstractEntityMap.getEntityMap( getPendingConnection().getVersion() );
 
         this.displayName = name;
 
@@ -269,7 +269,7 @@ public final class UserConnection implements ProxiedPlayer
                     future.channel().close();
                     pendingConnects.remove( target );
 
-                    ServerInfo def = ProxyServer.getInstance().getServers().get( getPendingConnection().getListener().getFallbackServer() );
+                    ServerInfo def = AbstractProxyServer.getInstance().getServers().get( getPendingConnection().getListener().getFallbackServer() );
                     if ( retry && target != def && ( getServer() == null || def != getServer().getInfo() ) )
                     {
                         sendMessage( bungee.getTranslation( "fallback_lobby" ) );
@@ -308,24 +308,24 @@ public final class UserConnection implements ProxiedPlayer
     }
 
     @Override
-    public void disconnect(BaseComponent... reason)
+    public void disconnect(AbstractBaseComponent... reason)
     {
         disconnect0( reason );
     }
 
     @Override
-    public void disconnect(BaseComponent reason)
+    public void disconnect(AbstractBaseComponent reason)
     {
         disconnect0( reason );
     }
 
-    public void disconnect0(final BaseComponent... reason)
+    public void disconnect0(final AbstractBaseComponent... reason)
     {
         if ( !ch.isClosed() )
         {
             bungee.getLogger().log( Level.INFO, "[{0}] disconnected with: {1}", new Object[]
             {
-                getName(), BaseComponent.toLegacyText( reason )
+                getName(), AbstractBaseComponent.toLegacyText( reason )
             } );
 
             // Why do we have to delay this you might ask? Well the simple reason is MOJANG.
@@ -374,13 +374,13 @@ public final class UserConnection implements ProxiedPlayer
     }
 
     @Override
-    public void sendMessage(BaseComponent... message)
+    public void sendMessage(AbstractBaseComponent... message)
     {
         sendMessage( ChatMessageType.CHAT, message );
     }
 
     @Override
-    public void sendMessage(BaseComponent message)
+    public void sendMessage(AbstractBaseComponent message)
     {
         sendMessage( ChatMessageType.CHAT, message );
     }
@@ -391,7 +391,7 @@ public final class UserConnection implements ProxiedPlayer
     }
 
     @Override
-    public void sendMessage(ChatMessageType position, BaseComponent... message)
+    public void sendMessage(ChatMessageType position, AbstractBaseComponent... message)
     {
         // Action bar doesn't display the new JSON formattings, legacy works - send it using this for now
         if ( position == ChatMessageType.ACTION_BAR && pendingConnection.getVersion() >= ProtocolConstants.MINECRAFT_1_8 )
@@ -404,7 +404,7 @@ public final class UserConnection implements ProxiedPlayer
     }
 
     @Override
-    public void sendMessage(ChatMessageType position, BaseComponent message)
+    public void sendMessage(ChatMessageType position, AbstractBaseComponent message)
     {
         // Action bar doesn't display the new JSON formattings, legacy works - send it using this for now
         if ( position == ChatMessageType.ACTION_BAR && pendingConnection.getVersion() >= ProtocolConstants.MINECRAFT_1_8 )
@@ -542,7 +542,7 @@ public final class UserConnection implements ProxiedPlayer
     private static final String EMPTY_TEXT = ComponentSerializer.toString( new TextComponent( "" ) );
 
     @Override
-    public void setTabHeader(BaseComponent header, BaseComponent footer)
+    public void setTabHeader(AbstractBaseComponent header, AbstractBaseComponent footer)
     {
         if ( pendingConnection.getVersion() >= ProtocolConstants.MINECRAFT_1_8 )
         {
@@ -554,7 +554,7 @@ public final class UserConnection implements ProxiedPlayer
     }
 
     @Override
-    public void setTabHeader(BaseComponent[] header, BaseComponent[] footer)
+    public void setTabHeader(AbstractBaseComponent[] header, AbstractBaseComponent[] footer)
     {
         if ( pendingConnection.getVersion() >= ProtocolConstants.MINECRAFT_1_8 )
         {
@@ -569,7 +569,7 @@ public final class UserConnection implements ProxiedPlayer
     public void resetTabHeader()
     {
         // Mojang did not add a way to remove the header / footer completely, we can only set it to empty
-        setTabHeader( (BaseComponent) null, null );
+        setTabHeader( (AbstractBaseComponent) null, null );
     }
 
     @Override

--- a/proxy/src/main/java/net/md_5/bungee/command/CommandBungee.java
+++ b/proxy/src/main/java/net/md_5/bungee/command/CommandBungee.java
@@ -2,10 +2,10 @@ package net.md_5.bungee.command;
 
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.CommandSender;
-import net.md_5.bungee.api.ProxyServer;
-import net.md_5.bungee.api.plugin.Command;
+import net.md_5.bungee.api.AbstractProxyServer;
+import net.md_5.bungee.api.plugin.AbstractCommand;
 
-public class CommandBungee extends Command
+public class CommandBungee extends AbstractCommand
 {
 
     public CommandBungee()
@@ -16,6 +16,6 @@ public class CommandBungee extends Command
     @Override
     public void execute(CommandSender sender, String[] args)
     {
-        sender.sendMessage( ChatColor.BLUE + "This server is running BungeeCord version " + ProxyServer.getInstance().getVersion() + " by md_5" );
+        sender.sendMessage( ChatColor.BLUE + "This server is running BungeeCord version " + AbstractProxyServer.getInstance().getVersion() + " by md_5" );
     }
 }

--- a/proxy/src/main/java/net/md_5/bungee/command/CommandEnd.java
+++ b/proxy/src/main/java/net/md_5/bungee/command/CommandEnd.java
@@ -3,13 +3,13 @@ package net.md_5.bungee.command;
 import com.google.common.base.Joiner;
 import net.md_5.bungee.BungeeCord;
 import net.md_5.bungee.api.CommandSender;
-import net.md_5.bungee.api.plugin.Command;
+import net.md_5.bungee.api.plugin.AbstractCommand;
 
 /**
  * Command to terminate the proxy instance. May only be used by the console by
  * default.
  */
-public class CommandEnd extends Command
+public class CommandEnd extends AbstractCommand
 {
 
     public CommandEnd()

--- a/proxy/src/main/java/net/md_5/bungee/command/CommandIP.java
+++ b/proxy/src/main/java/net/md_5/bungee/command/CommandIP.java
@@ -2,10 +2,10 @@ package net.md_5.bungee.command;
 
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.CommandSender;
-import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.AbstractProxyServer;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 
-public class CommandIP extends PlayerCommand
+public class CommandIP extends AbstractPlayerCommand
 {
 
     public CommandIP()
@@ -21,7 +21,7 @@ public class CommandIP extends PlayerCommand
             sender.sendMessage( ChatColor.RED + "Please follow this command by a user name" );
             return;
         }
-        ProxiedPlayer user = ProxyServer.getInstance().getPlayer( args[0] );
+        ProxiedPlayer user = AbstractProxyServer.getInstance().getPlayer( args[0] );
         if ( user == null )
         {
             sender.sendMessage( ChatColor.RED + "That user is not online" );

--- a/proxy/src/main/java/net/md_5/bungee/command/CommandPerms.java
+++ b/proxy/src/main/java/net/md_5/bungee/command/CommandPerms.java
@@ -5,10 +5,10 @@ import java.util.Set;
 import net.md_5.bungee.Util;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.CommandSender;
-import net.md_5.bungee.api.ProxyServer;
-import net.md_5.bungee.api.plugin.Command;
+import net.md_5.bungee.api.AbstractProxyServer;
+import net.md_5.bungee.api.plugin.AbstractCommand;
 
-public class CommandPerms extends Command
+public class CommandPerms extends AbstractCommand
 {
 
     public CommandPerms()
@@ -22,7 +22,7 @@ public class CommandPerms extends Command
         Set<String> permissions = new HashSet<>();
         for ( String group : sender.getGroups() )
         {
-            permissions.addAll( ProxyServer.getInstance().getConfigurationAdapter().getPermissions( group ) );
+            permissions.addAll( AbstractProxyServer.getInstance().getConfigurationAdapter().getPermissions( group ) );
         }
         sender.sendMessage( ChatColor.GOLD + "You have the following groups: " + Util.csv( sender.getGroups() ) );
 

--- a/proxy/src/main/java/net/md_5/bungee/command/CommandReload.java
+++ b/proxy/src/main/java/net/md_5/bungee/command/CommandReload.java
@@ -3,10 +3,10 @@ package net.md_5.bungee.command;
 import net.md_5.bungee.BungeeCord;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.CommandSender;
-import net.md_5.bungee.api.plugin.Command;
+import net.md_5.bungee.api.plugin.AbstractCommand;
 import net.md_5.bungee.api.event.ProxyReloadEvent;
 
-public class CommandReload extends Command
+public class CommandReload extends AbstractCommand
 {
 
     public CommandReload()

--- a/proxy/src/main/java/net/md_5/bungee/command/ConsoleCommandSender.java
+++ b/proxy/src/main/java/net/md_5/bungee/command/ConsoleCommandSender.java
@@ -4,8 +4,8 @@ import java.util.Collection;
 import java.util.Collections;
 import lombok.Getter;
 import net.md_5.bungee.api.CommandSender;
-import net.md_5.bungee.api.ProxyServer;
-import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.api.AbstractProxyServer;
+import net.md_5.bungee.api.chat.AbstractBaseComponent;
 
 /**
  * Command sender representing the proxy console.
@@ -23,7 +23,7 @@ public class ConsoleCommandSender implements CommandSender
     @Override
     public void sendMessage(String message)
     {
-        ProxyServer.getInstance().getLogger().info( message );
+        AbstractProxyServer.getInstance().getLogger().info( message );
     }
 
     @Override
@@ -36,13 +36,13 @@ public class ConsoleCommandSender implements CommandSender
     }
 
     @Override
-    public void sendMessage(BaseComponent... message)
+    public void sendMessage(AbstractBaseComponent... message)
     {
-        sendMessage( BaseComponent.toLegacyText( message ) );
+        sendMessage( AbstractBaseComponent.toLegacyText( message ) );
     }
 
     @Override
-    public void sendMessage(BaseComponent message)
+    public void sendMessage(AbstractBaseComponent message)
     {
         sendMessage( message.toLegacyText() );
     }

--- a/proxy/src/main/java/net/md_5/bungee/compress/PacketCompressor.java
+++ b/proxy/src/main/java/net/md_5/bungee/compress/PacketCompressor.java
@@ -6,7 +6,7 @@ import io.netty.handler.codec.MessageToByteEncoder;
 import java.util.zip.Deflater;
 import lombok.Setter;
 import net.md_5.bungee.jni.zlib.BungeeZlib;
-import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.protocol.AbstractDefinedPacket;
 
 public class PacketCompressor extends MessageToByteEncoder<ByteBuf>
 {
@@ -33,11 +33,11 @@ public class PacketCompressor extends MessageToByteEncoder<ByteBuf>
         int origSize = msg.readableBytes();
         if ( origSize < threshold )
         {
-            DefinedPacket.writeVarInt( 0, out );
+            AbstractDefinedPacket.writeVarInt( 0, out );
             out.writeBytes( msg );
         } else
         {
-            DefinedPacket.writeVarInt( origSize, out );
+            AbstractDefinedPacket.writeVarInt( origSize, out );
 
             zlib.process( msg, out );
         }

--- a/proxy/src/main/java/net/md_5/bungee/compress/PacketDecompressor.java
+++ b/proxy/src/main/java/net/md_5/bungee/compress/PacketDecompressor.java
@@ -5,7 +5,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.ByteToMessageDecoder;
 import java.util.List;
 import net.md_5.bungee.jni.zlib.BungeeZlib;
-import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.protocol.AbstractDefinedPacket;
 
 public class PacketDecompressor extends ByteToMessageDecoder
 {
@@ -32,7 +32,7 @@ public class PacketDecompressor extends ByteToMessageDecoder
             return;
         }
 
-        int size = DefinedPacket.readVarInt( in );
+        int size = AbstractDefinedPacket.readVarInt( in );
         if ( size == 0 )
         {
             out.add( in.copy() );

--- a/proxy/src/main/java/net/md_5/bungee/conf/Configuration.java
+++ b/proxy/src/main/java/net/md_5/bungee/conf/Configuration.java
@@ -13,7 +13,7 @@ import javax.imageio.ImageIO;
 import lombok.Getter;
 import net.md_5.bungee.api.Favicon;
 import net.md_5.bungee.api.ProxyConfig;
-import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.AbstractProxyServer;
 import net.md_5.bungee.api.config.ConfigurationAdapter;
 import net.md_5.bungee.api.config.ListenerInfo;
 import net.md_5.bungee.api.config.ServerInfo;
@@ -60,7 +60,7 @@ public class Configuration implements ProxyConfig
 
     public void load()
     {
-        ConfigurationAdapter adapter = ProxyServer.getInstance().getConfigurationAdapter();
+        ConfigurationAdapter adapter = AbstractProxyServer.getInstance().getConfigurationAdapter();
         adapter.load();
 
         File fav = new File( "server-icon.png" );
@@ -71,7 +71,7 @@ public class Configuration implements ProxyConfig
                 favicon = Favicon.create( ImageIO.read( fav ) );
             } catch ( IOException | IllegalArgumentException ex )
             {
-                ProxyServer.getInstance().getLogger().log( Level.WARNING, "Could not load server icon", ex );
+                AbstractProxyServer.getInstance().getLogger().log( Level.WARNING, "Could not load server icon", ex );
             }
         }
 
@@ -121,7 +121,7 @@ public class Configuration implements ProxyConfig
             {
                 if ( !servers.containsKey( server ) )
                 {
-                    ProxyServer.getInstance().getLogger().log( Level.WARNING, "Forced host server {0} is not defined", server );
+                    AbstractProxyServer.getInstance().getLogger().log( Level.WARNING, "Forced host server {0} is not defined", server );
                 }
             }
         }

--- a/proxy/src/main/java/net/md_5/bungee/conf/YamlConfig.java
+++ b/proxy/src/main/java/net/md_5/bungee/conf/YamlConfig.java
@@ -18,7 +18,7 @@ import java.util.logging.Level;
 import lombok.RequiredArgsConstructor;
 import net.md_5.bungee.Util;
 import net.md_5.bungee.api.ChatColor;
-import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.AbstractProxyServer;
 import net.md_5.bungee.api.config.ConfigurationAdapter;
 import net.md_5.bungee.api.config.ListenerInfo;
 import net.md_5.bungee.api.config.ServerInfo;
@@ -136,7 +136,7 @@ public class YamlConfig implements ConfigurationAdapter
             }
         } catch ( IOException ex )
         {
-            ProxyServer.getInstance().getLogger().log( Level.WARNING, "Could not save config", ex );
+            AbstractProxyServer.getInstance().getLogger().log( Level.WARNING, "Could not save config", ex );
         }
     }
 
@@ -173,7 +173,7 @@ public class YamlConfig implements ConfigurationAdapter
             String motd = ChatColor.translateAlternateColorCodes( '&', get( "motd", "&1Just another BungeeCord - Forced Host", val ) );
             boolean restricted = get( "restricted", false, val );
             InetSocketAddress address = Util.getAddr( addr );
-            ServerInfo info = ProxyServer.getInstance().constructServerInfo( name, address, motd, restricted );
+            ServerInfo info = AbstractProxyServer.getInstance().constructServerInfo( name, address, motd, restricted );
             ret.put( name, info );
         }
 

--- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
@@ -14,7 +14,7 @@ import net.md_5.bungee.api.event.ServerDisconnectEvent;
 import net.md_5.bungee.api.event.TabCompleteResponseEvent;
 import net.md_5.bungee.UserConnection;
 import net.md_5.bungee.Util;
-import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.AbstractProxyServer;
 import net.md_5.bungee.api.config.ServerInfo;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.event.PluginMessageEvent;
@@ -26,8 +26,8 @@ import net.md_5.bungee.api.score.Scoreboard;
 import net.md_5.bungee.api.score.Team;
 import net.md_5.bungee.chat.ComponentSerializer;
 import net.md_5.bungee.netty.ChannelWrapper;
-import net.md_5.bungee.netty.PacketHandler;
-import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.netty.AbstractPacketHandler;
+import net.md_5.bungee.protocol.AbstractDefinedPacket;
 import net.md_5.bungee.protocol.PacketWrapper;
 import net.md_5.bungee.protocol.ProtocolConstants;
 import net.md_5.bungee.protocol.packet.KeepAlive;
@@ -39,13 +39,13 @@ import net.md_5.bungee.protocol.packet.PluginMessage;
 import net.md_5.bungee.protocol.packet.Kick;
 import net.md_5.bungee.protocol.packet.SetCompression;
 import net.md_5.bungee.protocol.packet.TabCompleteResponse;
-import net.md_5.bungee.tab.TabList;
+import net.md_5.bungee.tab.AbstractTabList;
 
 @RequiredArgsConstructor
-public class DownstreamBridge extends PacketHandler
+public class DownstreamBridge extends AbstractPacketHandler
 {
 
-    private final ProxyServer bungee;
+    private final AbstractProxyServer bungee;
     private final UserConnection con;
     private final ServerConnection server;
 
@@ -109,7 +109,7 @@ public class DownstreamBridge extends PacketHandler
     @Override
     public void handle(PlayerListItem playerList) throws Exception
     {
-        con.getTabListHandler().onUpdate( TabList.rewrite( playerList ) );
+        con.getTabListHandler().onUpdate( AbstractTabList.rewrite( playerList ) );
         throw CancelSendSignal.INSTANCE; // Always throw because of profile rewriting
     }
 
@@ -231,10 +231,10 @@ public class DownstreamBridge extends PacketHandler
                 try
                 {
                     ByteBuf brand = Unpooled.wrappedBuffer( pluginMessage.getData() );
-                    String serverBrand = DefinedPacket.readString( brand );
+                    String serverBrand = AbstractDefinedPacket.readString( brand );
                     brand.release();
                     brand = ByteBufAllocator.DEFAULT.heapBuffer();
-                    DefinedPacket.writeString( bungee.getName() + " (" + bungee.getVersion() + ")" + " <- " + serverBrand, brand );
+                    AbstractDefinedPacket.writeString( bungee.getName() + " (" + bungee.getVersion() + ")" + " <- " + serverBrand, brand );
                     pluginMessage.setData( brand.array().clone() );
                     brand.release();
                 } catch ( Exception ignored )

--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -6,7 +6,6 @@ import java.math.BigInteger;
 import java.net.InetSocketAddress;
 import java.net.URLEncoder;
 import java.security.MessageDigest;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.logging.Level;
@@ -20,9 +19,9 @@ import net.md_5.bungee.*;
 import net.md_5.bungee.api.Callback;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.Favicon;
-import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.AbstractProxyServer;
 import net.md_5.bungee.api.ServerPing;
-import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.api.chat.AbstractBaseComponent;
 import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.api.config.ListenerInfo;
 import net.md_5.bungee.api.config.ServerInfo;
@@ -35,11 +34,11 @@ import net.md_5.bungee.chat.ComponentSerializer;
 import net.md_5.bungee.http.HttpClient;
 import net.md_5.bungee.netty.HandlerBoss;
 import net.md_5.bungee.netty.ChannelWrapper;
-import net.md_5.bungee.netty.PacketHandler;
+import net.md_5.bungee.netty.AbstractPacketHandler;
 import net.md_5.bungee.netty.PipelineUtils;
 import net.md_5.bungee.netty.cipher.CipherDecoder;
 import net.md_5.bungee.netty.cipher.CipherEncoder;
-import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.protocol.AbstractDefinedPacket;
 import net.md_5.bungee.protocol.packet.Handshake;
 import net.md_5.bungee.protocol.packet.PluginMessage;
 import net.md_5.bungee.protocol.packet.EncryptionResponse;
@@ -61,10 +60,10 @@ import net.md_5.bungee.protocol.packet.StatusResponse;
 import net.md_5.bungee.util.BoundedArrayList;
 
 @RequiredArgsConstructor
-public class InitialHandler extends PacketHandler implements PendingConnection
+public class InitialHandler extends AbstractPacketHandler implements PendingConnection
 {
 
-    private final ProxyServer bungee;
+    private final AbstractProxyServer bungee;
     private ChannelWrapper ch;
     @Getter
     private final ListenerInfo listener;
@@ -79,7 +78,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
     private final Unsafe unsafe = new Unsafe()
     {
         @Override
-        public void sendPacket(DefinedPacket packet)
+        public void sendPacket(AbstractDefinedPacket packet)
         {
             ch.write( packet );
         }
@@ -522,7 +521,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
     }
 
     @Override
-    public void disconnect(final BaseComponent... reason)
+    public void disconnect(final AbstractBaseComponent... reason)
     {
         if ( !ch.isClosed() )
         {
@@ -548,9 +547,9 @@ public class InitialHandler extends PacketHandler implements PendingConnection
     }
 
     @Override
-    public void disconnect(BaseComponent reason)
+    public void disconnect(AbstractBaseComponent reason)
     {
-        disconnect( new BaseComponent[]
+        disconnect( new AbstractBaseComponent[]
         {
             reason
         } );

--- a/proxy/src/main/java/net/md_5/bungee/connection/PingHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/PingHandler.java
@@ -5,11 +5,11 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.RequiredArgsConstructor;
 import net.md_5.bungee.BungeeCord;
 import net.md_5.bungee.api.Callback;
-import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.AbstractProxyServer;
 import net.md_5.bungee.api.ServerPing;
 import net.md_5.bungee.api.config.ServerInfo;
 import net.md_5.bungee.netty.ChannelWrapper;
-import net.md_5.bungee.netty.PacketHandler;
+import net.md_5.bungee.netty.AbstractPacketHandler;
 import net.md_5.bungee.netty.PipelineUtils;
 import net.md_5.bungee.protocol.MinecraftDecoder;
 import net.md_5.bungee.protocol.MinecraftEncoder;
@@ -20,7 +20,7 @@ import net.md_5.bungee.protocol.packet.StatusRequest;
 import net.md_5.bungee.protocol.packet.StatusResponse;
 
 @RequiredArgsConstructor
-public class PingHandler extends PacketHandler
+public class PingHandler extends AbstractPacketHandler
 {
 
     private final ServerInfo target;
@@ -34,7 +34,7 @@ public class PingHandler extends PacketHandler
         this.channel = channel;
         MinecraftEncoder encoder = new MinecraftEncoder( Protocol.HANDSHAKE, false, protocol );
 
-        channel.getHandle().pipeline().addAfter( PipelineUtils.FRAME_DECODER, PipelineUtils.PACKET_DECODER, new MinecraftDecoder( Protocol.STATUS, false, ProxyServer.getInstance().getProtocolVersion() ) );
+        channel.getHandle().pipeline().addAfter( PipelineUtils.FRAME_DECODER, PipelineUtils.PACKET_DECODER, new MinecraftDecoder( Protocol.STATUS, false, AbstractProxyServer.getInstance().getProtocolVersion() ) );
         channel.getHandle().pipeline().addAfter( PipelineUtils.FRAME_PREPENDER, PipelineUtils.PACKET_ENCODER, encoder );
 
         channel.write( new Handshake( protocol, target.getAddress().getHostString(), target.getAddress().getPort(), 1 ) );

--- a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
@@ -4,14 +4,14 @@ import com.google.common.base.Preconditions;
 import net.md_5.bungee.BungeeCord;
 import net.md_5.bungee.UserConnection;
 import net.md_5.bungee.Util;
-import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.AbstractProxyServer;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.event.ChatEvent;
 import net.md_5.bungee.api.event.PlayerDisconnectEvent;
 import net.md_5.bungee.api.event.PluginMessageEvent;
 import net.md_5.bungee.api.event.TabCompleteEvent;
 import net.md_5.bungee.netty.ChannelWrapper;
-import net.md_5.bungee.netty.PacketHandler;
+import net.md_5.bungee.netty.AbstractPacketHandler;
 import net.md_5.bungee.protocol.PacketWrapper;
 import net.md_5.bungee.protocol.ProtocolConstants;
 import net.md_5.bungee.protocol.packet.KeepAlive;
@@ -25,13 +25,13 @@ import java.util.List;
 import net.md_5.bungee.forge.ForgeConstants;
 import net.md_5.bungee.protocol.packet.TabCompleteResponse;
 
-public class UpstreamBridge extends PacketHandler
+public class UpstreamBridge extends AbstractPacketHandler
 {
 
-    private final ProxyServer bungee;
+    private final AbstractProxyServer bungee;
     private final UserConnection con;
 
-    public UpstreamBridge(ProxyServer bungee, UserConnection con)
+    public UpstreamBridge(AbstractProxyServer bungee, UserConnection con)
     {
         this.bungee = bungee;
         this.con = con;

--- a/proxy/src/main/java/net/md_5/bungee/entitymap/AbstractEntityMap.java
+++ b/proxy/src/main/java/net/md_5/bungee/entitymap/AbstractEntityMap.java
@@ -4,14 +4,14 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.netty.buffer.ByteBuf;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.protocol.AbstractDefinedPacket;
 import net.md_5.bungee.protocol.ProtocolConstants;
 
 /**
  * Class to rewrite integers within packets.
  */
 @NoArgsConstructor(access = AccessLevel.PACKAGE)
-public abstract class EntityMap
+public abstract class AbstractEntityMap
 {
 
     private final boolean[] clientboundInts = new boolean[ 256 ];
@@ -21,7 +21,7 @@ public abstract class EntityMap
     private final boolean[] serverboundVarInts = new boolean[ 256 ];
 
     // Returns the correct entity map for the protocol version
-    public static EntityMap getEntityMap(int version)
+    public static AbstractEntityMap getEntityMap(int version)
     {
         switch ( version )
         {
@@ -84,14 +84,14 @@ public abstract class EntityMap
     protected static void rewriteVarInt(ByteBuf packet, int oldId, int newId, int offset)
     {
         // Need to rewrite the packet because VarInts are variable length
-        int readId = DefinedPacket.readVarInt( packet );
+        int readId = AbstractDefinedPacket.readVarInt( packet );
         int readIdLength = packet.readerIndex() - offset;
         if ( readId == oldId || readId == newId )
         {
             ByteBuf data = packet.slice().copy();
             packet.readerIndex( offset );
             packet.writerIndex( offset );
-            DefinedPacket.writeVarInt( readId == oldId ? newId : oldId, packet );
+            AbstractDefinedPacket.writeVarInt( readId == oldId ? newId : oldId, packet );
             packet.writeBytes( data );
             data.release();
         }
@@ -101,7 +101,7 @@ public abstract class EntityMap
     private static void rewrite(ByteBuf packet, int oldId, int newId, boolean[] ints, boolean[] varints)
     {
         int readerIndex = packet.readerIndex();
-        int packetId = DefinedPacket.readVarInt( packet );
+        int packetId = AbstractDefinedPacket.readVarInt( packet );
         int packetIdLength = packet.readerIndex() - readerIndex;
 
         if ( ints[ packetId ] )

--- a/proxy/src/main/java/net/md_5/bungee/entitymap/EntityMap_1_7_2.java
+++ b/proxy/src/main/java/net/md_5/bungee/entitymap/EntityMap_1_7_2.java
@@ -1,13 +1,13 @@
 package net.md_5.bungee.entitymap;
 
 import io.netty.buffer.ByteBuf;
-import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.protocol.AbstractDefinedPacket;
 import net.md_5.bungee.protocol.ProtocolConstants;
 
-class EntityMap_1_7_2 extends EntityMap
+class EntityMap_1_7_2 extends AbstractEntityMap
 {
 
-    static final EntityMap INSTANCE = new EntityMap_1_7_2();
+    static final AbstractEntityMap INSTANCE = new EntityMap_1_7_2();
 
     EntityMap_1_7_2()
     {
@@ -48,7 +48,7 @@ class EntityMap_1_7_2 extends EntityMap
 
         //Special cases
         int readerIndex = packet.readerIndex();
-        int packetId = DefinedPacket.readVarInt( packet );
+        int packetId = AbstractDefinedPacket.readVarInt( packet );
         int packetIdLength = packet.readerIndex() - readerIndex;
         if ( packetId == 0x0D /* Collect Item */ || packetId == 0x1B /* Attach Entity */ )
         {
@@ -62,7 +62,7 @@ class EntityMap_1_7_2 extends EntityMap
             }
         } else if ( packetId == 0x0E /* Spawn Object */ )
         {
-            DefinedPacket.readVarInt( packet );
+            AbstractDefinedPacket.readVarInt( packet );
             int type = packet.readUnsignedByte();
 
             if ( type == 60 || type == 90 )

--- a/proxy/src/main/java/net/md_5/bungee/entitymap/EntityMap_1_7_6.java
+++ b/proxy/src/main/java/net/md_5/bungee/entitymap/EntityMap_1_7_6.java
@@ -5,7 +5,7 @@ import io.netty.buffer.ByteBuf;
 import net.md_5.bungee.BungeeCord;
 import net.md_5.bungee.UserConnection;
 import net.md_5.bungee.connection.LoginResult;
-import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.protocol.AbstractDefinedPacket;
 
 class EntityMap_1_7_6 extends EntityMap_1_7_2
 {
@@ -19,15 +19,15 @@ class EntityMap_1_7_6 extends EntityMap_1_7_2
         super.rewriteClientbound( packet, oldId, newId );
 
         int readerIndex = packet.readerIndex();
-        int packetId = DefinedPacket.readVarInt( packet );
+        int packetId = AbstractDefinedPacket.readVarInt( packet );
         int packetIdLength = packet.readerIndex() - readerIndex;
         if ( packetId == 0x0C /* Spawn Player */ )
         {
-            DefinedPacket.readVarInt( packet );
+            AbstractDefinedPacket.readVarInt( packet );
             int idLength = packet.readerIndex() - readerIndex - packetIdLength;
-            String uuid = DefinedPacket.readString( packet );
-            String username = DefinedPacket.readString( packet );
-            int props = DefinedPacket.readVarInt( packet );
+            String uuid = AbstractDefinedPacket.readString( packet );
+            String username = AbstractDefinedPacket.readString( packet );
+            int props = AbstractDefinedPacket.readVarInt( packet );
             if ( props == 0 )
             {
                 UserConnection player = (UserConnection) BungeeCord.getInstance().getPlayer( username );
@@ -40,14 +40,14 @@ class EntityMap_1_7_6 extends EntityMap_1_7_2
                         ByteBuf rest = packet.slice().copy();
                         packet.readerIndex( readerIndex );
                         packet.writerIndex( readerIndex + packetIdLength + idLength );
-                        DefinedPacket.writeString( player.getUniqueId().toString(), packet );
-                        DefinedPacket.writeString( username, packet );
-                        DefinedPacket.writeVarInt( profile.getProperties().length, packet );
+                        AbstractDefinedPacket.writeString( player.getUniqueId().toString(), packet );
+                        AbstractDefinedPacket.writeString( username, packet );
+                        AbstractDefinedPacket.writeVarInt( profile.getProperties().length, packet );
                         for ( LoginResult.Property property : profile.getProperties() )
                         {
-                            DefinedPacket.writeString( property.getName(), packet );
-                            DefinedPacket.writeString( property.getValue(), packet );
-                            DefinedPacket.writeString( property.getSignature(), packet );
+                            AbstractDefinedPacket.writeString( property.getName(), packet );
+                            AbstractDefinedPacket.writeString( property.getValue(), packet );
+                            AbstractDefinedPacket.writeString( property.getSignature(), packet );
                         }
                         packet.writeBytes( rest );
                         rest.release();

--- a/proxy/src/main/java/net/md_5/bungee/entitymap/EntityMap_1_8.java
+++ b/proxy/src/main/java/net/md_5/bungee/entitymap/EntityMap_1_8.java
@@ -5,11 +5,11 @@ import io.netty.buffer.ByteBuf;
 import net.md_5.bungee.BungeeCord;
 import net.md_5.bungee.UserConnection;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
-import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.protocol.AbstractDefinedPacket;
 import net.md_5.bungee.protocol.ProtocolConstants;
 import java.util.UUID;
 
-class EntityMap_1_8 extends EntityMap
+class EntityMap_1_8 extends AbstractEntityMap
 {
 
     static final EntityMap_1_8 INSTANCE = new EntityMap_1_8();
@@ -55,26 +55,26 @@ class EntityMap_1_8 extends EntityMap
 
         //Special cases
         int readerIndex = packet.readerIndex();
-        int packetId = DefinedPacket.readVarInt( packet );
+        int packetId = AbstractDefinedPacket.readVarInt( packet );
         int packetIdLength = packet.readerIndex() - readerIndex;
         if ( packetId == 0x0D /* Collect Item */ )
         {
-            DefinedPacket.readVarInt( packet );
+            AbstractDefinedPacket.readVarInt( packet );
             rewriteVarInt( packet, oldId, newId, packet.readerIndex() );
         } else if ( packetId == 0x1B /* Attach Entity */ )
         {
             rewriteInt( packet, oldId, newId, readerIndex + packetIdLength + 4 );
         } else if ( packetId == 0x13 /* Destroy Entities */ )
         {
-            int count = DefinedPacket.readVarInt( packet );
+            int count = AbstractDefinedPacket.readVarInt( packet );
             int[] ids = new int[ count ];
             for ( int i = 0; i < count; i++ )
             {
-                ids[ i ] = DefinedPacket.readVarInt( packet );
+                ids[ i ] = AbstractDefinedPacket.readVarInt( packet );
             }
             packet.readerIndex( readerIndex + packetIdLength );
             packet.writerIndex( readerIndex + packetIdLength );
-            DefinedPacket.writeVarInt( count, packet );
+            AbstractDefinedPacket.writeVarInt( count, packet );
             for ( int id : ids )
             {
                 if ( id == oldId )
@@ -84,12 +84,12 @@ class EntityMap_1_8 extends EntityMap
                 {
                     id = oldId;
                 }
-                DefinedPacket.writeVarInt( id, packet );
+                AbstractDefinedPacket.writeVarInt( id, packet );
             }
         } else if ( packetId == 0x0E /* Spawn Object */ )
         {
 
-            DefinedPacket.readVarInt( packet );
+            AbstractDefinedPacket.readVarInt( packet );
             int type = packet.readUnsignedByte();
 
             if ( type == 60 || type == 90 )
@@ -123,16 +123,16 @@ class EntityMap_1_8 extends EntityMap
             }
         } else if ( packetId == 0x0C /* Spawn Player */ )
         {
-            DefinedPacket.readVarInt( packet ); // Entity ID
+            AbstractDefinedPacket.readVarInt( packet ); // Entity ID
             int idLength = packet.readerIndex() - readerIndex - packetIdLength;
-            UUID uuid = DefinedPacket.readUUID( packet );
+            UUID uuid = AbstractDefinedPacket.readUUID( packet );
             ProxiedPlayer player;
             if ( ( player = BungeeCord.getInstance().getPlayerByOfflineUUID( uuid ) ) != null )
             {
                 int previous = packet.writerIndex();
                 packet.readerIndex( readerIndex );
                 packet.writerIndex( readerIndex + packetIdLength + idLength );
-                DefinedPacket.writeUUID( player.getUniqueId(), packet );
+                AbstractDefinedPacket.writeUUID( player.getUniqueId(), packet );
                 packet.writerIndex( previous );
             }
         } else if ( packetId == 0x42 /* Combat Event */ )
@@ -140,14 +140,14 @@ class EntityMap_1_8 extends EntityMap
             int event = packet.readUnsignedByte();
             if ( event == 1 /* End Combat*/ )
             {
-                DefinedPacket.readVarInt( packet );
+                AbstractDefinedPacket.readVarInt( packet );
                 rewriteInt( packet, oldId, newId, packet.readerIndex() );
             } else if ( event == 2 /* Entity Dead */ )
             {
                 int position = packet.readerIndex();
                 rewriteVarInt( packet, oldId, newId, packet.readerIndex() );
                 packet.readerIndex( position );
-                DefinedPacket.readVarInt( packet );
+                AbstractDefinedPacket.readVarInt( packet );
                 rewriteInt( packet, oldId, newId, packet.readerIndex() );
             }
         }
@@ -160,19 +160,19 @@ class EntityMap_1_8 extends EntityMap
         super.rewriteServerbound( packet, oldId, newId );
         //Special cases
         int readerIndex = packet.readerIndex();
-        int packetId = DefinedPacket.readVarInt( packet );
+        int packetId = AbstractDefinedPacket.readVarInt( packet );
         int packetIdLength = packet.readerIndex() - readerIndex;
 
         if ( packetId == 0x18 /* Spectate */ && !BungeeCord.getInstance().getConfig().isIpForward() )
         {
-            UUID uuid = DefinedPacket.readUUID( packet );
+            UUID uuid = AbstractDefinedPacket.readUUID( packet );
             ProxiedPlayer player;
             if ( ( player = BungeeCord.getInstance().getPlayer( uuid ) ) != null )
             {
                 int previous = packet.writerIndex();
                 packet.readerIndex( readerIndex );
                 packet.writerIndex( readerIndex + packetIdLength );
-                DefinedPacket.writeUUID( ( (UserConnection) player ).getPendingConnection().getOfflineId(), packet );
+                AbstractDefinedPacket.writeUUID( ( (UserConnection) player ).getPendingConnection().getOfflineId(), packet );
                 packet.writerIndex( previous );
             }
         }

--- a/proxy/src/main/java/net/md_5/bungee/forge/ForgeUtils.java
+++ b/proxy/src/main/java/net/md_5/bungee/forge/ForgeUtils.java
@@ -8,7 +8,7 @@ import com.google.common.collect.Maps;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
-import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.protocol.AbstractDefinedPacket;
 import net.md_5.bungee.protocol.packet.PluginMessage;
 
 public class ForgeUtils
@@ -42,10 +42,10 @@ public class ForgeUtils
         if ( discriminator == 2 ) // ModList
         {
             ByteBuf buffer = payload.slice();
-            int modCount = DefinedPacket.readVarInt( buffer, 2 );
+            int modCount = AbstractDefinedPacket.readVarInt( buffer, 2 );
             for ( int i = 0; i < modCount; i++ )
             {
-                modTags.put( DefinedPacket.readString( buffer ), DefinedPacket.readString( buffer ) );
+                modTags.put( AbstractDefinedPacket.readString( buffer ), AbstractDefinedPacket.readString( buffer ) );
             }
         }
         return modTags;

--- a/proxy/src/main/java/net/md_5/bungee/module/ModuleManager.java
+++ b/proxy/src/main/java/net/md_5/bungee/module/ModuleManager.java
@@ -15,7 +15,7 @@ import java.util.Map;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.logging.Level;
-import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.AbstractProxyServer;
 import net.md_5.bungee.api.plugin.PluginDescription;
 import net.md_5.bungee.util.CaseInsensitiveMap;
 import org.yaml.snakeyaml.DumperOptions;
@@ -35,7 +35,7 @@ public class ModuleManager
             {
                 "SF_SWITCH_FALLTHROUGH", "SF_SWITCH_NO_DEFAULT"
             })
-    public void load(ProxyServer proxy, File moduleDirectory) throws Exception
+    public void load(AbstractProxyServer proxy, File moduleDirectory) throws Exception
     {
         moduleDirectory.mkdir();
 
@@ -145,7 +145,7 @@ public class ModuleManager
             }
         } catch ( Exception ex )
         {
-            ProxyServer.getInstance().getLogger().log( Level.WARNING, "Could not check module from file " + file, ex );
+            AbstractProxyServer.getInstance().getLogger().log( Level.WARNING, "Could not check module from file " + file, ex );
         }
 
         return null;

--- a/proxy/src/main/java/net/md_5/bungee/netty/AbstractPacketHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/netty/AbstractPacketHandler.java
@@ -2,7 +2,7 @@ package net.md_5.bungee.netty;
 
 import net.md_5.bungee.protocol.PacketWrapper;
 
-public abstract class PacketHandler extends net.md_5.bungee.protocol.AbstractPacketHandler
+public abstract class AbstractPacketHandler extends net.md_5.bungee.protocol.AbstractPacketHandler
 {
 
     @Override

--- a/proxy/src/main/java/net/md_5/bungee/netty/HandlerBoss.java
+++ b/proxy/src/main/java/net/md_5/bungee/netty/HandlerBoss.java
@@ -8,14 +8,14 @@ import io.netty.handler.timeout.ReadTimeoutException;
 import io.netty.handler.codec.DecoderException;
 import java.io.IOException;
 import java.util.logging.Level;
-import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.AbstractProxyServer;
 import net.md_5.bungee.connection.CancelSendSignal;
 import net.md_5.bungee.connection.InitialHandler;
 import net.md_5.bungee.connection.PingHandler;
 import net.md_5.bungee.protocol.BadPacketException;
 
 /**
- * This class is a primitive wrapper for {@link PacketHandler} instances tied to
+ * This class is a primitive wrapper for {@link AbstractPacketHandler} instances tied to
  * channels to maintain simple states, and only call the required, adapted
  * methods when the channel is connected.
  */
@@ -23,9 +23,9 @@ public class HandlerBoss extends ChannelInboundHandlerAdapter
 {
 
     private ChannelWrapper channel;
-    private PacketHandler handler;
+    private AbstractPacketHandler handler;
 
-    public void setHandler(PacketHandler handler)
+    public void setHandler(AbstractPacketHandler handler)
     {
         Preconditions.checkArgument( handler != null, "handler" );
         this.handler = handler;
@@ -41,7 +41,7 @@ public class HandlerBoss extends ChannelInboundHandlerAdapter
 
             if ( !( handler instanceof InitialHandler || handler instanceof PingHandler ) )
             {
-                ProxyServer.getInstance().getLogger().log( Level.INFO, "{0} has connected", handler );
+                AbstractProxyServer.getInstance().getLogger().log( Level.INFO, "{0} has connected", handler );
             }
         }
     }
@@ -55,7 +55,7 @@ public class HandlerBoss extends ChannelInboundHandlerAdapter
 
             if ( !( handler instanceof InitialHandler || handler instanceof PingHandler ) )
             {
-                ProxyServer.getInstance().getLogger().log( Level.INFO, "{0} has disconnected", handler );
+                AbstractProxyServer.getInstance().getLogger().log( Level.INFO, "{0} has disconnected", handler );
             }
         }
     }
@@ -97,22 +97,22 @@ public class HandlerBoss extends ChannelInboundHandlerAdapter
         {
             if ( cause instanceof ReadTimeoutException )
             {
-                ProxyServer.getInstance().getLogger().log( Level.WARNING, "{0} - read timed out", handler );
+                AbstractProxyServer.getInstance().getLogger().log( Level.WARNING, "{0} - read timed out", handler );
             } else if ( cause instanceof DecoderException && cause.getCause() instanceof BadPacketException )
             {
-                ProxyServer.getInstance().getLogger().log( Level.WARNING, "{0} - bad packet ID, are mods in use!? {1}", new Object[]
+                AbstractProxyServer.getInstance().getLogger().log( Level.WARNING, "{0} - bad packet ID, are mods in use!? {1}", new Object[]
                 {
                     handler, cause.getCause().getMessage()
                 } );
             } else if ( cause instanceof IOException )
             {
-                ProxyServer.getInstance().getLogger().log( Level.WARNING, "{0} - IOException: {1}", new Object[]
+                AbstractProxyServer.getInstance().getLogger().log( Level.WARNING, "{0} - IOException: {1}", new Object[]
                 {
                     handler, cause.getMessage()
                 } );
             } else
             {
-                ProxyServer.getInstance().getLogger().log( Level.SEVERE, handler + " - encountered exception", cause );
+                AbstractProxyServer.getInstance().getLogger().log( Level.SEVERE, handler + " - encountered exception", cause );
             }
 
             if ( handler != null )
@@ -122,7 +122,7 @@ public class HandlerBoss extends ChannelInboundHandlerAdapter
                     handler.exception( cause );
                 } catch ( Exception ex )
                 {
-                    ProxyServer.getInstance().getLogger().log( Level.SEVERE, handler + " - exception processing exception", ex );
+                    AbstractProxyServer.getInstance().getLogger().log( Level.SEVERE, handler + " - exception processing exception", ex );
                 }
             }
 

--- a/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java
+++ b/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java
@@ -28,7 +28,7 @@ import net.md_5.bungee.BungeeServerInfo;
 import net.md_5.bungee.UserConnection;
 import net.md_5.bungee.Util;
 import net.md_5.bungee.connection.InitialHandler;
-import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.AbstractProxyServer;
 import net.md_5.bungee.api.config.ListenerInfo;
 import net.md_5.bungee.protocol.KickStringWriter;
 import net.md_5.bungee.protocol.LegacyDecoder;
@@ -58,10 +58,10 @@ public class PipelineUtils
 
             BASE.initChannel( ch );
             ch.pipeline().addBefore( FRAME_DECODER, LEGACY_DECODER, new LegacyDecoder() );
-            ch.pipeline().addAfter( FRAME_DECODER, PACKET_DECODER, new MinecraftDecoder( Protocol.HANDSHAKE, true, ProxyServer.getInstance().getProtocolVersion() ) );
-            ch.pipeline().addAfter( FRAME_PREPENDER, PACKET_ENCODER, new MinecraftEncoder( Protocol.HANDSHAKE, true, ProxyServer.getInstance().getProtocolVersion() ) );
+            ch.pipeline().addAfter( FRAME_DECODER, PACKET_DECODER, new MinecraftDecoder( Protocol.HANDSHAKE, true, AbstractProxyServer.getInstance().getProtocolVersion() ) );
+            ch.pipeline().addAfter( FRAME_PREPENDER, PACKET_ENCODER, new MinecraftEncoder( Protocol.HANDSHAKE, true, AbstractProxyServer.getInstance().getProtocolVersion() ) );
             ch.pipeline().addBefore( FRAME_PREPENDER, LEGACY_KICKER, new KickStringWriter() );
-            ch.pipeline().get( HandlerBoss.class ).setHandler( new InitialHandler( ProxyServer.getInstance(), ch.attr( LISTENER ).get() ) );
+            ch.pipeline().get( HandlerBoss.class ).setHandler( new InitialHandler( AbstractProxyServer.getInstance(), ch.attr( LISTENER ).get() ) );
         }
     };
     public static final Base BASE = new Base();
@@ -83,14 +83,14 @@ public class PipelineUtils
     {
         if ( !PlatformDependent.isWindows() && Boolean.parseBoolean( System.getProperty( "bungee.epoll", "true" ) ) )
         {
-            ProxyServer.getInstance().getLogger().info( "Not on Windows, attempting to use enhanced EpollEventLoop" );
+            AbstractProxyServer.getInstance().getLogger().info( "Not on Windows, attempting to use enhanced EpollEventLoop" );
 
             if ( epoll = Epoll.isAvailable() )
             {
-                ProxyServer.getInstance().getLogger().info( "Epoll is working, utilising it!" );
+                AbstractProxyServer.getInstance().getLogger().info( "Epoll is working, utilising it!" );
             } else
             {
-                ProxyServer.getInstance().getLogger().log( Level.WARNING, "Epoll is not working, falling back to NIO: {0}", Util.exception( Epoll.unavailabilityCause() ) );
+                AbstractProxyServer.getInstance().getLogger().log( Level.WARNING, "Epoll is not working, falling back to NIO: {0}", Util.exception( Epoll.unavailabilityCause() ) );
             }
         }
     }

--- a/proxy/src/main/java/net/md_5/bungee/scheduler/BungeeTask.java
+++ b/proxy/src/main/java/net/md_5/bungee/scheduler/BungeeTask.java
@@ -4,7 +4,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import lombok.Data;
-import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.AbstractProxyServer;
 import net.md_5.bungee.api.plugin.Plugin;
 import net.md_5.bungee.api.scheduler.ScheduledTask;
 
@@ -63,7 +63,7 @@ public class BungeeTask implements Runnable, ScheduledTask
                 task.run();
             } catch ( Throwable t )
             {
-                ProxyServer.getInstance().getLogger().log( Level.SEVERE, String.format( "Task %s encountered an exception", this ), t );
+                AbstractProxyServer.getInstance().getLogger().log( Level.SEVERE, String.format( "Task %s encountered an exception", this ), t );
             }
 
             // If we have a period of 0 or less, only run once

--- a/proxy/src/main/java/net/md_5/bungee/tab/AbstractTabList.java
+++ b/proxy/src/main/java/net/md_5/bungee/tab/AbstractTabList.java
@@ -8,7 +8,7 @@ import net.md_5.bungee.connection.LoginResult;
 import net.md_5.bungee.protocol.packet.PlayerListItem;
 
 @RequiredArgsConstructor
-public abstract class TabList
+public abstract class AbstractTabList
 {
 
     protected final ProxiedPlayer player;

--- a/proxy/src/main/java/net/md_5/bungee/tab/Global.java
+++ b/proxy/src/main/java/net/md_5/bungee/tab/Global.java
@@ -11,7 +11,7 @@ import net.md_5.bungee.protocol.packet.PlayerListItem;
 
 import java.util.Collection;
 
-public class Global extends TabList
+public class Global extends AbstractTabList
 {
 
     private boolean sentPing;

--- a/proxy/src/main/java/net/md_5/bungee/tab/ServerUnique.java
+++ b/proxy/src/main/java/net/md_5/bungee/tab/ServerUnique.java
@@ -8,7 +8,7 @@ import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.protocol.ProtocolConstants;
 import net.md_5.bungee.protocol.packet.PlayerListItem;
 
-public class ServerUnique extends TabList
+public class ServerUnique extends AbstractTabList
 {
 
     private final Collection<UUID> uuids = new HashSet<>();

--- a/proxy/src/test/java/net/md_5/bungee/chat/ComponentsTest.java
+++ b/proxy/src/test/java/net/md_5/bungee/chat/ComponentsTest.java
@@ -1,7 +1,7 @@
 package net.md_5.bungee.chat;
 
 import net.md_5.bungee.api.ChatColor;
-import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.api.chat.AbstractBaseComponent;
 import net.md_5.bungee.api.chat.ClickEvent;
 import net.md_5.bungee.api.chat.ComponentBuilder;
 import net.md_5.bungee.api.chat.HoverEvent;
@@ -26,17 +26,17 @@ public class ComponentsTest
     @Test
     public void testLegacyConverter()
     {
-        BaseComponent[] test1 = TextComponent.fromLegacyText( ChatColor.AQUA + "Aqua " + ChatColor.RED + ChatColor.BOLD + "RedBold" );
+        AbstractBaseComponent[] test1 = TextComponent.fromLegacyText( ChatColor.AQUA + "Aqua " + ChatColor.RED + ChatColor.BOLD + "RedBold" );
 
-        Assert.assertEquals( "Aqua RedBold", BaseComponent.toPlainText( test1 ) );
-        Assert.assertEquals( ChatColor.AQUA + "Aqua " + ChatColor.RED + ChatColor.BOLD + "RedBold", BaseComponent.toLegacyText( test1 ) );
+        Assert.assertEquals( "Aqua RedBold", AbstractBaseComponent.toPlainText( test1 ) );
+        Assert.assertEquals( ChatColor.AQUA + "Aqua " + ChatColor.RED + ChatColor.BOLD + "RedBold", AbstractBaseComponent.toLegacyText( test1 ) );
 
-        BaseComponent[] test2 = TextComponent.fromLegacyText( "Text http://spigotmc.org " + ChatColor.GREEN + "google.com/test" );
+        AbstractBaseComponent[] test2 = TextComponent.fromLegacyText( "Text http://spigotmc.org " + ChatColor.GREEN + "google.com/test" );
 
-        Assert.assertEquals( "Text http://spigotmc.org google.com/test", BaseComponent.toPlainText( test2 ) );
+        Assert.assertEquals( "Text http://spigotmc.org google.com/test", AbstractBaseComponent.toPlainText( test2 ) );
         //The extra ChatColor.WHITEs are sometimes inserted when not needed but it doesn't change the result
         Assert.assertEquals( ChatColor.WHITE + "Text " + ChatColor.WHITE + "http://spigotmc.org" + ChatColor.WHITE
-                + " " + ChatColor.GREEN + "google.com/test", BaseComponent.toLegacyText( test2 ) );
+                + " " + ChatColor.GREEN + "google.com/test", AbstractBaseComponent.toLegacyText( test2 ) );
 
         ClickEvent url1 = test2[1].getClickEvent();
         Assert.assertNotNull( url1 );
@@ -72,19 +72,19 @@ public class ComponentsTest
     @Test
     public void testBuilder()
     {
-        BaseComponent[] components = new ComponentBuilder( "Hello " ).color( ChatColor.RED ).
+        AbstractBaseComponent[] components = new ComponentBuilder( "Hello " ).color( ChatColor.RED ).
                 append( "World" ).bold( true ).color( ChatColor.BLUE ).
                 append( "!" ).color( ChatColor.YELLOW ).create();
 
-        Assert.assertEquals( "Hello World!", BaseComponent.toPlainText( components ) );
+        Assert.assertEquals( "Hello World!", AbstractBaseComponent.toPlainText( components ) );
         Assert.assertEquals( ChatColor.RED + "Hello " + ChatColor.BLUE + ChatColor.BOLD
-                + "World" + ChatColor.YELLOW + ChatColor.BOLD + "!", BaseComponent.toLegacyText( components ) );
+                + "World" + ChatColor.YELLOW + ChatColor.BOLD + "!", AbstractBaseComponent.toLegacyText( components ) );
     }
 
     @Test
     public void testBuilderReset()
     {
-        BaseComponent[] components = new ComponentBuilder( "Hello " ).color(ChatColor.RED)
+        AbstractBaseComponent[] components = new ComponentBuilder( "Hello " ).color(ChatColor.RED)
                 .append("World").reset().create();
 
         Assert.assertEquals( components[0].getColor(), ChatColor.RED );
@@ -94,7 +94,7 @@ public class ComponentsTest
     @Test
     public void testBuilderFormatRetention()
     {
-        BaseComponent[] noneRetention = new ComponentBuilder( "Hello " ).color( ChatColor.RED )
+        AbstractBaseComponent[] noneRetention = new ComponentBuilder( "Hello " ).color( ChatColor.RED )
                 .append( "World", ComponentBuilder.FormatRetention.NONE ).create();
 
         Assert.assertEquals( noneRetention[0].getColor(), ChatColor.RED );
@@ -102,7 +102,7 @@ public class ComponentsTest
 
         HoverEvent testEvent = new HoverEvent( HoverEvent.Action.SHOW_TEXT, new ComponentBuilder( "test" ).create() );
 
-        BaseComponent[] formattingRetention = new ComponentBuilder( "Hello " ).color( ChatColor.RED )
+        AbstractBaseComponent[] formattingRetention = new ComponentBuilder( "Hello " ).color( ChatColor.RED )
                 .event( testEvent ).append( "World", ComponentBuilder.FormatRetention.FORMATTING ).create();
 
         Assert.assertEquals( formattingRetention[0].getColor(), ChatColor.RED );
@@ -112,7 +112,7 @@ public class ComponentsTest
 
         ClickEvent testClickEvent = new ClickEvent( ClickEvent.Action.OPEN_URL, "http://www.example.com" );
 
-        BaseComponent[] eventRetention = new ComponentBuilder( "Hello " ).color( ChatColor.RED )
+        AbstractBaseComponent[] eventRetention = new ComponentBuilder( "Hello " ).color( ChatColor.RED )
                 .event( testEvent ).event(testClickEvent).append("World", ComponentBuilder.FormatRetention.EVENTS).create();
 
         Assert.assertEquals( eventRetention[0].getColor(), ChatColor.RED );

--- a/query/src/main/java/net/md_5/bungee/query/QueryHandler.java
+++ b/query/src/main/java/net/md_5/bungee/query/QueryHandler.java
@@ -13,7 +13,7 @@ import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import lombok.RequiredArgsConstructor;
-import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.AbstractProxyServer;
 import net.md_5.bungee.api.config.ListenerInfo;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 
@@ -21,7 +21,7 @@ import net.md_5.bungee.api.connection.ProxiedPlayer;
 public class QueryHandler extends SimpleChannelInboundHandler<DatagramPacket>
 {
 
-    private final ProxyServer bungee;
+    private final AbstractProxyServer bungee;
     private final ListenerInfo listener;
     /*========================================================================*/
     private final Random random = new Random();

--- a/query/src/main/java/net/md_5/bungee/query/RemoteQuery.java
+++ b/query/src/main/java/net/md_5/bungee/query/RemoteQuery.java
@@ -6,14 +6,14 @@ import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.EventLoopGroup;
 import java.net.InetSocketAddress;
 import lombok.RequiredArgsConstructor;
-import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.AbstractProxyServer;
 import net.md_5.bungee.api.config.ListenerInfo;
 
 @RequiredArgsConstructor
 public class RemoteQuery
 {
 
-    private final ProxyServer bungee;
+    private final AbstractProxyServer bungee;
     private final ListenerInfo listener;
 
     public void start(Class<? extends Channel> channel, InetSocketAddress address, EventLoopGroup eventLoop, ChannelFutureListener future)


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S00118 - Abstract class names should comply with a naming convention
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S00118
Please let me know if you have any questions.
M-Ezzat