### PR TITLE
Revert "Improve EventBus by removing read locking."

### DIFF
--- a/event/src/main/java/net/md_5/bungee/event/EventBus.java
+++ b/event/src/main/java/net/md_5/bungee/event/EventBus.java
@@ -9,9 +9,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -19,8 +18,8 @@ public class EventBus
 {
 
     private final Map<Class<?>, Map<Byte, Map<Object, Method[]>>> byListenerAndPriority = new HashMap<>();
-    private final Map<Class<?>, EventHandlerMethod[]> byEventBaked = new ConcurrentHashMap<>();
-    private final Lock lock = new ReentrantLock();
+    private final Map<Class<?>, EventHandlerMethod[]> byEventBaked = new HashMap<>();
+    private final ReadWriteLock lock = new ReentrantReadWriteLock();
     private final Logger logger;
 
     public EventBus()
@@ -35,7 +34,15 @@ public class EventBus
 
     public void post(Object event)
     {
-        EventHandlerMethod[] handlers = byEventBaked.get( event.getClass() );
+        EventHandlerMethod[] handlers;
+        lock.readLock().lock();
+        try
+        {
+            handlers = byEventBaked.get( event.getClass() );
+        } finally
+        {
+            lock.readLock().unlock();
+        }
 
         if ( handlers != null )
         {
@@ -96,7 +103,7 @@ public class EventBus
     public void register(Object listener)
     {
         Map<Class<?>, Map<Byte, Set<Method>>> handler = findHandlers( listener );
-        lock.lock();
+        lock.writeLock().lock();
         try
         {
             for ( Map.Entry<Class<?>, Map<Byte, Set<Method>>> e : handler.entrySet() )
@@ -122,14 +129,14 @@ public class EventBus
             }
         } finally
         {
-            lock.unlock();
+            lock.writeLock().unlock();
         }
     }
 
     public void unregister(Object listener)
     {
         Map<Class<?>, Map<Byte, Set<Method>>> handler = findHandlers( listener );
-        lock.lock();
+        lock.writeLock().lock();
         try
         {
             for ( Map.Entry<Class<?>, Map<Byte, Set<Method>>> e : handler.entrySet() )
@@ -158,7 +165,7 @@ public class EventBus
             }
         } finally
         {
-            lock.unlock();
+            lock.writeLock().unlock();
         }
     }
 
@@ -195,7 +202,7 @@ public class EventBus
             byEventBaked.put( eventClass, handlersList.toArray( new EventHandlerMethod[ handlersList.size() ] ) );
         } else
         {
-            byEventBaked.remove( eventClass );
+            byEventBaked.put( eventClass, null );
         }
     }
 }


### PR DESCRIPTION
This reverts commit 59208aad8678291f011da1435b1b390488ec303c.

Improving my microbenchmark reveals that removing read locking does not substantially improve performance in most cases, and may have decreased it.

Single-threaded: https://gist.github.com/minecrafter/26d1f25f181f38a089dd
Multi-threaded (4): https://gist.github.com/minecrafter/513a87e8db8108aaca53