### PR TITLE
Fix slow event detection

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
@@ -378,7 +378,7 @@ public class PluginManager
         event.postCall();
 
         long elapsed = System.nanoTime() - start;
-        if ( elapsed > 250000 )
+        if ( elapsed > 10_000_000 )
         {
             ProxyServer.getInstance().getLogger().log( Level.WARNING, "Event {0} took more {1}ns to process!", new Object[]
             {

--- a/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
@@ -377,7 +377,7 @@ public class PluginManager
         eventBus.post( event );
         event.postCall();
 
-        long elapsed = start - System.nanoTime();
+        long elapsed = System.nanoTime() - start;
         if ( elapsed > 250000 )
         {
             ProxyServer.getInstance().getLogger().log( Level.WARNING, "Event {0} took more {1}ns to process!", new Object[]

--- a/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
@@ -380,7 +380,7 @@ public class PluginManager
         long elapsed = System.nanoTime() - start;
         if ( elapsed > 10_000_000 )
         {
-            ProxyServer.getInstance().getLogger().log( Level.WARNING, "Event {0} took more {1}ns to process!", new Object[]
+            ProxyServer.getInstance().getLogger().log( Level.WARNING, "Event {0} took {1}ns to process!", new Object[]
             {
                 event, elapsed
             } );


### PR DESCRIPTION
Time moves forward, so the second call to nanoTime returns a bigger number than
the first one, giving a negative elapsed time … defeating the whole purpose of
this code. :-(

@md-5 