### PR TITLE
Resend MC|Brand plugin message to new servers

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
+++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
@@ -175,6 +175,11 @@ public class ServerConnector extends PacketHandler
             ch.write( message );
         }
 
+        if ( user.getPendingConnection().getMcBrandMessage() != null )
+        {
+            ch.write( user.getPendingConnection().getMcBrandMessage() );
+        }
+
         if ( user.getSettings() != null )
         {
             ch.write( user.getSettings() );

--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -14,6 +14,7 @@ import com.google.gson.Gson;
 import java.util.concurrent.TimeUnit;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 import net.md_5.bungee.*;
 import net.md_5.bungee.api.Callback;
 import net.md_5.bungee.api.ChatColor;
@@ -73,6 +74,9 @@ public class InitialHandler extends PacketHandler implements PendingConnection
     private EncryptionRequest request;
     @Getter
     private final List<PluginMessage> registerMessages = new BoundedArrayList<>( 128 );
+    @Getter
+    @Setter
+    private PluginMessage mcBrandMessage;
     private State thisState = State.HANDSHAKE;
     private final Unsafe unsafe = new Unsafe()
     {
@@ -129,6 +133,11 @@ public class InitialHandler extends PacketHandler implements PendingConnection
         if ( pluginMessage.getTag().equals( "REGISTER" ) )
         {
             registerMessages.add( pluginMessage );
+        }
+
+        if ( pluginMessage.getTag().equals( "MC|Brand" ))
+        {
+            setMcBrandMessage( pluginMessage );
         }
     }
 

--- a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
@@ -195,6 +195,11 @@ public class UpstreamBridge extends PacketHandler
         {
             con.getPendingConnection().getRegisterMessages().add( pluginMessage );
         }
+
+        if ( pluginMessage.getTag().equals( "MC|Brand" ))
+        {
+            con.getPendingConnection().setMcBrandMessage( pluginMessage );
+        }
     }
 
     @Override


### PR DESCRIPTION
The client normally sends an MC|Brand plugin message to identify a client modification. Some Spigot servers depend on this functionality for plugins.

This PR makes it so the plugin message is resent to new servers.