### PR TITLE
Should break the priority lookup after server found

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
@@ -243,6 +243,7 @@ public final class UserConnection implements ProxiedPlayer
             if ( !Objects.equal( currentTarget, candidate ) )
             {
                 next = candidate;
+                break;
             }
         }
 


### PR DESCRIPTION
If the list would look like this

- test1 -> 1.8 -> ServerKickEvent cancelled -> reason set to "outdated"
- test2 -> 1.8
- test3 -> 1.9

and a player joins with version 1.8 he would never be connected to test2 because the server test2 is not equal to test1 and the server test3 is not equal to test1.
So test3 is the last in the while loop and would be used also if another server with higher priority matches the requirements.