### PR TITLE
Fix handling of Title packet for 1.11 and maintain backwards compat w…

### DIFF
--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/Title.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/Title.java
@@ -28,11 +28,19 @@ public class Title extends DefinedPacket
     @Override
     public void read(ByteBuf buf, ProtocolConstants.Direction direction, int protocolVersion)
     {
-        action = Action.values()[readVarInt( buf )];
+        int index = readVarInt(buf);
+
+        // If we're working on 1.10 or lower, increment the value of the index so we pull out the correct value.
+        if (ProtocolConstants.MINECRAFT_1_10 >= protocolVersion && index <= 2) {
+            index++;
+        }
+
+        action = Action.values()[index];
         switch ( action )
         {
             case TITLE:
             case SUBTITLE:
+            case ACTIONBAR:
                 text = readString( buf );
                 break;
             case TIMES:
@@ -46,11 +54,19 @@ public class Title extends DefinedPacket
     @Override
     public void write(ByteBuf buf, ProtocolConstants.Direction direction, int protocolVersion)
     {
-        writeVarInt( action.ordinal(), buf );
-        switch ( action )
+        int index = readVarInt(buf);
+
+        // If we're working on 1.10 or lower, increment the value of the index so we pull out the correct value.
+        if (ProtocolConstants.MINECRAFT_1_10 >= protocolVersion && index <= 2) {
+            index++;
+        }
+
+        action = Action.values()[index];
+        switch (action)
         {
             case TITLE:
             case SUBTITLE:
+            case ACTIONBAR:
                 writeString( text, buf );
                 break;
             case TIMES:
@@ -72,6 +88,7 @@ public class Title extends DefinedPacket
 
         TITLE,
         SUBTITLE,
+        ACTIONBAR,
         TIMES,
         CLEAR,
         RESET


### PR DESCRIPTION
…ith 1.10 and earlier

in 1.11, an additional action has been added to the title packet. This PR handles that change, and handles earlier packet versions.