### PR TITLE
Add API to get the character of a ChatColor

### DIFF
--- a/chat/src/main/java/net/md_5/bungee/api/ChatColor.java
+++ b/chat/src/main/java/net/md_5/bungee/api/ChatColor.java
@@ -116,6 +116,7 @@ public enum ChatColor
     /**
      * The code appended to {@link #COLOR_CHAR} to make usable colour.
      */
+    @Getter
     private final char code;
     /**
      * This colour's colour char prefixed by the {@link #COLOR_CHAR}.


### PR DESCRIPTION
Use case: converting between Bukkit and BungeeCord chat colors more easily when writing plugins with the Spigot API.

Also provides general API completeness.