### PR TITLE
Fix for missing lifecycle mapping metadata on scriptus for m2e

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,5 +148,36 @@
                 <version>2.7</version>
             </plugin>
         </plugins>
+        <pluginManagement>
+            <plugins>
+                <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+                <plugin>
+                    <groupId>org.eclipse.m2e</groupId>
+                    <artifactId>lifecycle-mapping</artifactId>
+                    <version>1.0.0</version>
+                    <configuration>
+                        <lifecycleMappingMetadata>
+                            <pluginExecutions>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>net.md-5</groupId>
+                                        <artifactId>scriptus</artifactId>
+                                        <versionRange>[0.3.1,)</versionRange>
+                                        <goals>
+                                            <goal>describe</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <execute>
+                                            <runOnIncremental>false</runOnIncremental>
+                                        </execute >
+                                     </action>
+                                </pluginExecution>
+                            </pluginExecutions>
+                        </lifecycleMappingMetadata>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 </project>


### PR DESCRIPTION
Fix for missing lifecycle configuration required by m2eclipse:
`Plugin execution not covered by lifecycle configuration: net.md-5:scriptus:0.3.1:describe (execution: default, phase: initialize)	pom.xml	/bungeecord-api	line 6`
Mandatory for eclipse as it will generate a fatal error preventing a compile.    
After some investigation I found the right fix here: [m2e: Execution not covered](https://www.eclipse.org/m2e/documentation/m2e-execution-not-covered.html) You can even find a rationale why m2eclipse is doing it that way.

This solution    
* works and calls scriptus as can be seen in my [build 14](https://jenkins.3zebras.eu/job/BungeeCord/14/)
* **doesn't interfere with anything other than m2eclipse itself** since it does only change `org.eclipse.m2e` configuration
* would really help all newcomers

There is a possibility to set the goal as ignored in m2eclipse global preferences, however this wouldn't be bound to the project and will potentially interfere with maven setups of the other projects.