### PR TITLE
Issue #1720 - Fix dimension change de-syncing

### DIFF
--- a/protocol/src/main/java/net/md_5/bungee/protocol/AbstractPacketHandler.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/AbstractPacketHandler.java
@@ -9,6 +9,7 @@ import net.md_5.bungee.protocol.packet.Chat;
 import net.md_5.bungee.protocol.packet.EncryptionRequest;
 import net.md_5.bungee.protocol.packet.PlayerListHeaderFooter;
 import net.md_5.bungee.protocol.packet.PlayerListItem;
+import net.md_5.bungee.protocol.packet.PlayerPositionLook;
 import net.md_5.bungee.protocol.packet.SetCompression;
 import net.md_5.bungee.protocol.packet.TabCompleteRequest;
 import net.md_5.bungee.protocol.packet.ScoreboardObjective;
@@ -146,6 +147,10 @@ public abstract class AbstractPacketHandler
     }
 
     public void handle(BossBar bossBar) throws Exception
+    {
+    }
+
+    public void handle(PlayerPositionLook playerPositionLook) throws Exception
     {
     }
 }

--- a/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java
@@ -25,6 +25,7 @@ import net.md_5.bungee.protocol.packet.LoginSuccess;
 import net.md_5.bungee.protocol.packet.PingPacket;
 import net.md_5.bungee.protocol.packet.PlayerListHeaderFooter;
 import net.md_5.bungee.protocol.packet.PlayerListItem;
+import net.md_5.bungee.protocol.packet.PlayerPositionLook;
 import net.md_5.bungee.protocol.packet.PluginMessage;
 import net.md_5.bungee.protocol.packet.Respawn;
 import net.md_5.bungee.protocol.packet.ScoreboardDisplay;
@@ -132,6 +133,11 @@ public enum Protocol
                     map( ProtocolConstants.MINECRAFT_1_9_4, 0x47 ),
                     map( ProtocolConstants.MINECRAFT_1_10, 0x47 )
             );
+            TO_CLIENT.registerPacket(
+                    PlayerPositionLook.class,
+                    map( ProtocolConstants.MINECRAFT_1_8, 0x08 ),
+                    map( ProtocolConstants.MINECRAFT_1_9, 0x2E )
+            );
 
             TO_SERVER.registerPacket(
                     KeepAlive.class,
@@ -158,6 +164,11 @@ public enum Protocol
                     map( ProtocolConstants.MINECRAFT_1_8, 0x17 ),
                     map( ProtocolConstants.MINECRAFT_1_9, 0x09 )
             );
+            /*TO_SERVER.registerPacket(
+                    PlayerPositionLook.class,
+                    map( ProtocolConstants.MINECRAFT_1_8, 0x06 ),
+                    map( ProtocolConstants.MINECRAFT_1_9, 0x0D )
+            );*/
         }
     },
     // 1

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/PlayerPositionLook.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/PlayerPositionLook.java
@@ -1,0 +1,75 @@
+package net.md_5.bungee.protocol.packet;
+
+import io.netty.buffer.ByteBuf;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import net.md_5.bungee.protocol.AbstractPacketHandler;
+import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.protocol.ProtocolConstants;
+
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = false)
+public class PlayerPositionLook extends DefinedPacket
+{
+
+    private double x;
+    private double y;
+    private double z;
+    private float yaw;
+    private float pitch;
+    private byte flags;
+    private int teleportID;
+    private boolean onGround;
+
+    @Override
+    public void read(ByteBuf buf, ProtocolConstants.Direction direction, int protocolVersion)
+    {
+        x = buf.readDouble();
+        y = buf.readDouble();
+        z = buf.readDouble();
+        yaw = buf.readFloat();
+        pitch = buf.readFloat();
+        if ( direction == ProtocolConstants.Direction.TO_CLIENT )
+        {
+            flags = buf.readByte();
+            if ( protocolVersion >= ProtocolConstants.MINECRAFT_1_9 )
+            {
+                teleportID = readVarInt( buf );
+            }
+        } else
+        {
+            onGround = buf.readBoolean();
+        }
+    }
+
+    @Override
+    public void write(ByteBuf buf, ProtocolConstants.Direction direction, int protocolVersion)
+    {
+        buf.writeDouble( x );
+        buf.writeDouble( y );
+        buf.writeDouble( z );
+        buf.writeFloat( yaw );
+        buf.writeFloat( pitch );
+        if ( direction == ProtocolConstants.Direction.TO_CLIENT )
+        {
+            buf.writeByte( flags );
+            if ( protocolVersion >= ProtocolConstants.MINECRAFT_1_9 )
+            {
+                writeVarInt( teleportID, buf );
+            }
+        } else
+        {
+            buf.writeBoolean( onGround );
+        }
+    }
+
+    @Override
+    public void handle(AbstractPacketHandler handler) throws Exception
+    {
+        handler.handle( this );
+    }
+}

--- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
+++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
@@ -224,7 +224,6 @@ public class ServerConnector extends PacketHandler
             }
             user.getSentBossBars().clear();
 
-            user.setDimensionChange( true );
             if ( login.getDimension() == user.getDimension() )
             {
                 user.unsafe().sendPacket( new Respawn( ( login.getDimension() >= 0 ? -1 : 0 ), login.getDifficulty(), login.getGameMode(), login.getLevelType() ) );
@@ -252,7 +251,6 @@ public class ServerConnector extends PacketHandler
         target.addPlayer( user );
         user.getPendingConnects().remove( target );
         user.setServerJoinQueue( null );
-        user.setDimensionChange( false );
 
         user.setServer( server );
         ch.getHandle().pipeline().get( HandlerBoss.class ).setHandler( new DownstreamBridge( bungee, user, server ) );

--- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
@@ -216,7 +216,6 @@ public final class UserConnection implements ProxiedPlayer
 
     public void connectNow(ServerInfo target)
     {
-        dimensionChange = true;
         connect(target);
     }
 

--- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
@@ -34,6 +34,7 @@ import net.md_5.bungee.protocol.packet.BossBar;
 import net.md_5.bungee.protocol.packet.KeepAlive;
 import net.md_5.bungee.protocol.packet.PlayerListItem;
 import net.md_5.bungee.protocol.packet.Respawn;
+import net.md_5.bungee.protocol.packet.PlayerPositionLook;
 import net.md_5.bungee.protocol.packet.ScoreboardObjective;
 import net.md_5.bungee.protocol.packet.ScoreboardScore;
 import net.md_5.bungee.protocol.packet.ScoreboardDisplay;
@@ -509,6 +510,12 @@ public class DownstreamBridge extends PacketHandler
     public void handle(Respawn respawn)
     {
         con.setDimension( respawn.getDimension() );
+    }
+
+    @Override
+    public void handle(PlayerPositionLook playerPositionLook)
+    {
+        con.setDimensionChange( false );
     }
 
     @Override

--- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
@@ -509,6 +509,11 @@ public class DownstreamBridge extends PacketHandler
     @Override
     public void handle(Respawn respawn)
     {
+        if ( respawn.getDimension() != con.getDimension() )
+        {
+            con.setDimensionChange( true );
+        }
+
         con.setDimension( respawn.getDimension() );
     }
 


### PR DESCRIPTION
When Minecraft handles S08PacketPlayerPosLook, '```doneLoadingTerrain```' is set to true, and calls the following ```gameController.displayGuiScreen((GuiScreen)null)```, which closes the loading terrain screen.

However, when Minecraft handles S07PacketRespawn, '```doneLoadingTerrain```' is set to false if the respawn dimension is different to their current one and invokes ```gameController.displayGuiScreen(new GuiDownloadTerrain(this))``` which opens the downloading terrain screen.

If the flag is not in sync, this poses an issue because as described in #1720 when the client is kicked whilst connecting to a server, they will be sent a message instead of ServerConnection disconnecting them, so this PR will resolve that.