### PR TITLE
Alter protocol definitions to use linked protocol for 1.10 and later versions

### DIFF
--- a/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java
@@ -129,10 +129,7 @@ public enum Protocol
                     PlayerListHeaderFooter.class,
                     map( ProtocolConstants.MINECRAFT_1_8, 0x47 ),
                     map( ProtocolConstants.MINECRAFT_1_9, 0x48 ),
-                    map( ProtocolConstants.MINECRAFT_1_9_4, 0x47 ),
-                    map( ProtocolConstants.MINECRAFT_1_10, 0x47 ),
-                    map( ProtocolConstants.MINECRAFT_1_11, 0x47 ),
-                    map( ProtocolConstants.MINECRAFT_1_11_1, 0x47 )
+                    map( ProtocolConstants.MINECRAFT_1_9_4, 0x47 )
             );
 
             TO_SERVER.registerPacket(
@@ -262,7 +259,9 @@ public enum Protocol
             linkedProtocols.put( ProtocolConstants.MINECRAFT_1_9, Arrays.asList(
                     ProtocolConstants.MINECRAFT_1_9_1,
                     ProtocolConstants.MINECRAFT_1_9_2,
-                    ProtocolConstants.MINECRAFT_1_9_4,
+                    ProtocolConstants.MINECRAFT_1_9_4
+            ) );
+            linkedProtocols.put( ProtocolConstants.MINECRAFT_1_9_4, Arrays.asList(
                     ProtocolConstants.MINECRAFT_1_10,
                     ProtocolConstants.MINECRAFT_1_11,
                     ProtocolConstants.MINECRAFT_1_11_1

--- a/protocol/src/test/java/net/md_5/bungee/protocol/ProtocolTest.java
+++ b/protocol/src/test/java/net/md_5/bungee/protocol/ProtocolTest.java
@@ -1,0 +1,24 @@
+package net.md_5.bungee.protocol;
+
+import net.md_5.bungee.protocol.packet.PlayerListHeaderFooter;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ProtocolTest
+{
+
+    @Test
+    public void testHeaderFooter() throws Exception
+    {
+        Protocol.DirectionData protocol = Protocol.GAME.TO_CLIENT;
+        assertEquals("Incorrect packet id", protocol.getId(PlayerListHeaderFooter.class, ProtocolConstants.MINECRAFT_1_8), 0x47);
+        assertEquals("Incorrect packet id", protocol.getId(PlayerListHeaderFooter.class, ProtocolConstants.MINECRAFT_1_9), 0x48);
+        assertEquals("Incorrect packet id", protocol.getId(PlayerListHeaderFooter.class, ProtocolConstants.MINECRAFT_1_9_1), 0x48);
+        assertEquals("Incorrect packet id", protocol.getId(PlayerListHeaderFooter.class, ProtocolConstants.MINECRAFT_1_9_2), 0x48);
+        assertEquals("Incorrect packet id", protocol.getId(PlayerListHeaderFooter.class, ProtocolConstants.MINECRAFT_1_9_4), 0x47);
+        assertEquals("Incorrect packet id", protocol.getId(PlayerListHeaderFooter.class, ProtocolConstants.MINECRAFT_1_10), 0x47);
+        assertEquals("Incorrect packet id", protocol.getId(PlayerListHeaderFooter.class, ProtocolConstants.MINECRAFT_1_11), 0x47);
+        assertEquals("Incorrect packet id", protocol.getId(PlayerListHeaderFooter.class, ProtocolConstants.MINECRAFT_1_11_1), 0x47);
+    }
+}


### PR DESCRIPTION
Added test case to ensure header footer packet not affected by changes.

PlayerListHeaderFooter packet is currently registering its id for every version post 1.9.4 despite not changing since that version. Using the linked protocol versions would remove the need for this to happen and makes the handling of this packet consistent with how other packets are handled.