### PR TITLE
Use Guava's Ticker in ConnectionThrottle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,7 @@
     <properties>
         <build.number>unknown</build.number>
         <netty.version>4.0.33.Final</netty.version>
+        <guava.version>18.0</guava.version>
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -81,7 +82,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>18.0</version>
+            <version>${guava.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -95,6 +96,12 @@
             <artifactId>lombok</artifactId>
             <version>1.14.8</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava-testlib</artifactId>
+            <version>${guava.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/proxy/src/main/java/net/md_5/bungee/ConnectionThrottle.java
+++ b/proxy/src/main/java/net/md_5/bungee/ConnectionThrottle.java
@@ -1,5 +1,6 @@
 package net.md_5.bungee;
 
+import com.google.common.base.Ticker;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import java.net.InetAddress;
@@ -12,9 +13,15 @@ public class ConnectionThrottle
 
     public ConnectionThrottle(int throttleTime)
     {
+        this( throttleTime, Ticker.systemTicker() );
+    }
+    
+    ConnectionThrottle(int throttleTime, Ticker ticker)
+    {
         this.throttle = CacheBuilder.newBuilder()
                 .concurrencyLevel( Runtime.getRuntime().availableProcessors() )
                 .initialCapacity( 100 )
+                .ticker( ticker )
                 .expireAfterWrite( throttleTime, TimeUnit.MILLISECONDS )
                 .build();
     }

--- a/proxy/src/test/java/net/md_5/bungee/ThrottleTest.java
+++ b/proxy/src/test/java/net/md_5/bungee/ThrottleTest.java
@@ -1,7 +1,9 @@
 package net.md_5.bungee;
 
+import com.google.common.testing.FakeTicker;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.concurrent.TimeUnit;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -11,7 +13,8 @@ public class ThrottleTest
     @Test
     public void testThrottle() throws InterruptedException, UnknownHostException
     {
-        ConnectionThrottle throttle = new ConnectionThrottle( 10 );
+        FakeTicker ticker = new FakeTicker();
+        ConnectionThrottle throttle = new ConnectionThrottle( 10, ticker );
         InetAddress address;
 
         try
@@ -24,8 +27,14 @@ public class ThrottleTest
 
         Assert.assertFalse( "Address should not be throttled", throttle.throttle( address ) );
         Assert.assertTrue( "Address should be throttled", throttle.throttle( address ) );
+        
+        ticker.advance(6, TimeUnit.MILLISECONDS);
+        Assert.assertTrue( "Address should be throttled", throttle.throttle( address ) );
+        
+        ticker.advance(6, TimeUnit.MILLISECONDS);
+        Assert.assertTrue( "Address should be throttled again", throttle.throttle( address ) );
 
-        Thread.sleep( 50 );
-        Assert.assertFalse( "Address should not be throttled", throttle.throttle( address ) );
+        ticker.advance(11, TimeUnit.MILLISECONDS);
+        Assert.assertFalse( "Address should not be throttled anymore", throttle.throttle( address ) );
     }
 }

--- a/proxy/src/test/java/net/md_5/bungee/ThrottleTest.java
+++ b/proxy/src/test/java/net/md_5/bungee/ThrottleTest.java
@@ -28,13 +28,13 @@ public class ThrottleTest
         Assert.assertFalse( "Address should not be throttled", throttle.throttle( address ) );
         Assert.assertTrue( "Address should be throttled", throttle.throttle( address ) );
         
-        ticker.advance(6, TimeUnit.MILLISECONDS);
+        ticker.advance( 6, TimeUnit.MILLISECONDS );
         Assert.assertTrue( "Address should be throttled", throttle.throttle( address ) );
         
-        ticker.advance(6, TimeUnit.MILLISECONDS);
+        ticker.advance( 6, TimeUnit.MILLISECONDS );
         Assert.assertTrue( "Address should be throttled again", throttle.throttle( address ) );
 
-        ticker.advance(11, TimeUnit.MILLISECONDS);
+        ticker.advance( 11, TimeUnit.MILLISECONDS );
         Assert.assertFalse( "Address should not be throttled anymore", throttle.throttle( address ) );
     }
 }


### PR DESCRIPTION
A little proof of concept to test the Connection Throttler using Guava's FakeTicker instead of Thread.sleep

cc @minecrafter 

Linked PR: #1864

NB: this doesn't need to be merged. I'm just toying with unit tests, and this seemed to be a good example. :)
