### PR TITLE
HoverEvent BaseComponent[] parameter replaced with varargs

### DIFF
--- a/chat/src/main/java/net/md_5/bungee/api/chat/HoverEvent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/HoverEvent.java
@@ -1,17 +1,20 @@
 package net.md_5.bungee.api.chat;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 
 @Getter
 @ToString
-@RequiredArgsConstructor
 final public class HoverEvent
 {
 
     private final Action action;
     private final BaseComponent[] value;
+
+    public HoverEvent(Action action, BaseComponent... value) {
+        this.action = action;
+        this.value = value;
+    }
 
     public enum Action
     {

--- a/chat/src/main/java/net/md_5/bungee/api/chat/HoverEvent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/HoverEvent.java
@@ -11,7 +11,8 @@ final public class HoverEvent
     private final Action action;
     private final BaseComponent[] value;
 
-    public HoverEvent(Action action, BaseComponent... value) {
+    public HoverEvent(Action action, BaseComponent... value)
+    {
         this.action = action;
         this.value = value;
     }


### PR DESCRIPTION
Makes making a hover event easier as you no longer need to make a new BaseComponent array. VarAgs is also backwards compatible with passing in arrays, so no major issues would arise from implementing it.