### PR TITLE
Fire ServerKickEvent when player loss connection to server

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/event/ServerKickEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/ServerKickEvent.java
@@ -44,11 +44,21 @@ public class ServerKickEvent extends Event implements Cancellable
      * State in which the kick occured.
      */
     private State state;
+    /**
+     * Circumstances which led to the kick.
+     */
+    private Cause cause;
 
     public enum State
     {
 
         CONNECTING, CONNECTED, UNKNOWN;
+    }
+
+    public enum Cause
+    {
+
+        SERVER, LOST_CONNECTION, EXCEPTION, UNKNOWN;
     }
 
     @Deprecated
@@ -63,13 +73,20 @@ public class ServerKickEvent extends Event implements Cancellable
         this( player, player.getServer().getInfo(), kickReasonComponent, cancelServer, state );
     }
 
+    @Deprecated
     public ServerKickEvent(ProxiedPlayer player, ServerInfo kickedFrom, BaseComponent[] kickReasonComponent, ServerInfo cancelServer, State state)
+    {
+        this( player, kickedFrom, kickReasonComponent, cancelServer, state, Cause.UNKNOWN );
+    }
+
+    public ServerKickEvent(ProxiedPlayer player, ServerInfo kickedFrom, BaseComponent[] kickReasonComponent, ServerInfo cancelServer, State state, Cause cause)
     {
         this.player = player;
         this.kickedFrom = kickedFrom;
         this.kickReasonComponent = kickReasonComponent;
         this.cancelServer = cancelServer;
         this.state = state;
+        this.cause = cause;
     }
 
     @Deprecated

--- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
+++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
@@ -269,7 +269,7 @@ public class ServerConnector extends PacketHandler
     public void handle(Kick kick) throws Exception
     {
         ServerInfo def = user.updateAndGetNextServer( target );
-        ServerKickEvent event = new ServerKickEvent( user, target, ComponentSerializer.parse( kick.getMessage() ), def, ServerKickEvent.State.CONNECTING );
+        ServerKickEvent event = new ServerKickEvent( user, target, ComponentSerializer.parse( kick.getMessage() ), def, ServerKickEvent.State.CONNECTING, ServerKickEvent.Cause.SERVER );
         if ( event.getKickReason().toLowerCase().contains( "outdated" ) && def != null )
         {
             // Pre cancel the event if we are going to try another server

--- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
@@ -59,7 +59,7 @@ public class DownstreamBridge extends PacketHandler
         }
 
         ServerInfo def = con.updateAndGetNextServer( server.getInfo() );
-        ServerKickEvent event = bungee.getPluginManager().callEvent( new ServerKickEvent( con, server.getInfo(), TextComponent.fromLegacyText( bungee.getTranslation( "server_went_down" ) ), def, ServerKickEvent.State.CONNECTED ) );
+        ServerKickEvent event = bungee.getPluginManager().callEvent( new ServerKickEvent( con, server.getInfo(), TextComponent.fromLegacyText( bungee.getTranslation( "server_went_down" ) ), def, ServerKickEvent.State.CONNECTED, ServerKickEvent.Cause.EXCEPTION ) );
         if ( event.isCancelled() && event.getCancelServer() != null )
         {
             server.setObsolete( true );
@@ -84,7 +84,7 @@ public class DownstreamBridge extends PacketHandler
         if ( !server.isObsolete() )
         {
             ServerInfo def = con.updateAndGetNextServer( server.getInfo() );
-            ServerKickEvent event = bungee.getPluginManager().callEvent( new ServerKickEvent( con, server.getInfo(), TextComponent.fromLegacyText( bungee.getTranslation( "lost_connection" ) ), def, ServerKickEvent.State.CONNECTED ) );
+            ServerKickEvent event = bungee.getPluginManager().callEvent( new ServerKickEvent( con, server.getInfo(), TextComponent.fromLegacyText( bungee.getTranslation( "lost_connection" ) ), def, ServerKickEvent.State.CONNECTED, ServerKickEvent.Cause.LOST_CONNECTION ) );
             if ( event.isCancelled() && event.getCancelServer() != null )
             {
                 server.setObsolete( true );
@@ -464,7 +464,7 @@ public class DownstreamBridge extends PacketHandler
         {
             def = null;
         }
-        ServerKickEvent event = bungee.getPluginManager().callEvent( new ServerKickEvent( con, server.getInfo(), ComponentSerializer.parse( kick.getMessage() ), def, ServerKickEvent.State.CONNECTED ) );
+        ServerKickEvent event = bungee.getPluginManager().callEvent( new ServerKickEvent( con, server.getInfo(), ComponentSerializer.parse( kick.getMessage() ), def, ServerKickEvent.State.CONNECTED, ServerKickEvent.Cause.SERVER ) );
         if ( event.isCancelled() && event.getCancelServer() != null )
         {
             con.connectNow( event.getCancelServer() );


### PR DESCRIPTION
When the player loses the connection to a Minecraft server (downstream), it is kicked. But it is not kicked by the Minecraft server, he is kicked by the proxy.
And in this situation, since the ServerKickEvent is not fired, it is difficult to act (to cancel the kick example).
All networks like manage the fallback server with some sort of load balancing, and this is impossible to do properly without that.

More information here: #1846 