### PR TITLE
Remove depreciation of sendMessage( String )

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/CommandSender.java
+++ b/api/src/main/java/net/md_5/bungee/api/CommandSender.java
@@ -19,7 +19,6 @@ public interface CommandSender
      *
      * @param message the message to send
      */
-    @Deprecated
     public void sendMessage(String message);
 
     /**
@@ -28,7 +27,6 @@ public interface CommandSender
      *
      * @param messages the messages to send
      */
-    @Deprecated
     public void sendMessages(String... messages);
 
     /**


### PR DESCRIPTION
I'd like to say there's no dire reason for this depreciation. It allows for cleaner code if only plain text messages are being sent.