### PR TITLE
Fix cancelled ServerConnectEvent timing out client if not connected to a previous server

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
@@ -252,6 +252,7 @@ public final class UserConnection implements ProxiedPlayer
             {
                 callback.done( false, null );
             }
+            Preconditions.checkState( getServer() != null || ch.isClosing(), "Cancelled ServerConnectEvent with no server or disconnect." );
             return;
         }
 


### PR DESCRIPTION
Force a disconnect instead to prevent loading screen showing until timeout.