### PR TITLE
Add MongoDB Driver

### DIFF
--- a/proxy/pom.xml
+++ b/proxy/pom.xml
@@ -81,6 +81,12 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
+            <groupId>org.mongodb</groupId>
+            <artifactId>mongo-java-driver</artifactId>
+            <version>3.2.2</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>org.javassist</groupId>
             <artifactId>javassist</artifactId>
             <version>3.20.0-GA</version>


### PR DESCRIPTION
Since MongoDB has gained much popularity in the last months, the driver should also be included in the BungeeCord Jar.