### PR TITLE
pmd:CommentDefaultAccessModifier -  Comment the default access modifier

### DIFF
--- a/api/src/main/java/net/md_5/bungee/util/CaseInsensitiveHashingStrategy.java
+++ b/api/src/main/java/net/md_5/bungee/util/CaseInsensitiveHashingStrategy.java
@@ -5,7 +5,7 @@ import gnu.trove.strategy.HashingStrategy;
 class CaseInsensitiveHashingStrategy implements HashingStrategy
 {
 
-    static final CaseInsensitiveHashingStrategy INSTANCE = new CaseInsensitiveHashingStrategy();
+	/* default */ static final CaseInsensitiveHashingStrategy INSTANCE = new CaseInsensitiveHashingStrategy();
 
     @Override
     public int computeHashCode(Object object)

--- a/native/src/main/java/net/md_5/bungee/jni/cipher/NativeCipherImpl.java
+++ b/native/src/main/java/net/md_5/bungee/jni/cipher/NativeCipherImpl.java
@@ -3,9 +3,9 @@ package net.md_5.bungee.jni.cipher;
 class NativeCipherImpl
 {
 
-    native long init(boolean forEncryption, byte[] key);
+	/* default */ native long init(boolean forEncryption, byte[] key);
 
-    native void free(long ctx);
+	/* default */ native void free(long ctx);
 
-    native void cipher(long ctx, long in, long out, int length);
+	/* default */ native void cipher(long ctx, long in, long out, int length);
 }

--- a/native/src/main/java/net/md_5/bungee/jni/zlib/NativeCompressImpl.java
+++ b/native/src/main/java/net/md_5/bungee/jni/zlib/NativeCompressImpl.java
@@ -3,21 +3,21 @@ package net.md_5.bungee.jni.zlib;
 public class NativeCompressImpl
 {
 
-    int consumed;
-    boolean finished;
+	/* default */ int consumed;
+	/* default */ boolean finished;
 
     static
     {
         initFields();
     }
 
-    static native void initFields();
+    /* default */ static native void initFields();
 
-    native void end(long ctx, boolean compress);
+    /* default */ native void end(long ctx, boolean compress);
 
-    native void reset(long ctx, boolean compress);
+    /* default */ native void reset(long ctx, boolean compress);
 
-    native long init(boolean compress, int compressionLevel);
+    /* default */ native long init(boolean compress, int compressionLevel);
 
-    native int process(long ctx, long in, int inLength, long out, int outLength, boolean compress);
+    /* default */ native int process(long ctx, long in, int inLength, long out, int outLength, boolean compress);
 }

--- a/proxy/src/main/java/net/md_5/bungee/log/BungeeLogger.java
+++ b/proxy/src/main/java/net/md_5/bungee/log/BungeeLogger.java
@@ -49,7 +49,7 @@ public class BungeeLogger extends Logger
         dispatcher.queue( record );
     }
 
-    void doLog(LogRecord record)
+    /* default */ void doLog(LogRecord record)
     {
         super.log( record );
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule pmd:CommentDefaultAccessModifier - Comment the default access modifier
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=pmd:CommentDefaultAccessModifier
Please let me know if you have any questions.
M-Ezzat