### PR TITLE
Fix PacketPlayOutCollect (0x48) for 1.11

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/entitymap/EntityMap_1_11.java
+++ b/proxy/src/main/java/net/md_5/bungee/entitymap/EntityMap_1_11.java
@@ -65,7 +65,15 @@ class EntityMap_1_11 extends EntityMap
                 break;
             case 0x48 /* Collect Item : PacketPlayOutCollect */:
                 DefinedPacket.readVarInt( packet );
-                rewriteVarInt( packet, oldId, newId, packet.readerIndex() );
+                jumpIndex = packet.readerIndex();
+                int collectorEntityId = DefinedPacket.readVarInt( packet );
+                int pickupItemCount = DefinedPacket.readVarInt( packet );
+                if ( collectorEntityId == oldId || collectorEntityId == newId ) {
+                    packet.readerIndex( jumpIndex );
+                    packet.writerIndex( jumpIndex );
+                    DefinedPacket.writeVarInt( collectorEntityId == oldId ? newId : oldId, packet );
+                    DefinedPacket.writeVarInt( pickupItemCount, packet );
+                }
                 break;
             case 0x40 /* Attach Entity : PacketPlayOutMount */:
                 DefinedPacket.readVarInt( packet );


### PR DESCRIPTION
Connecting with BungeeCord 1.11 to an 1.10.2 Server running ViaVersion will result in an error

https://puu.sh/si0Dp/9284db4cfb.png