### PR TITLE
Manually add the setDescriptionComponent(BaseComponent) ...

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/ServerPing.java
+++ b/api/src/main/java/net/md_5/bungee/api/ServerPing.java
@@ -144,6 +144,10 @@ public class ServerPing
     public String getDescription() {
         return BaseComponent.toLegacyText( description );
     }
+    
+    public void setDescriptionComponent(BaseComponent description) {
+        this.description = description;
+    }
 
     public BaseComponent getDescriptionComponent() {
         return description;


### PR DESCRIPTION
... Lombok won't generate because of the overloading of setDescription(String). I named it setDescriptionComponent() for consistency.

As I described over here: https://github.com/SpigotMC/BungeeCord/commit/79262306820cc874d1830210b71729884efaa918#commitcomment-16449199 Lombok won't generate setters for already assigned method names.