### PR TITLE
Correctly show outdated_client and outdated_server messages

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -295,7 +295,12 @@ public class InitialHandler extends PacketHandler implements PendingConnection
 
                 if ( !ProtocolConstants.SUPPORTED_VERSION_IDS.contains( handshake.getProtocolVersion() ) )
                 {
-                    disconnect( bungee.getTranslation( "outdated_server" ) );
+                    if (handshake.getProtocolVersion() > bungee.getProtocolVersion())
+                    {
+                        disconnect( bungee.getTranslation( "outdated_server" ) );
+                    } else {
+                        disconnect( bungee.getTranslation( "outdated_client" ) );
+                    }
                     return;
                 }
 


### PR DESCRIPTION
If the client protocol version is not supported, show outdated_server message only if client version is higher than highest supported protocol version, outdated_client message else.