### PR TITLE
Fix entitymap for 1.8 so that arrows / rods are transformed correctly.

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/entitymap/EntityMap_1_8.java
+++ b/proxy/src/main/java/net/md_5/bungee/entitymap/EntityMap_1_8.java
@@ -92,17 +92,27 @@ class EntityMap_1_8 extends EntityMap
             DefinedPacket.readVarInt( packet );
             int type = packet.readUnsignedByte();
 
-            if ( type == 60 || type == 90 )
-            {
-                packet.skipBytes( 14 );
+            if ( type == 60 || type == 90 ) {
+                packet.skipBytes(14);
                 int position = packet.readerIndex();
                 int readId = packet.readInt();
-                if ( readId == oldId )
-                {
-                    packet.setInt( position, newId );
-                } else if ( readId == newId )
-                {
-                    packet.setInt( position, oldId );
+                int changedId = -1;
+                if (readId == oldId) {
+                    packet.setInt(position, newId);
+                    changedId = newId;
+                } else if (readId == newId) {
+                    packet.setInt(position, oldId);
+                    changedId = oldId;
+                }
+                if (changedId != -1) {
+                    if (changedId == 0 && readId != 0) { // Trim off the extra data
+                        packet.readerIndex(readerIndex);
+                        packet.writerIndex(packet.readableBytes() - 6);
+                    } else if (changedId != 0 && readId == 0) { // Add on the extra data
+                        packet.readerIndex(readerIndex);
+                        packet.capacity(packet.readableBytes() + 6);
+                        packet.writerIndex(packet.readableBytes() + 6);
+                    }
                 }
             }
         } else if ( packetId == 0x0C /* Spawn Player */ )

--- a/proxy/src/main/java/net/md_5/bungee/entitymap/EntityMap_1_8.java
+++ b/proxy/src/main/java/net/md_5/bungee/entitymap/EntityMap_1_8.java
@@ -90,28 +90,34 @@ class EntityMap_1_8 extends EntityMap
         {
 
             DefinedPacket.readVarInt( packet );
-            int type = packet.readUnsignedByte();
+            int idLength = packet.readerIndex() - readerIndex - packetIdLength;
 
-            if ( type == 60 || type == 90 ) {
-                packet.skipBytes(14);
-                int position = packet.readerIndex();
-                int readId = packet.readInt();
+            int type = packet.getByte( readerIndex + packetIdLength + idLength );
+
+            if ( type == 60 || type == 90 )
+            {
+                int readId = packet.getInt( packetIdLength + idLength + 15 );
                 int changedId = -1;
-                if (readId == oldId) {
-                    packet.setInt(position, newId);
+                if ( readId == oldId )
+                {
+                    packet.setInt( packetIdLength + idLength + 15, newId );
                     changedId = newId;
-                } else if (readId == newId) {
-                    packet.setInt(position, oldId);
-                    changedId = oldId;
+                } else if ( readId == newId )
+                {
+                    packet.setInt( packetIdLength + idLength + 15, oldId );
+                    changedId = newId;
                 }
-                if (changedId != -1) {
-                    if (changedId == 0 && readId != 0) { // Trim off the extra data
-                        packet.readerIndex(readerIndex);
-                        packet.writerIndex(packet.readableBytes() - 6);
-                    } else if (changedId != 0 && readId == 0) { // Add on the extra data
-                        packet.readerIndex(readerIndex);
-                        packet.capacity(packet.readableBytes() + 6);
-                        packet.writerIndex(packet.readableBytes() + 6);
+                if ( changedId != -1 )
+                {
+                    if ( changedId == 0 && readId != 0 )
+                    { // Trim off the extra data
+                        packet.readerIndex( readerIndex );
+                        packet.writerIndex( packet.readableBytes() - 6 );
+                    } else if ( changedId != 0 && readId == 0 )
+                    { // Add on the extra data
+                        packet.readerIndex( readerIndex );
+                        packet.capacity( packet.readableBytes() + 6 );
+                        packet.writerIndex( packet.readableBytes() + 6 );
                     }
                 }
             }


### PR DESCRIPTION
For some reason the 1.8 entity map got changed, I've restored the arrow and fishing rod rewriting to how @Thinkofname made it in:
https://github.com/SpigotMC/BungeeCord/commit/f71272a1c0edfe24754be0047f055d21529ba5f7

This prevents clients from crashing when no data is sent from arrows / fishing rods in terms of the optional velocities.