### PR TITLE
Remove redundant HashSet initialisation and synchronisation on a local variable

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/BungeeServerInfo.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeServerInfo.java
@@ -10,7 +10,6 @@ import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.Queue;
 import lombok.Getter;
@@ -66,7 +65,7 @@ public class BungeeServerInfo implements ServerInfo
     @Override
     public Collection<ProxiedPlayer> getPlayers()
     {
-        return Collections.unmodifiableCollection( new HashSet( players ) );
+        return Collections.unmodifiableCollection( players );
     }
 
     @Override

--- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
+++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
@@ -160,12 +160,9 @@ public class ServerConnector extends PacketHandler
 
         ch.write( BungeeCord.getInstance().registerChannels() );
         Queue<DefinedPacket> packetQueue = target.getPacketQueue();
-        synchronized ( packetQueue )
+        while ( !packetQueue.isEmpty() )
         {
-            while ( !packetQueue.isEmpty() )
-            {
-                ch.write( packetQueue.poll() );
-            }
+            ch.write( packetQueue.poll() );
         }
 
         for ( PluginMessage message : user.getPendingConnection().getRelayMessages() )


### PR DESCRIPTION
It's possible the intended use of synchronised was for `target.getPacketQueue()`, in which case I'll update it ;)