### PR TITLE
Index UUIDs to speed up player queries

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
@@ -125,6 +125,7 @@ public class BungeeCord extends ProxyServer
     private final Map<String, UserConnection> connections = new CaseInsensitiveMap<>();
     // Used to help with packet rewriting
     private final Map<UUID, UserConnection> connectionsByOfflineUUID = new HashMap<>();
+    private final Map<UUID, UserConnection> connectionsByUUID = new HashMap<>();
     private final ReadWriteLock connectionLock = new ReentrantReadWriteLock();
     /**
      * Plugin manager.
@@ -542,15 +543,7 @@ public class BungeeCord extends ProxyServer
         connectionLock.readLock().lock();
         try
         {
-            for ( ProxiedPlayer proxiedPlayer : connections.values() )
-            {
-                if ( proxiedPlayer.getUniqueId().equals( uuid ) )
-                {
-                    return proxiedPlayer;
-                }
-            }
-
-            return null;
+            return connectionsByUUID.get( uuid );
         } finally
         {
             connectionLock.readLock().unlock();
@@ -645,6 +638,7 @@ public class BungeeCord extends ProxyServer
         try
         {
             connections.put( con.getName(), con );
+            connectionsByUUID.put( con.getUniqueId(), con );
             connectionsByOfflineUUID.put( con.getPendingConnection().getOfflineId(), con );
         } finally
         {
@@ -661,6 +655,7 @@ public class BungeeCord extends ProxyServer
             if ( connections.get( con.getName() ) == con )
             {
                 connections.remove( con.getName() );
+                connectionsByUUID.remove( con.getUniqueId() );
                 connectionsByOfflineUUID.remove( con.getPendingConnection().getOfflineId() );
             }
         } finally


### PR DESCRIPTION
UUIDs are the unique player identifiers. They should really be indexed.