### PR TITLE
Possible Bug Fix

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
@@ -259,12 +259,11 @@ public class DownstreamBridge extends PacketHandler
                     in.readFully( data );
 
                     // Prepare new data to send
-                    out.writeUTF( channel );
                     out.writeShort( data.length );
                     out.write( data );
                     byte[] payload = out.toByteArray();
 
-                    target.getServer().sendData( "BungeeCord", payload );
+                    target.getServer().sendData( channel, payload );
                 }
 
                 // Null out stream, important as we don't want to send to ourselves
@@ -280,7 +279,6 @@ public class DownstreamBridge extends PacketHandler
                 in.readFully( data );
 
                 // Prepare new data to send
-                out.writeUTF( channel );
                 out.writeShort( data.length );
                 out.write( data );
                 byte[] payload = out.toByteArray();
@@ -294,7 +292,7 @@ public class DownstreamBridge extends PacketHandler
                     {
                         if ( server != con.getServer().getInfo() )
                         {
-                            server.sendData( "BungeeCord", payload );
+                            server.sendData( channel, payload );
                         }
                     }
                 } else if ( target.equals( "ONLINE" ) )
@@ -303,7 +301,7 @@ public class DownstreamBridge extends PacketHandler
                     {
                         if ( server != con.getServer().getInfo() )
                         {
-                            server.sendData( "BungeeCord", payload, false );
+                            server.sendData( channel, payload, false );
                         }
                     }
                 } else
@@ -311,7 +309,7 @@ public class DownstreamBridge extends PacketHandler
                     ServerInfo server = bungee.getServerInfo( target );
                     if ( server != null )
                     {
-                        server.sendData( "BungeeCord", payload );
+                        server.sendData( channel, payload );
                     }
                 }
             }


### PR DESCRIPTION
Based on [this documentation](https://www.spigotmc.org/wiki/bukkit-bungee-plugin-messaging-channel/#forward), I believe that the channel here is acting like a subchannel and that the corrections I have made reflect the documentation better.

Currently, when you specify your own channel (for example, Core), it would pass the message onto your servers with BungeeCord being the channel, and Core being the subchannel.

I don't believe this is right, so here is the fix I have crafted.