### PR TITLE
Make exceptions thrown by QueryHandler nicer.

### DIFF
--- a/query/src/main/java/net/md_5/bungee/query/QueryHandler.java
+++ b/query/src/main/java/net/md_5/bungee/query/QueryHandler.java
@@ -141,4 +141,10 @@ public class QueryHandler extends SimpleChannelInboundHandler<DatagramPacket>
 
         ctx.writeAndFlush( response );
     }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception
+    {
+        bungee.getLogger().log( Level.WARNING, "Error whilst handling query packet from " + ctx.channel().remoteAddress(), cause );
+    }
 }


### PR DESCRIPTION
Previously, they would result in a large and scary message from Netty (see #1740). This instead sends the message to the BungeeCord logger and de-establishes the connection.
