### PR TITLE
Fix TabListItemHeaderFooter for 1.11.1

### DIFF
--- a/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java
@@ -131,7 +131,8 @@ public enum Protocol
                     map( ProtocolConstants.MINECRAFT_1_9, 0x48 ),
                     map( ProtocolConstants.MINECRAFT_1_9_4, 0x47 ),
                     map( ProtocolConstants.MINECRAFT_1_10, 0x47 ),
-                    map( ProtocolConstants.MINECRAFT_1_11, 0x47 )
+                    map( ProtocolConstants.MINECRAFT_1_11, 0x47 ),
+                    map( ProtocolConstants.MINECRAFT_1_11_1, 0x47 )
             );
 
             TO_SERVER.registerPacket(


### PR DESCRIPTION
When setting the Tablist Header/Footer via the BungeeCord-API you cannot join a 1.11.1 Server but instead get an error seconds after the world loaded for the client.

This can be reproduced by installing https://www.spigotmc.org/resources/bungeetablistplus.313/ on your latest bungee. The default config will work to demonstrate this.