### PR TITLE
Chat Component Tweaks

### DIFF
--- a/chat/src/main/java/net/md_5/bungee/api/chat/BaseComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/BaseComponent.java
@@ -4,12 +4,14 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.experimental.Accessors;
 import net.md_5.bungee.api.ChatColor;
 
 import java.util.ArrayList;
 import java.util.List;
 import lombok.ToString;
 
+@Accessors(chain = true)
 @Setter
 @ToString(exclude = "parent")
 @NoArgsConstructor
@@ -300,13 +302,19 @@ public abstract class BaseComponent
         return obfuscated;
     }
 
-    public void setExtra(List<BaseComponent> components)
+    /**
+     * Appended components that inherit this component's formatting and events
+     *
+     * @param components the components
+     */
+    public BaseComponent setExtra(List<BaseComponent> components)
     {
         for ( BaseComponent component : components )
         {
             component.parent = this;
         }
         extra = components;
+        return this;
     }
 
     /**
@@ -315,9 +323,9 @@ public abstract class BaseComponent
      *
      * @param text the text to append
      */
-    public void addExtra(String text)
+    public BaseComponent addExtra(String text)
     {
-        addExtra( new TextComponent( text ) );
+        return addExtra( new TextComponent( text ) );
     }
 
     /**
@@ -326,7 +334,7 @@ public abstract class BaseComponent
      *
      * @param component the component to append
      */
-    public void addExtra(BaseComponent component)
+    public BaseComponent addExtra(BaseComponent component)
     {
         if ( extra == null )
         {
@@ -334,6 +342,7 @@ public abstract class BaseComponent
         }
         component.parent = this;
         extra.add( component );
+        return this;
     }
 
     /**

--- a/chat/src/main/java/net/md_5/bungee/api/chat/HoverEvent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/HoverEvent.java
@@ -1,12 +1,10 @@
 package net.md_5.bungee.api.chat;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 
 @Getter
 @ToString
-@RequiredArgsConstructor
 final public class HoverEvent
 {
 
@@ -20,5 +18,30 @@ final public class HoverEvent
         SHOW_ACHIEVEMENT,
         SHOW_ITEM,
         SHOW_ENTITY
+    }
+
+    /**
+     * Creates a HoverEvent with the passed action and value
+     *
+     * @param action the action
+     * @param value the value
+     */
+    @java.beans.ConstructorProperties({"action", "value"})
+    public HoverEvent(Action action, BaseComponent[] value)
+    {
+        this.action = action;
+        this.value = value;
+    }
+
+    /**
+     * Creates a HoverEvent with the passed action and value
+     *
+     * @param action the action
+     * @param value the value
+     */
+    @java.beans.ConstructorProperties({"action", "value"})
+    public HoverEvent(Action action, BaseComponent value)
+    {
+        this( action, new BaseComponent[] { value } );
     }
 }

--- a/chat/src/main/java/net/md_5/bungee/api/chat/TextComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/TextComponent.java
@@ -2,8 +2,8 @@ package net.md_5.bungee.api.chat;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.experimental.Accessors;
 import net.md_5.bungee.api.ChatColor;
 
 import java.util.ArrayList;
@@ -11,6 +11,7 @@ import java.util.Arrays;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+@Accessors(chain = true)
 @Getter
 @Setter
 @AllArgsConstructor

--- a/chat/src/main/java/net/md_5/bungee/api/chat/TextComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/TextComponent.java
@@ -8,6 +8,7 @@ import net.md_5.bungee.api.ChatColor;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -173,9 +174,84 @@ public class TextComponent extends BaseComponent
      * @return the duplicate of this TextComponent.
      */
     @Override
-    public BaseComponent duplicate()
+    public TextComponent duplicate()
     {
         return new TextComponent( this );
+    }
+
+    @Override
+    public TextComponent setColor(ChatColor color) {
+        super.setColor( color );
+        return this;
+    }
+
+    @Override
+    public TextComponent setBold(Boolean bold) {
+        super.setBold( bold );
+        return this;
+    }
+
+    @Override
+    public TextComponent setItalic(Boolean italic) {
+        super.setItalic( italic );
+        return this;
+    }
+
+    @Override
+    public TextComponent setUnderlined(Boolean underlined) {
+        super.setUnderlined( underlined );
+        return this;
+    }
+
+    @Override
+    public TextComponent setStrikethrough(Boolean strikethrough) {
+        super.setStrikethrough( strikethrough );
+        return this;
+    }
+
+    @Override
+    public TextComponent setObfuscated(Boolean obfuscated) {
+        super.setObfuscated( obfuscated );
+        return this;
+    }
+
+    @Override
+    public TextComponent setInsertion(String insertion) {
+        super.setInsertion( insertion );
+        return this;
+    }
+
+    @Override
+    public TextComponent setExtra(List<BaseComponent> components)
+    {
+        super.setExtra( components );
+        return this;
+    }
+
+    @Override
+    public TextComponent addExtra(String text)
+    {
+        super.addExtra( text );
+        return this;
+    }
+
+    @Override
+    public TextComponent addExtra(BaseComponent component)
+    {
+        super.addExtra( component );
+        return this;
+    }
+
+    @Override
+    public TextComponent setClickEvent(ClickEvent clickEvent) {
+        super.setClickEvent( clickEvent );
+        return this;
+    }
+
+    @Override
+    public TextComponent setHoverEvent(HoverEvent hoverEvent) {
+        super.setHoverEvent( hoverEvent );
+        return this;
     }
 
     @Override

--- a/chat/src/main/java/net/md_5/bungee/api/chat/TranslatableComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/TranslatableComponent.java
@@ -3,15 +3,18 @@ package net.md_5.bungee.api.chat;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.Accessors;
 import net.md_5.bungee.api.ChatColor;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import lombok.ToString;
 
+@Accessors(chain = true)
 @Getter
 @Setter
 @ToString
@@ -96,14 +99,17 @@ public class TranslatableComponent extends BaseComponent
      * any previously set substitutions
      *
      * @param components the components to substitute
+     *
+     * @return this TranslatableComponent
      */
-    public void setWith(List<BaseComponent> components)
+    public TranslatableComponent setWith(List<BaseComponent> components)
     {
         for ( BaseComponent component : components )
         {
             component.parent = this;
         }
         with = components;
+        return this;
     }
 
     /**
@@ -111,10 +117,12 @@ public class TranslatableComponent extends BaseComponent
      * component's formatting
      *
      * @param text the text to substitute
+     *
+     * @return this TranslatableComponent
      */
-    public void addWith(String text)
+    public TranslatableComponent addWith(String text)
     {
-        addWith( new TextComponent( text ) );
+        return addWith( new TextComponent( text ) );
     }
 
     /**
@@ -122,8 +130,10 @@ public class TranslatableComponent extends BaseComponent
      * this component's formatting
      *
      * @param component the component to substitute
+     *
+     * @return this TranslatableComponent
      */
-    public void addWith(BaseComponent component)
+    public TranslatableComponent addWith(BaseComponent component)
     {
         if ( with == null )
         {
@@ -131,6 +141,7 @@ public class TranslatableComponent extends BaseComponent
         }
         component.parent = this;
         with.add( component );
+        return this;
     }
 
     @Override

--- a/chat/src/main/java/net/md_5/bungee/api/chat/TranslatableComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/TranslatableComponent.java
@@ -89,9 +89,84 @@ public class TranslatableComponent extends BaseComponent
      * @return the duplicate of this TranslatableComponent.
      */
     @Override
-    public BaseComponent duplicate()
+    public TranslatableComponent duplicate()
     {
         return new TranslatableComponent( this );
+    }
+
+    @Override
+    public TranslatableComponent setColor(ChatColor color) {
+        super.setColor( color );
+        return this;
+    }
+
+    @Override
+    public TranslatableComponent setBold(Boolean bold) {
+        super.setBold( bold );
+        return this;
+    }
+
+    @Override
+    public TranslatableComponent setItalic(Boolean italic) {
+        super.setItalic( italic );
+        return this;
+    }
+
+    @Override
+    public TranslatableComponent setUnderlined(Boolean underlined) {
+        super.setUnderlined( underlined );
+        return this;
+    }
+
+    @Override
+    public TranslatableComponent setStrikethrough(Boolean strikethrough) {
+        super.setStrikethrough( strikethrough );
+        return this;
+    }
+
+    @Override
+    public TranslatableComponent setObfuscated(Boolean obfuscated) {
+        super.setObfuscated( obfuscated );
+        return this;
+    }
+
+    @Override
+    public TranslatableComponent setInsertion(String insertion) {
+        super.setInsertion( insertion );
+        return this;
+    }
+
+    @Override
+    public TranslatableComponent setExtra(List<BaseComponent> components)
+    {
+        super.setExtra( components );
+        return this;
+    }
+
+    @Override
+    public TranslatableComponent addExtra(String text)
+    {
+        super.addExtra( text );
+        return this;
+    }
+
+    @Override
+    public TranslatableComponent addExtra(BaseComponent component)
+    {
+        super.addExtra( component );
+        return this;
+    }
+
+    @Override
+    public TranslatableComponent setClickEvent(ClickEvent clickEvent) {
+        super.setClickEvent( clickEvent );
+        return this;
+    }
+
+    @Override
+    public TranslatableComponent setHoverEvent(HoverEvent hoverEvent) {
+        super.setHoverEvent( hoverEvent );
+        return this;
     }
 
     /**


### PR DESCRIPTION
Essentially combines the granularity of using `TextComponent` with the usability of `ComponentBuilder`.

Using current `TextComponent`:
```
TextComponent message = new TextComponent("Memory usage: ");
message.setColor(ChatColor.GOLD);

TextComponent extra = new TextComponent("1");
extra.setColor(ChatColor.GREEN);
TextComponent hover = new TextComponent("Used");
hover.setColor(ChatColor.GRAY);
extra.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new TextComponent[] {hover}));

message.addExtra(extra);
message.addExtra("/");

extra = new TextComponent("2");
extra.setColor(ChatColor.GREEN);
hover = new TextComponent("Allocated");
hover.setColor(ChatColor.GRAY);
extra.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new TextComponent[] {hover}));

message.addExtra(extra);
message.addExtra("/");

extra = new TextComponent("3");
extra.setColor(ChatColor.GREEN);
hover = new TextComponent("Max");
hover.setColor(ChatColor.GRAY);
extra.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new TextComponent[] {hover}));

message.addExtra(extra);
message.addExtra(" MB");
```

Using `ComponentBuilder`:
```
BaseComponent[] message = new ComponentBuilder("Memory usage: ").color(ChatColor.GOLD)
            .append("1").color(ChatColor.GREEN).event(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new ComponentBuilder("Used").color(ChatColor.GRAY).create()))
            .append("/").retain(ComponentBuilder.FormatRetention.NONE).color(ChatColor.GOLD)
            .append("2").color(ChatColor.GREEN).event(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new ComponentBuilder("Allocated").color(ChatColor.GRAY).create()))
            .append("/").retain(ComponentBuilder.FormatRetention.NONE).color(ChatColor.GOLD)
            .append("3").color(ChatColor.GREEN).event(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new ComponentBuilder("Max").color(ChatColor.GRAY).create()))
            .append(" MB").retain(ComponentBuilder.FormatRetention.NONE).color(ChatColor.GOLD)
            .create();
```

Using `TextComponent` with chained setters:
```
TextComponent message = new TextComponent("Memory usage: ").setColor(ChatColor.GOLD)
            .addExtra(new TextComponent("1").setColor(ChatColor.GREEN).setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new TextComponent("Used").setColor(ChatColor.GRAY))))
            .addExtra("/")
            .addExtra(new TextComponent("2").setColor(ChatColor.GREEN).setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new TextComponent("Allocated").setColor(ChatColor.GRAY))))
            .addExtra("/")
            .addExtra(new TextComponent("3").setColor(ChatColor.GREEN).setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new TextComponent("Max").setColor(ChatColor.GRAY))))
            .addExtra(" MB");
```

`ComponentBuilder` is currently less verbose than `TextComponent` usage wise but tends to create longer JSON. In this case, 470 characters vs 413 for `TextComponent`. This isn't that important in production but is a symptom of the less efficient way it creates messages. Its linear flow is also less intuitive. (In that `TextComponent` makes the inheritance aspect of formatting more apparent.)

It's not absolutely necessary that `TextComponent` and `TranslatableComponent` setters return their exact type but doing so avoids potentially needing to cast.
