### PR TITLE
Use player name casing from LoginResult

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -92,6 +92,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
     private boolean onlineMode = BungeeCord.getInstance().config.isOnlineMode();
     @Getter
     private InetSocketAddress virtualHost;
+    private String name = null;
     @Getter
     private UUID uniqueId;
     @Getter
@@ -419,6 +420,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
                     if ( obj != null && obj.getId() != null )
                     {
                         loginProfile = obj;
+                        name = obj.getName();
                         uniqueId = Util.getUUID( obj.getId() );
                         finish();
                         return;
@@ -560,7 +562,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
     @Override
     public String getName()
     {
-        return ( loginRequest == null ) ? null : loginRequest.getData();
+        return (name != null ) ? name : ( loginRequest == null ) ? null : loginRequest.getData();
     }
 
     @Override

--- a/proxy/src/main/java/net/md_5/bungee/connection/LoginResult.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/LoginResult.java
@@ -9,6 +9,7 @@ public class LoginResult
 {
 
     private String id;
+    private String name;
     private Property[] properties;
 
     @Data


### PR DESCRIPTION
Modded clients are able to alter the casing of their username. This could be very annoying if they change this on every login.

As pointed out in http://wiki.vg/Protocol_Encryption#Authentication the server should use the nickname sent in name field of LoginResult sent from the session servers.

This PR changes that. It could break some nick or skin restorer plugins, but they ain't supported anyway.