### PR TITLE
Only double switch if the dimension is the same.

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
+++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
@@ -222,10 +222,15 @@ public class ServerConnector extends PacketHandler
             }
             user.getSentBossBars().clear();
 
-            user.sendDimensionSwitch();
+            user.setDimensionChange( true );
+            if ( login.getDimension() == user.getDimension() )
+            {
+                user.unsafe().sendPacket( new Respawn( ( login.getDimension() >= 0 ? -1 : 0 ), login.getDifficulty(), login.getGameMode(), login.getLevelType() ) );
+            }
 
             user.setServerEntityId( login.getEntityId() );
             user.unsafe().sendPacket( new Respawn( login.getDimension(), login.getDifficulty(), login.getGameMode(), login.getLevelType() ) );
+            user.setDimension( login.getDimension() );
 
             // Remove from old servers
             user.getServer().disconnect( "Quitting" );

--- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
@@ -55,6 +55,7 @@ import net.md_5.bungee.protocol.packet.ClientSettings;
 import net.md_5.bungee.protocol.packet.Kick;
 import net.md_5.bungee.protocol.packet.PlayerListHeaderFooter;
 import net.md_5.bungee.protocol.packet.PluginMessage;
+import net.md_5.bungee.protocol.packet.Respawn;
 import net.md_5.bungee.protocol.packet.SetCompression;
 import net.md_5.bungee.tab.ServerUnique;
 import net.md_5.bungee.tab.TabList;
@@ -78,6 +79,9 @@ public final class UserConnection implements ProxiedPlayer
     @Getter
     @Setter
     private ServerConnection server;
+    @Getter
+    @Setter
+    private int dimension;
     @Getter
     @Setter
     private boolean dimensionChange = true;
@@ -210,17 +214,10 @@ public final class UserConnection implements ProxiedPlayer
         connect( target, callback, false );
     }
 
-    void sendDimensionSwitch()
-    {
-        dimensionChange = true;
-        unsafe().sendPacket( PacketConstants.DIM1_SWITCH );
-        unsafe().sendPacket( PacketConstants.DIM2_SWITCH );
-    }
-
     public void connectNow(ServerInfo target)
     {
-        sendDimensionSwitch();
-        connect( target );
+        dimensionChange = true;
+        connect(target);
     }
 
     public ServerInfo updateAndGetNextServer(ServerInfo currentTarget)

--- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
@@ -33,6 +33,7 @@ import net.md_5.bungee.protocol.PacketWrapper;
 import net.md_5.bungee.protocol.packet.BossBar;
 import net.md_5.bungee.protocol.packet.KeepAlive;
 import net.md_5.bungee.protocol.packet.PlayerListItem;
+import net.md_5.bungee.protocol.packet.Respawn;
 import net.md_5.bungee.protocol.packet.ScoreboardObjective;
 import net.md_5.bungee.protocol.packet.ScoreboardScore;
 import net.md_5.bungee.protocol.packet.ScoreboardDisplay;
@@ -502,6 +503,12 @@ public class DownstreamBridge extends PacketHandler
                 con.getSentBossBars().remove( bossBar.getUuid() );
                 break;
         }
+    }
+
+    @Override
+    public void handle(Respawn respawn)
+    {
+        con.setDimension( respawn.getDimension() );
     }
 
     @Override


### PR DESCRIPTION
According to the protocol, a double respawn packet is only needed to be
sent if the new dimension is the same as the current dimension; so by storing the last known dimension,
we are able to compare and avoid the double packet.

This also maintains the same behavior for Spigot
https://hub.spigotmc.org/stash/projects/SPIGOT/repos/craftbukkit/commits/ad2f806097e51fbf72f64ba97e2e4c3785326f42