### PR TITLE
Add "Not authenticated with Minecraft.net" message in the messages.properties

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -421,7 +421,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
                         finish();
                         return;
                     }
-                    disconnect( "Not authenticated with Minecraft.net" );
+                    disconnect( bungee.getTranslation( "offline_mode_player" ) );
                 } else
                 {
                     disconnect( bungee.getTranslation( "mojang_fail" ) );

--- a/proxy/src/main/resources/messages.properties
+++ b/proxy/src/main/resources/messages.properties
@@ -24,3 +24,4 @@ name_too_long=Cannot have username longer than 16 characters
 name_invalid=Username contains invalid characters.
 ping_cannot_connect=\u00a7c[Bungee] Can't connect to server.
 join_throttle_kick=You have connected too fast. You must wait at least {0} seconds between connections.
+offline_mode_player=Not authenticated with Minecraft.net


### PR DESCRIPTION
I'm French and if an offline player tries to connect on my network he doesn't understand why he can't connect.