### PR TITLE
Add API to get supported MC Protocols

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/ProxyServer.java
+++ b/api/src/main/java/net/md_5/bungee/api/ProxyServer.java
@@ -6,6 +6,7 @@ import com.google.common.base.Preconditions;
 import java.io.File;
 import java.net.InetSocketAddress;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.logging.Logger;
@@ -199,6 +200,13 @@ public abstract class ProxyServer
      */
     @Deprecated
     public abstract int getProtocolVersion();
+
+    /**
+     * Get the Minecraft Protocol Versions supported by this proxy.
+     *
+     * @return the Minecraft protocol ids list
+     */
+    public abstract List<Integer> getSupportedProtocols();
 
     /**
      * Factory method to construct an implementation specific server info

--- a/protocol/src/main/java/net/md_5/bungee/protocol/ProtocolConstants.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/ProtocolConstants.java
@@ -1,7 +1,6 @@
 package net.md_5.bungee.protocol;
 
-import java.util.Arrays;
-import java.util.List;
+import com.google.common.collect.ImmutableList;
 
 public class ProtocolConstants
 {
@@ -11,11 +10,12 @@ public class ProtocolConstants
     public static final int MINECRAFT_1_9_1 = 108;
     public static final int MINECRAFT_1_9_2 = 109;
     public static final int MINECRAFT_1_9_4 = 110;
-    public static final List<String> SUPPORTED_VERSIONS = Arrays.asList(
+    public static final ImmutableList<String> SUPPORTED_VERSIONS = ImmutableList.of(
             "1.8.x",
             "1.9.x"
     );
-    public static final List<Integer> SUPPORTED_VERSION_IDS = Arrays.asList(ProtocolConstants.MINECRAFT_1_8,
+    public static final ImmutableList<Integer> SUPPORTED_VERSION_IDS = ImmutableList.of(
+            ProtocolConstants.MINECRAFT_1_8,
             ProtocolConstants.MINECRAFT_1_9,
             ProtocolConstants.MINECRAFT_1_9_1,
             ProtocolConstants.MINECRAFT_1_9_2,

--- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
@@ -43,6 +43,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.MissingResourceException;
@@ -581,6 +582,12 @@ public class BungeeCord extends ProxyServer
     public PluginMessage registerChannels()
     {
         return new PluginMessage( "REGISTER", Util.format( pluginChannels, "\00" ).getBytes( Charsets.UTF_8 ), false );
+    }
+
+    @Override
+    public List<Integer> getSupportedProtocols()
+    {
+        return ProtocolConstants.SUPPORTED_VERSION_IDS;
     }
 
     @Override


### PR DESCRIPTION
Adds a getSupportedProtocols() to ProxyServer, allowing plugins to get
the list of supported protocols.
