### PR TITLE
Remove any tracked bossbars when a client switches servers

### DIFF
--- a/protocol/src/main/java/net/md_5/bungee/protocol/AbstractPacketHandler.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/AbstractPacketHandler.java
@@ -1,5 +1,6 @@
 package net.md_5.bungee.protocol;
 
+import net.md_5.bungee.protocol.packet.BossBar;
 import net.md_5.bungee.protocol.packet.KeepAlive;
 import net.md_5.bungee.protocol.packet.ClientSettings;
 import net.md_5.bungee.protocol.packet.ClientStatus;
@@ -141,6 +142,10 @@ public abstract class AbstractPacketHandler
     }
 
     public void handle(SetCompression setCompression) throws Exception
+    {
+    }
+
+    public void handle(BossBar bossBar) throws Exception
     {
     }
 }

--- a/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java
@@ -59,7 +59,7 @@ public enum Protocol
                     TO_CLIENT.registerPacket( 0x01, 0x23, Login.class );
                     TO_CLIENT.registerPacket( 0x02, 0x0F, Chat.class );
                     TO_CLIENT.registerPacket( 0x07, 0x33, Respawn.class );
-                    TO_CLIENT.registerPacket( 0x0C, 0x0C, BossBar.class );
+                    TO_CLIENT.registerPacket( 0x0C, 0x0C, BossBar.class, true );
                     TO_CLIENT.registerPacket( 0x38, 0x2D, PlayerListItem.class ); // PlayerInfo
                     TO_CLIENT.registerPacket( 0x3A, 0x0E, TabCompleteResponse.class );
                     TO_CLIENT.registerPacket( 0x3B, 0x3F, ScoreboardObjective.class );
@@ -168,6 +168,12 @@ public enum Protocol
 
         protected final void registerPacket(int id, int newId, Class<? extends DefinedPacket> packetClass)
         {
+            registerPacket( id, newId, packetClass, false );
+
+        }
+
+        protected final void registerPacket(int id, int newId, Class<? extends DefinedPacket> packetClass, boolean newOnly)
+        {
             try
             {
                 packetConstructors[id] = packetClass.getDeclaredConstructor();
@@ -178,8 +184,12 @@ public enum Protocol
             packetClasses[id] = packetClass;
             packetMap.put( packetClass, id );
 
-            packetRemap.get( ProtocolConstants.MINECRAFT_1_8 ).put( id, id );
-            packetRemapInv.get( ProtocolConstants.MINECRAFT_1_8 ).put( id, id );
+            if ( !newOnly )
+            {
+                packetRemap.get( ProtocolConstants.MINECRAFT_1_8 ).put( id, id );
+                packetRemapInv.get( ProtocolConstants.MINECRAFT_1_8 ).put( id, id );
+            }
+
             packetRemap.get( ProtocolConstants.MINECRAFT_1_9 ).put( newId, id );
             packetRemapInv.get( ProtocolConstants.MINECRAFT_1_9 ).put( id, newId );
         }

--- a/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java
@@ -12,6 +12,7 @@ import java.util.Arrays;
 import java.util.List;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import net.md_5.bungee.protocol.packet.BossBar;
 import net.md_5.bungee.protocol.packet.Chat;
 import net.md_5.bungee.protocol.packet.ClientSettings;
 import net.md_5.bungee.protocol.packet.EncryptionRequest;
@@ -58,6 +59,7 @@ public enum Protocol
                     TO_CLIENT.registerPacket( 0x01, 0x23, Login.class );
                     TO_CLIENT.registerPacket( 0x02, 0x0F, Chat.class );
                     TO_CLIENT.registerPacket( 0x07, 0x33, Respawn.class );
+                    TO_CLIENT.registerPacket( 0x0C, 0x0C, BossBar.class );
                     TO_CLIENT.registerPacket( 0x38, 0x2D, PlayerListItem.class ); // PlayerInfo
                     TO_CLIENT.registerPacket( 0x3A, 0x0E, TabCompleteResponse.class );
                     TO_CLIENT.registerPacket( 0x3B, 0x3F, ScoreboardObjective.class );

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/BossBar.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/BossBar.java
@@ -1,0 +1,132 @@
+package net.md_5.bungee.protocol.packet;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+import io.netty.buffer.ByteBuf;
+import java.util.UUID;
+import net.md_5.bungee.protocol.AbstractPacketHandler;
+import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.protocol.ProtocolConstants;
+
+@Data
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = false)
+public class BossBar extends DefinedPacket
+{
+
+    private UUID uuid;
+    private Action action;
+    private String title;
+    private float health;
+    private Color color;
+    private Division division;
+    private byte flags;
+
+    public BossBar(UUID uuid, Action action)
+    {
+        this.uuid = uuid;
+        this.action = action;
+    }
+
+    @Override
+    public void read(ByteBuf buf, ProtocolConstants.Direction direction, int protocolVersion)
+    {
+        uuid = readUUID( buf );
+        action = Action.values()[readVarInt( buf )];
+
+        switch ( action )
+        {
+            case ADD:
+                title = readString( buf );
+                health = buf.readFloat();
+                color = Color.values()[readVarInt( buf )];
+                division = Division.values()[readVarInt( buf )];
+                flags = buf.readByte();
+                break;
+            case HEATLH:
+                health = buf.readFloat();
+                break;
+            case TITLE:
+                title = readString( buf );
+                break;
+            case STYLE:
+                color = Color.values()[readVarInt( buf )];
+                division = Division.values()[readVarInt( buf )];
+                break;
+            case FLAGS:
+                flags = buf.readByte();
+                break;
+        }
+    }
+
+    @Override
+    public void write(ByteBuf buf, ProtocolConstants.Direction direction, int protocolVersion)
+    {
+        writeUUID( uuid, buf );
+        writeVarInt( action.ordinal(), buf );
+
+        switch ( action )
+        {
+            case ADD:
+                writeString( title, buf );
+                buf.writeFloat( health );
+                writeVarInt( color.ordinal(), buf );
+                writeVarInt( division.ordinal(), buf );
+                buf.writeByte( flags );
+                break;
+            case HEATLH:
+                buf.writeFloat( health );
+                break;
+            case TITLE:
+                writeString( title, buf );
+                break;
+            case STYLE:
+                writeVarInt( color.ordinal(), buf );
+                writeVarInt( division.ordinal(), buf );
+                break;
+            case FLAGS:
+                buf.writeByte( flags );
+                break;
+        }
+    }
+
+    @Override
+    public void handle(AbstractPacketHandler handler) throws Exception
+    {
+        handler.handle( this );
+    }
+
+    public static enum Division
+    {
+        NONE,
+        SIX,
+        TEN,
+        TWELVE,
+        TWENTY;
+    }
+
+    public static enum Action
+    {
+
+        ADD,
+        REMOVE,
+        HEATLH,
+        TITLE,
+        STYLE,
+        FLAGS;
+    }
+
+    public static enum Color
+    {
+
+        PINK,
+        BLUE,
+        RED,
+        GREEN,
+        YELLOW,
+        PURPLE,
+        WHITE;
+    }
+}

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/BossBar.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/BossBar.java
@@ -17,14 +17,14 @@ public class BossBar extends DefinedPacket
 {
 
     private UUID uuid;
-    private Action action;
+    private int action;
     private String title;
     private float health;
-    private Color color;
-    private Division division;
+    private int color;
+    private int division;
     private byte flags;
 
-    public BossBar(UUID uuid, Action action)
+    public BossBar(UUID uuid, int action)
     {
         this.uuid = uuid;
         this.action = action;
@@ -34,28 +34,33 @@ public class BossBar extends DefinedPacket
     public void read(ByteBuf buf, ProtocolConstants.Direction direction, int protocolVersion)
     {
         uuid = readUUID( buf );
-        action = Action.values()[readVarInt( buf )];
+        action = readVarInt( buf );
 
         switch ( action )
         {
-            case ADD:
+            // Add
+            case 0:
                 title = readString( buf );
                 health = buf.readFloat();
-                color = Color.values()[readVarInt( buf )];
-                division = Division.values()[readVarInt( buf )];
+                color = readVarInt( buf );
+                division = readVarInt( buf );
                 flags = buf.readByte();
                 break;
-            case HEATLH:
+            // Health
+            case 2:
                 health = buf.readFloat();
                 break;
-            case TITLE:
+            // Title
+            case 3:
                 title = readString( buf );
                 break;
-            case STYLE:
-                color = Color.values()[readVarInt( buf )];
-                division = Division.values()[readVarInt( buf )];
+            // Style
+            case 4:
+                color = readVarInt( buf );
+                division = readVarInt( buf );
                 break;
-            case FLAGS:
+            // Flags
+            case 5:
                 flags = buf.readByte();
                 break;
         }
@@ -65,28 +70,33 @@ public class BossBar extends DefinedPacket
     public void write(ByteBuf buf, ProtocolConstants.Direction direction, int protocolVersion)
     {
         writeUUID( uuid, buf );
-        writeVarInt( action.ordinal(), buf );
+        writeVarInt( action, buf );
 
         switch ( action )
         {
-            case ADD:
+            // Add
+            case 0:
                 writeString( title, buf );
                 buf.writeFloat( health );
-                writeVarInt( color.ordinal(), buf );
-                writeVarInt( division.ordinal(), buf );
+                writeVarInt( color, buf );
+                writeVarInt( division, buf );
                 buf.writeByte( flags );
                 break;
-            case HEATLH:
+            // Health
+            case 2:
                 buf.writeFloat( health );
                 break;
-            case TITLE:
+            // Title
+            case 3:
                 writeString( title, buf );
                 break;
-            case STYLE:
-                writeVarInt( color.ordinal(), buf );
-                writeVarInt( division.ordinal(), buf );
+            // Style
+            case 4:
+                writeVarInt( color, buf );
+                writeVarInt( division, buf );
                 break;
-            case FLAGS:
+            // Flags
+            case 5:
                 buf.writeByte( flags );
                 break;
         }
@@ -96,37 +106,5 @@ public class BossBar extends DefinedPacket
     public void handle(AbstractPacketHandler handler) throws Exception
     {
         handler.handle( this );
-    }
-
-    public static enum Division
-    {
-        NONE,
-        SIX,
-        TEN,
-        TWELVE,
-        TWENTY;
-    }
-
-    public static enum Action
-    {
-
-        ADD,
-        REMOVE,
-        HEATLH,
-        TITLE,
-        STYLE,
-        FLAGS;
-    }
-
-    public static enum Color
-    {
-
-        PINK,
-        BLUE,
-        RED,
-        GREEN,
-        YELLOW,
-        PURPLE,
-        WHITE;
     }
 }

--- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
+++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
@@ -219,7 +219,8 @@ public class ServerConnector extends PacketHandler
 
             for ( UUID bossbar : user.getSentBossBars() )
             {
-                user.unsafe().sendPacket( new net.md_5.bungee.protocol.packet.BossBar( bossbar, BossBar.Action.REMOVE ) );
+                // Send remove bossbar packet
+                user.unsafe().sendPacket( new net.md_5.bungee.protocol.packet.BossBar( bossbar, 1 ) );
             }
             user.getSentBossBars().clear();
 

--- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
+++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
@@ -1,13 +1,12 @@
 package net.md_5.bungee;
 
-import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 
-import java.util.List;
 import java.util.Queue;
 import java.util.Set;
+import java.util.UUID;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import net.md_5.bungee.api.ChatColor;
@@ -31,7 +30,7 @@ import net.md_5.bungee.netty.HandlerBoss;
 import net.md_5.bungee.netty.PacketHandler;
 import net.md_5.bungee.protocol.DefinedPacket;
 import net.md_5.bungee.protocol.Protocol;
-import net.md_5.bungee.protocol.ProtocolConstants;
+import net.md_5.bungee.protocol.packet.BossBar;
 import net.md_5.bungee.protocol.packet.EncryptionRequest;
 import net.md_5.bungee.protocol.packet.Handshake;
 import net.md_5.bungee.protocol.packet.Kick;
@@ -217,6 +216,11 @@ public class ServerConnector extends PacketHandler
                 user.unsafe().sendPacket( new net.md_5.bungee.protocol.packet.Team( team.getName() ) );
             }
             serverScoreboard.clear();
+
+            for ( UUID bossbar : user.getSentBossBars() )
+            {
+                user.unsafe().sendPacket( new net.md_5.bungee.protocol.packet.BossBar( bossbar, BossBar.Action.REMOVE ) );
+            }
 
             user.sendDimensionSwitch();
 

--- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
+++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
@@ -221,6 +221,7 @@ public class ServerConnector extends PacketHandler
             {
                 user.unsafe().sendPacket( new net.md_5.bungee.protocol.packet.BossBar( bossbar, BossBar.Action.REMOVE ) );
             }
+            user.getSentBossBars().clear();
 
             user.sendDimensionSwitch();
 

--- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
@@ -11,6 +11,7 @@ import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.util.internal.PlatformDependent;
 import java.net.InetSocketAddress;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -124,6 +125,8 @@ public final class UserConnection implements ProxiedPlayer
     private ClientSettings settings;
     @Getter
     private final Scoreboard serverSentScoreboard = new Scoreboard();
+    @Getter
+    private final List<UUID> sentBossBars = new ArrayList();
     /*========================================================================*/
     @Getter
     private String displayName;

--- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
@@ -29,7 +29,7 @@ import net.md_5.bungee.netty.ChannelWrapper;
 import net.md_5.bungee.netty.PacketHandler;
 import net.md_5.bungee.protocol.DefinedPacket;
 import net.md_5.bungee.protocol.PacketWrapper;
-import net.md_5.bungee.protocol.ProtocolConstants;
+import net.md_5.bungee.protocol.packet.BossBar;
 import net.md_5.bungee.protocol.packet.KeepAlive;
 import net.md_5.bungee.protocol.packet.PlayerListItem;
 import net.md_5.bungee.protocol.packet.ScoreboardObjective;
@@ -482,6 +482,20 @@ public class DownstreamBridge extends PacketHandler
         }
 
         throw CancelSendSignal.INSTANCE;
+    }
+
+    @Override
+    public void handle(BossBar bossBar)
+    {
+        switch ( bossBar.getAction() )
+        {
+            case ADD:
+                con.getSentBossBars().add( bossBar.getUuid() );
+                break;
+            case REMOVE:
+                con.getSentBossBars().remove( bossBar.getUuid() );
+                break;
+        }
     }
 
     @Override

--- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
@@ -489,10 +489,12 @@ public class DownstreamBridge extends PacketHandler
     {
         switch ( bossBar.getAction() )
         {
-            case ADD:
+            // Handle add bossbar
+            case 0:
                 con.getSentBossBars().add( bossBar.getUuid() );
                 break;
-            case REMOVE:
+            // Handle remove bossbar
+            case 1:
                 con.getSentBossBars().remove( bossBar.getUuid() );
                 break;
         }


### PR DESCRIPTION
Without the proxy tracking and clearing sent bossbars, the client will end up with tons of bossbars if the server doesn't remove them before the client switches. It's impossible for the next server to clear them instead, as it will not know the UUID of any existing bars.

This pull request is complete except that the packet gets added to both 1.8 and 1.9 protocol lists: I haven't touched this as the current protocol class is 1.8 based, so there's no clear way to only register a 1.9 packet. Please tell me how you'd like this to be done and I'll happily implement it.