### PR TITLE
[BREAKING] Make PluginManager an interface and let dispatchCommand() throw exceptions.

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/ProxyServer.java
+++ b/api/src/main/java/net/md_5/bungee/api/ProxyServer.java
@@ -107,7 +107,7 @@ public abstract class ProxyServer
     /**
      * Get the {@link PluginManager} associated with loading plugins and
      * dispatching events. It is recommended that implementations use the
-     * provided PluginManager class.
+     * provided PluginManagerImpl class.
      *
      * @return the plugin manager
      */

--- a/api/src/main/java/net/md_5/bungee/api/plugin/CommandExecutionException.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/CommandExecutionException.java
@@ -1,0 +1,26 @@
+package net.md_5.bungee.api.plugin;
+
+import net.md_5.bungee.api.CommandSender;
+
+/**
+ * {@code CommandExecutionException} is thrown when an {@link Command} fails to execute.
+ *
+ * @see PluginManager#dispatchCommand(CommandSender, String)
+ */
+public class CommandExecutionException extends Exception
+{
+    public CommandExecutionException(String message)
+    {
+        super( message );
+    }
+
+    public CommandExecutionException(String message, Throwable cause)
+    {
+        super( message, cause );
+    }
+
+    public CommandExecutionException(Throwable cause)
+    {
+        super( cause );
+    }
+}

--- a/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
@@ -1,429 +1,90 @@
 package net.md_5.bungee.api.plugin;
 
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Multimap;
-import com.google.common.eventbus.Subscribe;
-import java.io.File;
-import java.io.InputStream;
-import java.lang.reflect.Method;
-import java.net.URL;
-import java.net.URLClassLoader;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.Stack;
-import java.util.jar.JarEntry;
-import java.util.jar.JarFile;
-import java.util.logging.Level;
-import java.util.regex.Pattern;
-import lombok.RequiredArgsConstructor;
-import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.CommandSender;
-import net.md_5.bungee.api.ProxyServer;
-import net.md_5.bungee.api.connection.ProxiedPlayer;
-import net.md_5.bungee.event.EventBus;
-import net.md_5.bungee.event.EventHandler;
-import org.yaml.snakeyaml.Yaml;
-import org.yaml.snakeyaml.constructor.Constructor;
-import org.yaml.snakeyaml.introspector.PropertyUtils;
 
-/**
- * Class to manage bridging between plugin duties and implementation duties, for
- * example event handling and plugin management.
- */
-@RequiredArgsConstructor
-public class PluginManager
+import java.util.Collection;
+import java.util.List;
+
+public interface PluginManager
 {
 
-    private static final Pattern argsSplit = Pattern.compile( " " );
-    /*========================================================================*/
-    private final ProxyServer proxy;
-    /*========================================================================*/
-    private final Yaml yaml;
-    private final EventBus eventBus;
-    private final Map<String, Plugin> plugins = new LinkedHashMap<>();
-    private final Map<String, Command> commandMap = new HashMap<>();
-    private Map<String, PluginDescription> toLoad = new HashMap<>();
-    private final Multimap<Plugin, Command> commandsByPlugin = ArrayListMultimap.create();
-    private final Multimap<Plugin, Listener> listenersByPlugin = ArrayListMultimap.create();
-
-    @SuppressWarnings("unchecked")
-    public PluginManager(ProxyServer proxy)
-    {
-        this.proxy = proxy;
-
-        // Ignore unknown entries in the plugin descriptions
-        Constructor yamlConstructor = new Constructor();
-        PropertyUtils propertyUtils = yamlConstructor.getPropertyUtils();
-        propertyUtils.setSkipMissingProperties( true );
-        yamlConstructor.setPropertyUtils( propertyUtils );
-        yaml = new Yaml( yamlConstructor );
-
-        eventBus = new EventBus( proxy.getLogger() );
-    }
-
     /**
-     * Register a command so that it may be executed.
-     *
-     * @param plugin the plugin owning this command
+     * Associates a command with a plugin. If the command already exists, the existing command is overridden with the new one.
+     * @param plugin the plugin associated with this command
      * @param command the command to register
      */
-    public void registerCommand(Plugin plugin, Command command)
-    {
-        commandMap.put( command.getName().toLowerCase(), command );
-        for ( String alias : command.getAliases() )
-        {
-            commandMap.put( alias.toLowerCase(), command );
-        }
-        commandsByPlugin.put( plugin, command );
-    }
+    void registerCommand(Plugin plugin, Command command);
 
     /**
-     * Unregister a command so it will no longer be executed.
-     *
+     * Unregisters a command.
      * @param command the command to unregister
      */
-    public void unregisterCommand(Command command)
-    {
-        while ( commandMap.values().remove( command ) );
-        commandsByPlugin.values().remove( command );
-    }
+    void unregisterCommand(Command command);
 
     /**
-     * Unregister all commands owned by a {@link Plugin}
-     *
-     * @param plugin the plugin to register the commands of
+     * Unregisters all of a plugin's commands.
+     * @param plugin the plugin with commands to unregister
      */
-    public void unregisterCommands(Plugin plugin)
-    {
-        for ( Iterator<Command> it = commandsByPlugin.get( plugin ).iterator(); it.hasNext(); )
-        {
-            Command command = it.next();
-            while ( commandMap.values().remove( command ) );
-            it.remove();
-        }
-    }
-
-    public boolean dispatchCommand(CommandSender sender, String commandLine)
-    {
-        return dispatchCommand( sender, commandLine, null );
-    }
+    void unregisterCommands(Plugin plugin);
 
     /**
-     * Execute a command if it is registered, else return false.
-     *
-     * @param sender the sender executing the command
-     * @param commandLine the complete command line including command name and
-     * arguments
-     * @return whether the command was handled
+     * Dispatches a command to all registered commands. If an exception occurs during command execution, the exception will
+     * be rethrown as an {@link CommandExecutionException}.
+     * @param sender the sender to use
+     * @param commandLine the full command to execute
+     * @return whether or not the command was executed
+     * @throws CommandExecutionException if an exception occurred whilst executing the command
      */
-    public boolean dispatchCommand(CommandSender sender, String commandLine, List<String> tabResults)
-    {
-        String[] split = argsSplit.split( commandLine, -1 );
-        // Check for chat that only contains " "
-        if ( split.length == 0 )
-        {
-            return false;
-        }
-
-        String commandName = split[0].toLowerCase();
-        if ( sender instanceof ProxiedPlayer && proxy.getDisabledCommands().contains( commandName ) )
-        {
-            return false;
-        }
-        Command command = commandMap.get( commandName );
-        if ( command == null )
-        {
-            return false;
-        }
-
-        String permission = command.getPermission();
-        if ( permission != null && !permission.isEmpty() && !sender.hasPermission( permission ) )
-        {
-            if ( !( command instanceof TabExecutor ) || tabResults == null )
-            {
-                sender.sendMessage( proxy.getTranslation( "no_permission" ) );
-            }
-            return true;
-        }
-
-        String[] args = Arrays.copyOfRange( split, 1, split.length );
-        try
-        {
-            if ( tabResults == null )
-            {
-                if ( proxy.getConfig().isLogCommands() )
-                {
-                    proxy.getLogger().log( Level.INFO, "{0} executed command: /{1}", new Object[]
-                    {
-                        sender.getName(), commandLine
-                    } );
-                }
-                command.execute( sender, args );
-            } else if ( commandLine.contains( " " ) && command instanceof TabExecutor )
-            {
-                for ( String s : ( (TabExecutor) command ).onTabComplete( sender, args ) )
-                {
-                    tabResults.add( s );
-                }
-            }
-        } catch ( Exception ex )
-        {
-            sender.sendMessage( ChatColor.RED + "An internal error occurred whilst executing this command, please check the console log for details." );
-            ProxyServer.getInstance().getLogger().log( Level.WARNING, "Error in dispatching command", ex );
-        }
-        return true;
-    }
+    boolean dispatchCommand(CommandSender sender, String commandLine) throws CommandExecutionException;
 
     /**
-     * Returns the {@link Plugin} objects corresponding to all loaded plugins.
-     *
-     * @return the set of loaded plugins
+     * Dispatches a command to all registered commands. If {@code tabResults} is non-null, asks for tab completion instead.
+     * If an exception occurs during command execution, the exception will be rethrown as an {@link CommandExecutionException}.
+     * @param sender the sender to use
+     * @param commandLine the full command to execute
+     * @param tabResults mutable {@code List} of results for tab complete, or {@code null} for command execution
+     * @return whether or not the command was executed
+     * @throws CommandExecutionException if an exception occurred whilst executing the command
      */
-    public Collection<Plugin> getPlugins()
-    {
-        return plugins.values();
-    }
+    boolean dispatchCommand(CommandSender sender, String commandLine, List<String> tabResults) throws CommandExecutionException;
 
     /**
-     * Returns a loaded plugin identified by the specified name.
-     *
-     * @param name of the plugin to retrieve
-     * @return the retrieved plugin or null if not loaded
+     * Returns a collection of all plugins enabled on this proxy.
+     * @return the plugins enabled
      */
-    public Plugin getPlugin(String name)
-    {
-        return plugins.get( name );
-    }
-
-    public void loadPlugins()
-    {
-        Map<PluginDescription, Boolean> pluginStatuses = new HashMap<>();
-        for ( Map.Entry<String, PluginDescription> entry : toLoad.entrySet() )
-        {
-            PluginDescription plugin = entry.getValue();
-            if ( !enablePlugin( pluginStatuses, new Stack<PluginDescription>(), plugin ) )
-            {
-                ProxyServer.getInstance().getLogger().log( Level.WARNING, "Failed to enable {0}", entry.getKey() );
-            }
-        }
-        toLoad.clear();
-        toLoad = null;
-    }
-
-    public void enablePlugins()
-    {
-        for ( Plugin plugin : plugins.values() )
-        {
-            try
-            {
-                plugin.onEnable();
-                ProxyServer.getInstance().getLogger().log( Level.INFO, "Enabled plugin {0} version {1} by {2}", new Object[]
-                {
-                    plugin.getDescription().getName(), plugin.getDescription().getVersion(), plugin.getDescription().getAuthor()
-                } );
-            } catch ( Throwable t )
-            {
-                ProxyServer.getInstance().getLogger().log( Level.WARNING, "Exception encountered when loading plugin: " + plugin.getDescription().getName(), t );
-            }
-        }
-    }
-
-    private boolean enablePlugin(Map<PluginDescription, Boolean> pluginStatuses, Stack<PluginDescription> dependStack, PluginDescription plugin)
-    {
-        if ( pluginStatuses.containsKey( plugin ) )
-        {
-            return pluginStatuses.get( plugin );
-        }
-
-        // combine all dependencies for 'for loop'
-        Set<String> dependencies = new HashSet<>();
-        dependencies.addAll( plugin.getDepends() );
-        dependencies.addAll( plugin.getSoftDepends() );
-
-        // success status
-        boolean status = true;
-
-        // try to load dependencies first
-        for ( String dependName : dependencies )
-        {
-            PluginDescription depend = toLoad.get( dependName );
-            Boolean dependStatus = ( depend != null ) ? pluginStatuses.get( depend ) : Boolean.FALSE;
-
-            if ( dependStatus == null )
-            {
-                if ( dependStack.contains( depend ) )
-                {
-                    StringBuilder dependencyGraph = new StringBuilder();
-                    for ( PluginDescription element : dependStack )
-                    {
-                        dependencyGraph.append( element.getName() ).append( " -> " );
-                    }
-                    dependencyGraph.append( plugin.getName() ).append( " -> " ).append( dependName );
-                    ProxyServer.getInstance().getLogger().log( Level.WARNING, "Circular dependency detected: {0}", dependencyGraph );
-                    status = false;
-                } else
-                {
-                    dependStack.push( plugin );
-                    dependStatus = this.enablePlugin( pluginStatuses, dependStack, depend );
-                    dependStack.pop();
-                }
-            }
-
-            if ( dependStatus == Boolean.FALSE && plugin.getDepends().contains( dependName ) ) // only fail if this wasn't a soft dependency
-            {
-                ProxyServer.getInstance().getLogger().log( Level.WARNING, "{0} (required by {1}) is unavailable", new Object[]
-                {
-                    String.valueOf( dependName ), plugin.getName()
-                } );
-                status = false;
-            }
-
-            if ( !status )
-            {
-                break;
-            }
-        }
-
-        // do actual loading
-        if ( status )
-        {
-            try
-            {
-                URLClassLoader loader = new PluginClassloader( new URL[]
-                {
-                    plugin.getFile().toURI().toURL()
-                } );
-                Class<?> main = loader.loadClass( plugin.getMain() );
-                Plugin clazz = (Plugin) main.getDeclaredConstructor().newInstance();
-
-                clazz.init( proxy, plugin );
-                plugins.put( plugin.getName(), clazz );
-                clazz.onLoad();
-                ProxyServer.getInstance().getLogger().log( Level.INFO, "Loaded plugin {0} version {1} by {2}", new Object[]
-                {
-                    plugin.getName(), plugin.getVersion(), plugin.getAuthor()
-                } );
-            } catch ( Throwable t )
-            {
-                proxy.getLogger().log( Level.WARNING, "Error enabling plugin " + plugin.getName(), t );
-            }
-        }
-
-        pluginStatuses.put( plugin, status );
-        return status;
-    }
+    Collection<Plugin> getPlugins();
 
     /**
-     * Load all plugins from the specified folder.
-     *
-     * @param folder the folder to search for plugins in
+     * Returns a specific plugin with this {@code name}.
+     * @param name the name to use
+     * @return the plugin, if enabled
      */
-    public void detectPlugins(File folder)
-    {
-        Preconditions.checkNotNull( folder, "folder" );
-        Preconditions.checkArgument( folder.isDirectory(), "Must load from a directory" );
-
-        for ( File file : folder.listFiles() )
-        {
-            if ( file.isFile() && file.getName().endsWith( ".jar" ) )
-            {
-                try ( JarFile jar = new JarFile( file ) )
-                {
-                    JarEntry pdf = jar.getJarEntry( "bungee.yml" );
-                    if ( pdf == null )
-                    {
-                        pdf = jar.getJarEntry( "plugin.yml" );
-                    }
-                    Preconditions.checkNotNull( pdf, "Plugin must have a plugin.yml or bungee.yml" );
-
-                    try ( InputStream in = jar.getInputStream( pdf ) )
-                    {
-                        PluginDescription desc = yaml.loadAs( in, PluginDescription.class );
-                        desc.setFile( file );
-                        toLoad.put( desc.getName(), desc );
-                    }
-                } catch ( Exception ex )
-                {
-                    ProxyServer.getInstance().getLogger().log( Level.WARNING, "Could not load plugin from file " + file, ex );
-                }
-            }
-        }
-    }
+    Plugin getPlugin(String name);
 
     /**
-     * Dispatch an event to all subscribed listeners and return the event once
-     * it has been handled by these listeners.
-     *
-     * @param <T> the type bounds, must be a class which extends event
-     * @param event the event to call
-     * @return the called event
+     * Posts an event to the BungeeCord event bus.
+     * @param event the event to be fired
+     * @param <T> the event type to use
+     * @return the same event instance passed in
      */
-    public <T extends Event> T callEvent(T event)
-    {
-        Preconditions.checkNotNull( event, "event" );
-
-        long start = System.nanoTime();
-        eventBus.post( event );
-        event.postCall();
-
-        long elapsed = start - System.nanoTime();
-        if ( elapsed > 250000 )
-        {
-            ProxyServer.getInstance().getLogger().log( Level.WARNING, "Event {0} took more {1}ns to process!", new Object[]
-            {
-                event, elapsed
-            } );
-        }
-        return event;
-    }
+    <T extends Event> T callEvent(T event);
 
     /**
-     * Register a {@link Listener} for receiving called events. Methods in this
-     * Object which wish to receive events must be annotated with the
-     * {@link EventHandler} annotation.
-     *
-     * @param plugin the owning plugin
-     * @param listener the listener to register events for
+     * Registers a listener associated with a plugin.
+     * @param plugin the plugin associated with this listener
+     * @param listener the listener to register
      */
-    public void registerListener(Plugin plugin, Listener listener)
-    {
-        for ( Method method : listener.getClass().getDeclaredMethods() )
-        {
-            Preconditions.checkArgument( !method.isAnnotationPresent( Subscribe.class ),
-                    "Listener %s has registered using deprecated subscribe annotation! Please update to @EventHandler.", listener );
-        }
-        eventBus.register( listener );
-        listenersByPlugin.put( plugin, listener );
-    }
+    void registerListener(Plugin plugin, Listener listener);
 
     /**
-     * Unregister a {@link Listener} so that the events do not reach it anymore.
-     *
-     * @param listener the listener to unregister
+     * Unregisters a listener.
+     * @param listener the listener to deregister
      */
-    public void unregisterListener(Listener listener)
-    {
-        eventBus.unregister( listener );
-        listenersByPlugin.values().remove( listener );
-    }
+    void unregisterListener(Listener listener);
 
     /**
-     * Unregister all of a Plugin's listener.
+     * Unregisters all listeners associated with a plugin.
+     * @param plugin the plugin whose listeners are to be unregistered
      */
-    public void unregisterListeners(Plugin plugin)
-    {
-        for ( Iterator<Listener> it = listenersByPlugin.get( plugin ).iterator(); it.hasNext(); )
-        {
-            eventBus.unregister( it.next() );
-            it.remove();
-        }
-    }
+    void unregisterListeners(Plugin plugin);
 }

--- a/api/src/main/java/net/md_5/bungee/api/plugin/PluginManagerImpl.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/PluginManagerImpl.java
@@ -1,0 +1,438 @@
+package net.md_5.bungee.api.plugin;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import com.google.common.eventbus.Subscribe;
+import java.io.File;
+import java.io.InputStream;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.Stack;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.logging.Level;
+import java.util.regex.Pattern;
+import lombok.RequiredArgsConstructor;
+import net.md_5.bungee.api.CommandSender;
+import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.connection.ProxiedPlayer;
+import net.md_5.bungee.event.EventBus;
+import net.md_5.bungee.event.EventHandler;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.Constructor;
+import org.yaml.snakeyaml.introspector.PropertyUtils;
+
+/**
+ * Class to manage bridging between plugin duties and implementation duties, for
+ * example event handling and plugin management.
+ */
+@RequiredArgsConstructor
+public class PluginManagerImpl implements PluginManager
+{
+
+    private static final Pattern argsSplit = Pattern.compile( " " );
+    /*========================================================================*/
+    private final ProxyServer proxy;
+    /*========================================================================*/
+    private final Yaml yaml;
+    private final EventBus eventBus;
+    private final Map<String, Plugin> plugins = new LinkedHashMap<>();
+    private final Map<String, Command> commandMap = new HashMap<>();
+    private Map<String, PluginDescription> toLoad = new HashMap<>();
+    private final Multimap<Plugin, Command> commandsByPlugin = ArrayListMultimap.create();
+    private final Multimap<Plugin, Listener> listenersByPlugin = ArrayListMultimap.create();
+
+    @SuppressWarnings("unchecked")
+    public PluginManagerImpl(ProxyServer proxy)
+    {
+        this.proxy = proxy;
+
+        // Ignore unknown entries in the plugin descriptions
+        Constructor yamlConstructor = new Constructor();
+        PropertyUtils propertyUtils = yamlConstructor.getPropertyUtils();
+        propertyUtils.setSkipMissingProperties( true );
+        yamlConstructor.setPropertyUtils( propertyUtils );
+        yaml = new Yaml( yamlConstructor );
+
+        eventBus = new EventBus( proxy.getLogger() );
+    }
+
+    /**
+     * Register a command so that it may be executed.
+     *
+     * @param plugin the plugin owning this command
+     * @param command the command to register
+     */
+    @Override
+    public void registerCommand(Plugin plugin, Command command)
+    {
+        commandMap.put( command.getName().toLowerCase(), command );
+        for ( String alias : command.getAliases() )
+        {
+            commandMap.put( alias.toLowerCase(), command );
+        }
+        commandsByPlugin.put( plugin, command );
+    }
+
+    /**
+     * Unregister a command so it will no longer be executed.
+     *
+     * @param command the command to unregister
+     */
+    @Override
+    public void unregisterCommand(Command command)
+    {
+        while ( commandMap.values().remove( command ) );
+        commandsByPlugin.values().remove( command );
+    }
+
+    /**
+     * Unregister all commands owned by a {@link Plugin}
+     *
+     * @param plugin the plugin to register the commands of
+     */
+    @Override
+    public void unregisterCommands(Plugin plugin)
+    {
+        for ( Iterator<Command> it = commandsByPlugin.get( plugin ).iterator(); it.hasNext(); )
+        {
+            Command command = it.next();
+            while ( commandMap.values().remove( command ) );
+            it.remove();
+        }
+    }
+
+    @Override
+    public boolean dispatchCommand(CommandSender sender, String commandLine) throws CommandExecutionException
+    {
+        return dispatchCommand( sender, commandLine, null );
+    }
+
+    /**
+     * Execute a command if it is registered, else return false.
+     *
+     * @param sender the sender executing the command
+     * @param commandLine the complete command line including command name and
+     * arguments
+     * @return whether the command was handled
+     */
+    @Override
+    public boolean dispatchCommand(CommandSender sender, String commandLine, List<String> tabResults) throws CommandExecutionException
+    {
+        String[] split = argsSplit.split( commandLine, -1 );
+        // Check for chat that only contains " "
+        if ( split.length == 0 )
+        {
+            return false;
+        }
+
+        String commandName = split[0].toLowerCase();
+        if ( sender instanceof ProxiedPlayer && proxy.getDisabledCommands().contains( commandName ) )
+        {
+            return false;
+        }
+        Command command = commandMap.get( commandName );
+        if ( command == null )
+        {
+            return false;
+        }
+
+        String permission = command.getPermission();
+        if ( permission != null && !permission.isEmpty() && !sender.hasPermission( permission ) )
+        {
+            if ( !( command instanceof TabExecutor ) || tabResults == null )
+            {
+                sender.sendMessage( proxy.getTranslation( "no_permission" ) );
+            }
+            return true;
+        }
+
+        String[] args = Arrays.copyOfRange( split, 1, split.length );
+        try
+        {
+            if ( tabResults == null )
+            {
+                if ( proxy.getConfig().isLogCommands() )
+                {
+                    proxy.getLogger().log( Level.INFO, "{0} executed command: /{1}", new Object[]
+                    {
+                        sender.getName(), commandLine
+                    } );
+                }
+                command.execute( sender, args );
+            } else if ( commandLine.contains( " " ) && command instanceof TabExecutor )
+            {
+                for ( String s : ( (TabExecutor) command ).onTabComplete( sender, args ) )
+                {
+                    tabResults.add( s );
+                }
+            }
+        } catch ( Exception ex )
+        {
+            throw new CommandExecutionException( "Command '" + command.getName() + "' threw an exception", ex );
+        }
+        return true;
+    }
+
+    /**
+     * Returns the {@link Plugin} objects corresponding to all loaded plugins.
+     *
+     * @return the set of loaded plugins
+     */
+    @Override
+    public Collection<Plugin> getPlugins()
+    {
+        return plugins.values();
+    }
+
+    /**
+     * Returns a loaded plugin identified by the specified name.
+     *
+     * @param name of the plugin to retrieve
+     * @return the retrieved plugin or null if not loaded
+     */
+    @Override
+    public Plugin getPlugin(String name)
+    {
+        return plugins.get( name );
+    }
+
+    public void loadPlugins()
+    {
+        Map<PluginDescription, Boolean> pluginStatuses = new HashMap<>();
+        for ( Map.Entry<String, PluginDescription> entry : toLoad.entrySet() )
+        {
+            PluginDescription plugin = entry.getValue();
+            if ( !enablePlugin( pluginStatuses, new Stack<PluginDescription>(), plugin ) )
+            {
+                ProxyServer.getInstance().getLogger().log( Level.WARNING, "Failed to enable {0}", entry.getKey() );
+            }
+        }
+        toLoad.clear();
+        toLoad = null;
+    }
+
+    public void enablePlugins()
+    {
+        for ( Plugin plugin : plugins.values() )
+        {
+            try
+            {
+                plugin.onEnable();
+                ProxyServer.getInstance().getLogger().log( Level.INFO, "Enabled plugin {0} version {1} by {2}", new Object[]
+                {
+                    plugin.getDescription().getName(), plugin.getDescription().getVersion(), plugin.getDescription().getAuthor()
+                } );
+            } catch ( Throwable t )
+            {
+                ProxyServer.getInstance().getLogger().log( Level.WARNING, "Exception encountered when loading plugin: " + plugin.getDescription().getName(), t );
+            }
+        }
+    }
+
+    private boolean enablePlugin(Map<PluginDescription, Boolean> pluginStatuses, Stack<PluginDescription> dependStack, PluginDescription plugin)
+    {
+        if ( pluginStatuses.containsKey( plugin ) )
+        {
+            return pluginStatuses.get( plugin );
+        }
+
+        // combine all dependencies for 'for loop'
+        Set<String> dependencies = new HashSet<>();
+        dependencies.addAll( plugin.getDepends() );
+        dependencies.addAll( plugin.getSoftDepends() );
+
+        // success status
+        boolean status = true;
+
+        // try to load dependencies first
+        for ( String dependName : dependencies )
+        {
+            PluginDescription depend = toLoad.get( dependName );
+            Boolean dependStatus = ( depend != null ) ? pluginStatuses.get( depend ) : Boolean.FALSE;
+
+            if ( dependStatus == null )
+            {
+                if ( dependStack.contains( depend ) )
+                {
+                    StringBuilder dependencyGraph = new StringBuilder();
+                    for ( PluginDescription element : dependStack )
+                    {
+                        dependencyGraph.append( element.getName() ).append( " -> " );
+                    }
+                    dependencyGraph.append( plugin.getName() ).append( " -> " ).append( dependName );
+                    ProxyServer.getInstance().getLogger().log( Level.WARNING, "Circular dependency detected: {0}", dependencyGraph );
+                    status = false;
+                } else
+                {
+                    dependStack.push( plugin );
+                    dependStatus = this.enablePlugin( pluginStatuses, dependStack, depend );
+                    dependStack.pop();
+                }
+            }
+
+            if ( dependStatus == Boolean.FALSE && plugin.getDepends().contains( dependName ) ) // only fail if this wasn't a soft dependency
+            {
+                ProxyServer.getInstance().getLogger().log( Level.WARNING, "{0} (required by {1}) is unavailable", new Object[]
+                {
+                    String.valueOf( dependName ), plugin.getName()
+                } );
+                status = false;
+            }
+
+            if ( !status )
+            {
+                break;
+            }
+        }
+
+        // do actual loading
+        if ( status )
+        {
+            try
+            {
+                URLClassLoader loader = new PluginClassloader( new URL[]
+                {
+                    plugin.getFile().toURI().toURL()
+                } );
+                Class<?> main = loader.loadClass( plugin.getMain() );
+                Plugin clazz = (Plugin) main.getDeclaredConstructor().newInstance();
+
+                clazz.init( proxy, plugin );
+                plugins.put( plugin.getName(), clazz );
+                clazz.onLoad();
+                ProxyServer.getInstance().getLogger().log( Level.INFO, "Loaded plugin {0} version {1} by {2}", new Object[]
+                {
+                    plugin.getName(), plugin.getVersion(), plugin.getAuthor()
+                } );
+            } catch ( Throwable t )
+            {
+                proxy.getLogger().log( Level.WARNING, "Error enabling plugin " + plugin.getName(), t );
+            }
+        }
+
+        pluginStatuses.put( plugin, status );
+        return status;
+    }
+
+    /**
+     * Load all plugins from the specified folder.
+     *
+     * @param folder the folder to search for plugins in
+     */
+    public void detectPlugins(File folder)
+    {
+        Preconditions.checkNotNull( folder, "folder" );
+        Preconditions.checkArgument( folder.isDirectory(), "Must load from a directory" );
+
+        for ( File file : folder.listFiles() )
+        {
+            if ( file.isFile() && file.getName().endsWith( ".jar" ) )
+            {
+                try ( JarFile jar = new JarFile( file ) )
+                {
+                    JarEntry pdf = jar.getJarEntry( "bungee.yml" );
+                    if ( pdf == null )
+                    {
+                        pdf = jar.getJarEntry( "plugin.yml" );
+                    }
+                    Preconditions.checkNotNull( pdf, "Plugin must have a plugin.yml or bungee.yml" );
+
+                    try ( InputStream in = jar.getInputStream( pdf ) )
+                    {
+                        PluginDescription desc = yaml.loadAs( in, PluginDescription.class );
+                        desc.setFile( file );
+                        toLoad.put( desc.getName(), desc );
+                    }
+                } catch ( Exception ex )
+                {
+                    ProxyServer.getInstance().getLogger().log( Level.WARNING, "Could not load plugin from file " + file, ex );
+                }
+            }
+        }
+    }
+
+    /**
+     * Dispatch an event to all subscribed listeners and return the event once
+     * it has been handled by these listeners.
+     *
+     * @param <T> the type bounds, must be a class which extends event
+     * @param event the event to call
+     * @return the called event
+     */
+    @Override
+    public <T extends Event> T callEvent(T event)
+    {
+        Preconditions.checkNotNull( event, "event" );
+
+        long start = System.nanoTime();
+        eventBus.post( event );
+        event.postCall();
+
+        long elapsed = start - System.nanoTime();
+        if ( elapsed > 250000 )
+        {
+            ProxyServer.getInstance().getLogger().log( Level.WARNING, "Event {0} took more {1}ns to process!", new Object[]
+            {
+                event, elapsed
+            } );
+        }
+        return event;
+    }
+
+    /**
+     * Register a {@link Listener} for receiving called events. Methods in this
+     * Object which wish to receive events must be annotated with the
+     * {@link EventHandler} annotation.
+     *
+     * @param plugin the owning plugin
+     * @param listener the listener to register events for
+     */
+    @Override
+    public void registerListener(Plugin plugin, Listener listener)
+    {
+        for ( Method method : listener.getClass().getDeclaredMethods() )
+        {
+            Preconditions.checkArgument( !method.isAnnotationPresent( Subscribe.class ),
+                    "Listener %s has registered using deprecated subscribe annotation! Please update to @EventHandler.", listener );
+        }
+        eventBus.register( listener );
+        listenersByPlugin.put( plugin, listener );
+    }
+
+    /**
+     * Unregister a {@link Listener} so that the events do not reach it anymore.
+     *
+     * @param listener the listener to unregister
+     */
+    @Override
+    public void unregisterListener(Listener listener)
+    {
+        eventBus.unregister( listener );
+        listenersByPlugin.values().remove( listener );
+    }
+
+    /**
+     * Unregister all of a Plugin's listener.
+     */
+    @Override
+    public void unregisterListeners(Plugin plugin)
+    {
+        for ( Iterator<Listener> it = listenersByPlugin.get( plugin ).iterator(); it.hasNext(); )
+        {
+            eventBus.unregister( it.next() );
+            it.remove();
+        }
+    }
+}

--- a/bootstrap/src/main/java/net/md_5/bungee/BungeeCordLauncher.java
+++ b/bootstrap/src/main/java/net/md_5/bungee/BungeeCordLauncher.java
@@ -6,10 +6,13 @@ import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.plugin.CommandExecutionException;
 import net.md_5.bungee.command.ConsoleCommandSender;
 
 public class BungeeCordLauncher
@@ -59,9 +62,15 @@ public class BungeeCordLauncher
             String line;
             while ( bungee.isRunning && ( line = bungee.getConsoleReader().readLine( ">" ) ) != null )
             {
-                if ( !bungee.getPluginManager().dispatchCommand( ConsoleCommandSender.getInstance(), line ) )
+                try
                 {
-                    bungee.getConsole().sendMessage( ChatColor.RED + "Command not found" );
+                    if ( !bungee.getPluginManager().dispatchCommand( ConsoleCommandSender.getInstance(), line ) )
+                    {
+                        bungee.getConsole().sendMessage(ChatColor.RED + "Command not found");
+                    }
+                } catch ( CommandExecutionException e )
+                {
+                    bungee.getLogger().log( Level.WARNING, "Error in dispatching command", e );
                 }
             }
         }

--- a/proxy/src/main/java/Test.java
+++ b/proxy/src/main/java/Test.java
@@ -2,7 +2,10 @@
 import net.md_5.bungee.BungeeCord;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.plugin.CommandExecutionException;
 import net.md_5.bungee.command.ConsoleCommandSender;
+
+import java.util.logging.Level;
 
 /*
  * To change this template, choose Tools | Templates
@@ -27,9 +30,15 @@ public class Test
             String line = bungee.getConsoleReader().readLine( ">" );
             if ( line != null )
             {
-                if ( !bungee.getPluginManager().dispatchCommand( ConsoleCommandSender.getInstance(), line ) )
+                try
                 {
-                    bungee.getConsole().sendMessage( ChatColor.RED + "Command not found" );
+                    if ( !bungee.getPluginManager().dispatchCommand( ConsoleCommandSender.getInstance(), line ) )
+                    {
+                        bungee.getConsole().sendMessage(ChatColor.RED + "Command not found");
+                    }
+                } catch ( CommandExecutionException e )
+                {
+                    bungee.getLogger().log( Level.WARNING, "Error in dispatching command", e );
                 }
             }
         }

--- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
@@ -11,7 +11,6 @@ import net.md_5.bungee.api.Favicon;
 import net.md_5.bungee.api.ServerPing;
 import net.md_5.bungee.api.Title;
 import net.md_5.bungee.module.ModuleManager;
-import com.google.common.io.ByteStreams;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.chat.ComponentSerializer;
@@ -52,9 +51,8 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import jline.UnsupportedTerminal;
+
 import jline.console.ConsoleReader;
-import jline.internal.Log;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.Synchronized;
@@ -66,7 +64,7 @@ import net.md_5.bungee.api.config.ListenerInfo;
 import net.md_5.bungee.api.config.ServerInfo;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.plugin.Plugin;
-import net.md_5.bungee.api.plugin.PluginManager;
+import net.md_5.bungee.api.plugin.PluginManagerImpl;
 import net.md_5.bungee.command.*;
 import net.md_5.bungee.compress.CompressFactory;
 import net.md_5.bungee.conf.YamlConfig;
@@ -122,7 +120,7 @@ public class BungeeCord extends ProxyServer
      * Plugin manager.
      */
     @Getter
-    public final PluginManager pluginManager = new PluginManager( this );
+    public final PluginManagerImpl pluginManager = new PluginManagerImpl( this );
     @Getter
     @Setter
     private ReconnectHandler reconnectHandler;

--- a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
@@ -4,12 +4,14 @@ import com.google.common.base.Preconditions;
 import net.md_5.bungee.BungeeCord;
 import net.md_5.bungee.UserConnection;
 import net.md_5.bungee.Util;
+import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.event.ChatEvent;
 import net.md_5.bungee.api.event.PlayerDisconnectEvent;
 import net.md_5.bungee.api.event.PluginMessageEvent;
 import net.md_5.bungee.api.event.TabCompleteEvent;
+import net.md_5.bungee.api.plugin.CommandExecutionException;
 import net.md_5.bungee.netty.ChannelWrapper;
 import net.md_5.bungee.netty.PacketHandler;
 import net.md_5.bungee.protocol.PacketWrapper;
@@ -22,6 +24,8 @@ import net.md_5.bungee.protocol.packet.ClientSettings;
 import net.md_5.bungee.protocol.packet.PluginMessage;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Level;
+
 import net.md_5.bungee.forge.ForgeConstants;
 import net.md_5.bungee.protocol.packet.TabCompleteResponse;
 
@@ -113,9 +117,16 @@ public class UpstreamBridge extends PacketHandler
         if ( !bungee.getPluginManager().callEvent( chatEvent ).isCancelled() )
         {
             chat.setMessage( chatEvent.getMessage() );
-            if ( !chatEvent.isCommand() || !bungee.getPluginManager().dispatchCommand( con, chat.getMessage().substring( 1 ) ) )
+            try
             {
-                con.getServer().unsafe().sendPacket( chat );
+                if ( !chatEvent.isCommand() || !bungee.getPluginManager().dispatchCommand( con, chat.getMessage().substring( 1 ) ) )
+                {
+                    con.getServer().unsafe().sendPacket( chat );
+                }
+            } catch ( CommandExecutionException ex )
+            {
+                con.sendMessage( ChatColor.RED + "An internal error occurred whilst executing this command, please check the console log for details." );
+                bungee.getLogger().log( Level.WARNING, "Error in dispatching command", ex );
             }
         }
         throw CancelSendSignal.INSTANCE;
@@ -128,7 +139,14 @@ public class UpstreamBridge extends PacketHandler
 
         if ( tabComplete.getCursor().startsWith( "/" ) )
         {
-            bungee.getPluginManager().dispatchCommand( con, tabComplete.getCursor().substring( 1 ), suggestions );
+            try
+            {
+                bungee.getPluginManager().dispatchCommand( con, tabComplete.getCursor().substring( 1 ), suggestions );
+            } catch ( CommandExecutionException ex )
+            {
+                // Just log a message.
+                bungee.getLogger().log( Level.WARNING, "Exception whilst filling tab complete", ex );
+            }
         }
 
         TabCompleteEvent tabCompleteEvent = new TabCompleteEvent( con, con.getServer(), tabComplete.getCursor(), suggestions );


### PR DESCRIPTION
The current BungeeCord implementation of command dispatching is utterly inappropriate for plugins based on successful command execution (i.e. Buycraft). This fixes the issue by allowing an exception to be thrown.

Additionally, PluginManager has become an interface. This allows more flexibility when major changes (like this change) are made.

**THIS WILL BREAK BINARY AND SOURCE COMPATIBILITY. PULL WISELY!**