### PR TITLE
Raise an error if a server in the priority list is undefined

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/conf/Configuration.java
+++ b/proxy/src/main/java/net/md_5/bungee/conf/Configuration.java
@@ -115,8 +115,11 @@ public class Configuration implements ProxyConfig
 
         for ( ListenerInfo listener : listeners )
         {
-            Preconditions.checkArgument( servers.containsKey( listener.getDefaultServer() ), "Default server %s is not defined", listener.getDefaultServer() );
-            Preconditions.checkArgument( servers.containsKey( listener.getFallbackServer() ), "Fallback server %s is not defined", listener.getFallbackServer() );
+            for ( int i = 0; i < listener.getServerPriority().size(); i++ )
+            {
+                String server = listener.getServerPriority().get( i );
+                Preconditions.checkArgument( servers.containsKey( server ), "Server %s (priority %s) is not defined", server, i );
+            }
             for ( String server : listener.getForcedHosts().values() )
             {
                 if ( !servers.containsKey( server ) )


### PR DESCRIPTION
Right now, only server one (and server two, if found) are checked. This adds an exception if any one of the servers isn't found.