### PR TITLE
Change color that the find command returns when successful

### DIFF
--- a/module/cmd-find/src/main/java/net/md_5/bungee/module/cmd/find/CommandFind.java
+++ b/module/cmd-find/src/main/java/net/md_5/bungee/module/cmd/find/CommandFind.java
@@ -28,7 +28,7 @@ public class CommandFind extends PlayerCommand
                 sender.sendMessage( ChatColor.RED + "That user is not online" );
             } else
             {
-                sender.sendMessage( ChatColor.BLUE + args[0] + " is online at " + player.getServer().getInfo().getName() );
+                sender.sendMessage( ChatColor.GREEN + args[0] + " is online at " + player.getServer().getInfo().getName() );
             }
         }
     }


### PR DESCRIPTION
Blue is quite hard to read in chat, especially if using a resource pack that modifies the font file.