### PR TITLE
Let Guava handle the Connection Throttling

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/ConnectionThrottle.java
+++ b/proxy/src/main/java/net/md_5/bungee/ConnectionThrottle.java
@@ -8,25 +8,22 @@ import java.util.concurrent.TimeUnit;
 public class ConnectionThrottle
 {
 
-    private final int throttleTime;
-    private final Cache<InetAddress, Long> throttle;
+    private final Cache<InetAddress, Boolean> throttle;
 
     public ConnectionThrottle(int throttleTime)
     {
-        this.throttleTime = throttleTime;
         this.throttle = CacheBuilder.newBuilder()
                 .concurrencyLevel( Runtime.getRuntime().availableProcessors() )
                 .initialCapacity( 100 )
-                .expireAfterAccess( throttleTime, TimeUnit.MILLISECONDS )
+                .expireAfterWrite( throttleTime, TimeUnit.MILLISECONDS )
                 .build();
     }
 
     public boolean throttle(InetAddress address)
     {
-        Long value = throttle.getIfPresent( address );
-        long currentTime = System.currentTimeMillis();
-
-        throttle.put( address, currentTime );
-        return value != null && currentTime - value < throttleTime;
+        boolean isThrottled = throttle.getIfPresent( address ) == true;
+        throttle.put( address, true );
+        
+        return isThrottled;
     }
 }


### PR DESCRIPTION
Less code, less bugs.

The only valid reason I see for this change is : The test failed on my computer, and I don't understand why the code has to be so _ugly_.