### PR TITLE
Limit log on packet overflow

### DIFF
--- a/protocol/src/main/java/net/md_5/bungee/protocol/DefinedPacket.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/DefinedPacket.java
@@ -1,7 +1,6 @@
 package net.md_5.bungee.protocol;
 
 import com.google.common.base.Charsets;
-import com.google.common.base.Preconditions;
 import io.netty.buffer.ByteBuf;
 import java.util.ArrayList;
 import java.util.List;
@@ -15,7 +14,10 @@ public abstract class DefinedPacket
 
     public static void writeString(String s, ByteBuf buf)
     {
-        Preconditions.checkArgument( s.length() <= Short.MAX_VALUE, "Cannot send string longer than Short.MAX_VALUE (got %s characters)", s.length() );
+        if ( s.length() > Short.MAX_VALUE )
+        {
+            throw new OverflowPacketException( String.format( "Cannot send string longer than Short.MAX_VALUE (got %s characters)", s.length() ) );
+        }
 
         byte[] b = s.getBytes( Charsets.UTF_8 );
         writeVarInt( b.length, buf );
@@ -25,7 +27,10 @@ public abstract class DefinedPacket
     public static String readString(ByteBuf buf)
     {
         int len = readVarInt( buf );
-        Preconditions.checkArgument( len <= Short.MAX_VALUE, "Cannot receive string longer than Short.MAX_VALUE (got %s characters)", len );
+        if ( len > Short.MAX_VALUE )
+        {
+            throw new OverflowPacketException( String.format( "Cannot receive string longer than Short.MAX_VALUE (got %s characters)", len ) );
+        }
 
         byte[] b = new byte[ len ];
         buf.readBytes( b );
@@ -35,7 +40,10 @@ public abstract class DefinedPacket
 
     public static void writeArray(byte[] b, ByteBuf buf)
     {
-        Preconditions.checkArgument( b.length <= Short.MAX_VALUE, "Cannot send byte array longer than Short.MAX_VALUE (got %s bytes)", b.length );
+        if ( b.length > Short.MAX_VALUE )
+        {
+            throw new OverflowPacketException( String.format( "Cannot send byte array longer than Short.MAX_VALUE (got %s bytes)", b.length ) );
+        }
         writeVarInt( b.length, buf );
         buf.writeBytes( b );
     }
@@ -48,7 +56,10 @@ public abstract class DefinedPacket
     public static byte[] readArray(ByteBuf buf, int limit)
     {
         int len = readVarInt( buf );
-        Preconditions.checkArgument( len <= limit, "Cannot receive byte array longer than %s (got %s bytes)", limit, len );
+        if ( len > limit )
+        {
+            throw new OverflowPacketException( String.format( "Cannot receive byte array longer than %s (got %s bytes)", limit, len ) );
+        }
         byte[] ret = new byte[ len ];
         buf.readBytes( ret );
         return ret;

--- a/protocol/src/main/java/net/md_5/bungee/protocol/OverflowPacketException.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/OverflowPacketException.java
@@ -1,0 +1,10 @@
+package net.md_5.bungee.protocol;
+
+public class OverflowPacketException extends RuntimeException
+{
+
+    public OverflowPacketException(String message)
+    {
+        super( message );
+    }
+}

--- a/proxy/src/main/java/net/md_5/bungee/netty/HandlerBoss.java
+++ b/proxy/src/main/java/net/md_5/bungee/netty/HandlerBoss.java
@@ -13,6 +13,7 @@ import net.md_5.bungee.connection.CancelSendSignal;
 import net.md_5.bungee.connection.InitialHandler;
 import net.md_5.bungee.connection.PingHandler;
 import net.md_5.bungee.protocol.BadPacketException;
+import net.md_5.bungee.protocol.OverflowPacketException;
 
 /**
  * This class is a primitive wrapper for {@link PacketHandler} instances tied to
@@ -101,6 +102,12 @@ public class HandlerBoss extends ChannelInboundHandlerAdapter
             } else if ( cause instanceof DecoderException && cause.getCause() instanceof BadPacketException )
             {
                 ProxyServer.getInstance().getLogger().log( Level.WARNING, "{0} - bad packet ID, are mods in use!? {1}", new Object[]
+                {
+                    handler, cause.getCause().getMessage()
+                } );
+            } else if ( cause instanceof DecoderException && cause.getCause() instanceof OverflowPacketException )
+            {
+                ProxyServer.getInstance().getLogger().log( Level.WARNING, "{0} - overflow in packet detected! {1}", new Object[]
                 {
                     handler, cause.getCause().getMessage()
                 } );


### PR DESCRIPTION
Added a new exception for packet overflows because these exceptions with stacktrace are spamming the log file.
A server that is attacked by such a hacked client will print tons of traces per second to the log.
Limiting it to the error message should be enough.