### PR TITLE
Add KeybindComponent for chat components

### DIFF
--- a/chat/src/main/java/net/md_5/bungee/api/Keybind.java
+++ b/chat/src/main/java/net/md_5/bungee/api/Keybind.java
@@ -1,91 +1,50 @@
 package net.md_5.bungee.api;
 
-import java.util.HashMap;
-import java.util.Map;
-
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-
 import net.md_5.bungee.api.chat.KeybindComponent;
 
 /**
- * All possible keybind values used by {@link KeybindComponent}.
+ * All keybind values supported by vanilla Minecraft.
+ * 
+ * @see {@link KeybindComponent}
  */
-@RequiredArgsConstructor
-public enum Keybind
+public abstract class Keybind
 {
-    JUMP( "key.jump", "SPACE" ),
-    SNEAK( "key.sneak", "LSHIFT" ),
-    SPRINT( "key.sprint", "LCTRL" ),
-    LEFT( "key.left", "A" ),
-    RIGHT( "key.right", "D" ),
-    BACK( "key.back", "S" ),
-    FORWARD( "key.forward", "W" ),
+    public static final String JUMP = "key.jump";
+    public static final String SNEAK = "key.sneak";
+    public static final String SPRINT = "key.sprint";
+    public static final String LEFT = "key.left";
+    public static final String RIGHT = "key.right";
+    public static final String BACK = "key.back";
+    public static final String FORWARD = "key.forward";
 
-    ATTACK( "key.attack", "LMOUSE" ),
-    PICK_ITEM( "key.pickItem", "MMOUSE" ),
-    USE( "key.use", "RMOUSE" ),
+    public static final String ATTACK = "key.attack";
+    public static final String PICK_ITEM = "key.pickItem";
+    public static final String USE = "key.use";
 
-    DROP( "key.drop", "Q" ),
-    HOTBAR_1( "key.hotbar.1", "1" ),
-    HOTBAR_2( "key.hotbar.2", "2" ),
-    HOTBAR_3( "key.hotbar.3", "3" ),
-    HOTBAR_4( "key.hotbar.4", "4" ),
-    HOTBAR_5( "key.hotbar.5", "5" ),
-    HOTBAR_6( "key.hotbar.6", "6" ),
-    HOTBAR_7( "key.hotbar.7", "7" ),
-    HOTBAR_8( "key.hotbar.8", "8" ),
-    HOTBAR_9( "key.hotbar.9", "9" ),
-    INVENTORY( "key.inventory", "E" ),
-    SWAP_HANDS( "key.swapHands", "F" ),
+    public static final String DROP = "key.drop";
+    public static final String HOTBAR_1 = "key.hotbar.1";
+    public static final String HOTBAR_2 = "key.hotbar.2";
+    public static final String HOTBAR_3 = "key.hotbar.3";
+    public static final String HOTBAR_4 = "key.hotbar.4";
+    public static final String HOTBAR_5 = "key.hotbar.5";
+    public static final String HOTBAR_6 = "key.hotbar.6";
+    public static final String HOTBAR_7 = "key.hotbar.7";
+    public static final String HOTBAR_8 = "key.hotbar.8";
+    public static final String HOTBAR_9 = "key.hotbar.9";
+    public static final String INVENTORY = "key.inventory";
+    public static final String SWAP_HANDS = "key.swapHands";
 
-    LOAD_TOOLBAR_ACTIVATOR( "key.loadToolbarActivator", "X" ),
-    SAVE_TOOLBAR_ACTIVATOR( "key.saveToolbarActivator", "C" ),
+    public static final String LOAD_TOOLBAR_ACTIVATOR = "key.loadToolbarActivator";
+    public static final String SAVE_TOOLBAR_ACTIVATOR = "key.saveToolbarActivator";
 
-    PLAYERLIST( "key.playerlist", "TAB" ),
-    CHAT( "key.chat", "T" ),
-    COMMAND( "key.command", "/" ),
+    public static final String PLAYERLIST = "key.playerlist";
+    public static final String CHAT = "key.chat";
+    public static final String COMMAND = "key.command";
 
-    ADVANCEMENTS( "key.advancements", "L" ),
-    SPECTATOR_OUTLINES( "key.spectatorOutlines", "" ),
-    SCREENSHOT( "key.screenshot", "F2" ),
-    SMOOTH_CAMERA( "key.smoothCamera", "" ),
-    FULLSCREEN( "key.fullscreen", "F11" ),
-    TOGGLE_PERSPECTIVE( "key.togglePerspective", "F5" ),
-
-    /**
-     * A special value indicating a custom internal value.
-     */
-    CUSTOM( "", "" );
-
-    private static final Map<String, Keybind> BY_VALUE = new HashMap<>();
-    /**
-     * The internal value to use.
-     */
-    @Getter
-    private final String value;
-    /**
-     * The default key.
-     */
-    @Getter
-    private final String defaultKey;
-
-    static
-    {
-        for ( Keybind keybind : values() )
-        {
-            BY_VALUE.put( keybind.value, keybind );
-        }
-    }
-
-    /**
-     * Get the keybind represented by the specified internal value.
-     *
-     * @param value the internal value to search for
-     * @return the Keybind, or null if none exists for the internal value
-     */
-    public static Keybind getByValue(String value)
-    {
-        return BY_VALUE.get( value );
-    }
+    public static final String ADVANCEMENTS = "key.advancements";
+    public static final String SPECTATOR_OUTLINES = "key.spectatorOutlines";
+    public static final String SCREENSHOT = "key.screenshot";
+    public static final String SMOOTH_CAMERA = "key.smoothCamera";
+    public static final String FULLSCREEN = "key.fullscreen";
+    public static final String TOGGLE_PERSPECTIVE = "key.togglePerspective";
 }

--- a/chat/src/main/java/net/md_5/bungee/api/Keybind.java
+++ b/chat/src/main/java/net/md_5/bungee/api/Keybind.java
@@ -1,0 +1,86 @@
+package net.md_5.bungee.api;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import net.md_5.bungee.api.chat.KeybindComponent;
+
+/**
+ * All possible keybind values used by {@link KeybindComponent}.
+ */
+@RequiredArgsConstructor
+public enum Keybind
+{
+    JUMP( "key.jump", "SPACE" ),
+    SNEAK( "key.sneak", "LSHIFT" ),
+    SPRINT( "key.sprint", "LCTRL" ),
+    LEFT( "key.left", "A" ),
+    RIGHT( "key.right", "D" ),
+    BACK( "key.back", "S" ),
+    FORWARD( "key.forward", "W" ),
+
+    ATTACK( "key.attack", "LMOUSE" ),
+    PICK_ITEM( "key.pickItem", "MMOUSE" ),
+    USE( "key.use", "RMOUSE" ),
+
+    DROP( "key.drop", "Q" ),
+    HOTBAR_1( "key.hotbar.1", "1" ),
+    HOTBAR_2( "key.hotbar.2", "2" ),
+    HOTBAR_3( "key.hotbar.3", "3" ),
+    HOTBAR_4( "key.hotbar.4", "4" ),
+    HOTBAR_5( "key.hotbar.5", "5" ),
+    HOTBAR_6( "key.hotbar.6", "6" ),
+    HOTBAR_7( "key.hotbar.7", "7" ),
+    HOTBAR_8( "key.hotbar.8", "8" ),
+    HOTBAR_9( "key.hotbar.9", "9" ),
+    INVENTORY( "key.inventory", "E" ),
+    SWAP_HANDS( "key.swapHands", "F" ),
+
+    LOAD_TOOLBAR_ACTIVATOR( "key.loadToolbarActivator", "X" ),
+    SAVE_TOOLBAR_ACTIVATOR( "key.saveToolbarActivator", "C" ),
+
+    PLAYERLIST( "key.playerlist", "TAB" ),
+    CHAT( "key.chat", "T" ),
+    COMMAND( "key.command", "/" ),
+
+    ADVANCEMENTS( "key.advancements", "L" ),
+    SPECTATOR_OUTLINES( "key.spectatorOutlines", "" ),
+    SCREENSHOT( "key.screenshot", "F2" ),
+    SMOOTH_CAMERA( "key.smoothCamera", "" ),
+    FULLSCREEN( "key.fullscreen", "F11" ),
+    TOGGLE_PERSPECTIVE( "key.togglePerspective", "F5" );
+
+    private static final Map<String, Keybind> BY_VALUE = new HashMap<>();
+    /**
+     * The internal value to use.
+     */
+    @Getter
+    private final String value;
+    /**
+     * The default key.
+     */
+    @Getter
+    private final String defaultKey;
+
+    static
+    {
+        for ( Keybind keybind : values() )
+        {
+            BY_VALUE.put( keybind.value, keybind );
+        }
+    }
+
+    /**
+     * Get the keybind represented by the specified internal value.
+     *
+     * @param value the internal value to search for
+     * @return the Keybind, or null if none exists for the internal value
+     */
+    public static Keybind getByValue(String value)
+    {
+        return BY_VALUE.get( value );
+    }
+}

--- a/chat/src/main/java/net/md_5/bungee/api/Keybind.java
+++ b/chat/src/main/java/net/md_5/bungee/api/Keybind.java
@@ -51,7 +51,12 @@ public enum Keybind
     SCREENSHOT( "key.screenshot", "F2" ),
     SMOOTH_CAMERA( "key.smoothCamera", "" ),
     FULLSCREEN( "key.fullscreen", "F11" ),
-    TOGGLE_PERSPECTIVE( "key.togglePerspective", "F5" );
+    TOGGLE_PERSPECTIVE( "key.togglePerspective", "F5" ),
+
+    /**
+     * A special value indicating a custom internal value.
+     */
+    CUSTOM( "", "" );
 
     private static final Map<String, Keybind> BY_VALUE = new HashMap<>();
     /**

--- a/chat/src/main/java/net/md_5/bungee/api/chat/KeybindComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/KeybindComponent.java
@@ -1,0 +1,95 @@
+package net.md_5.bungee.api.chat;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import net.md_5.bungee.api.ChatColor;
+import net.md_5.bungee.api.Keybind;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class KeybindComponent extends BaseComponent
+{
+
+    /**
+     * The keybind to use. Will be replaced with the actual key the client is
+     * using.
+     */
+    private Keybind keybind;
+
+    /**
+     * Creates a keybind component from the original to clone it.
+     *
+     * @param original the original for the new keybind component.
+     */
+    public KeybindComponent(KeybindComponent original)
+    {
+        super( original );
+        setKeybind( original.getKeybind() );
+    }
+
+    /**
+     * Creates a keybind component with the passed keybind
+     *
+     * @param keybind the keybind
+     */
+    public KeybindComponent(Keybind keybind)
+    {
+    	setKeybind( keybind );
+    }
+
+    /**
+     * Creates a duplicate of this KeybindComponent.
+     *
+     * @return the duplicate of this KeybindComponent.
+     */
+    @Override
+    public BaseComponent duplicate()
+    {
+        return new KeybindComponent( this );
+    }
+
+    @Override
+    protected void toPlainText(StringBuilder builder)
+    {
+        builder.append( keybind.getDefaultKey() );
+        super.toPlainText( builder );
+    }
+
+    @Override
+    protected void toLegacyText(StringBuilder builder)
+    {
+        builder.append( getColor() );
+        if ( isBold() )
+        {
+            builder.append( ChatColor.BOLD );
+        }
+        if ( isItalic() )
+        {
+            builder.append( ChatColor.ITALIC );
+        }
+        if ( isUnderlined() )
+        {
+            builder.append( ChatColor.UNDERLINE );
+        }
+        if ( isStrikethrough() )
+        {
+            builder.append( ChatColor.STRIKETHROUGH );
+        }
+        if ( isObfuscated() )
+        {
+            builder.append( ChatColor.MAGIC );
+        }
+        builder.append( keybind.getDefaultKey() );
+
+        super.toLegacyText( builder );
+    }
+
+    @Override
+    public String toString()
+    {
+        return String.format( "KeybindComponent{keybind=%s, %s}", keybind, super.toString() );
+    }
+}

--- a/chat/src/main/java/net/md_5/bungee/api/chat/KeybindComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/KeybindComponent.java
@@ -14,10 +14,10 @@ public class KeybindComponent extends BaseComponent
 {
 
     /**
-     * The internal keybind value to use. Will be replaced with the actual key
+     * The keybind value to use. Will be replaced with the actual key
      * the client is using.
      */
-    private String keybindValue;
+    private String keybind;
 
     /**
      * Creates a keybind component from the original to clone it.
@@ -27,27 +27,18 @@ public class KeybindComponent extends BaseComponent
     public KeybindComponent(KeybindComponent original)
     {
         super( original );
-        setKeybindValue( original.getKeybindValue() );
-    }
-
-    /**
-     * Creates a keybind component with the passed keybind.
-     *
-     * @param keybind the keybind
-     */
-    public KeybindComponent(Keybind keybind)
-    {
-        setKeybind( keybind );
+        setKeybind( original.getKeybind() );
     }
 
     /**
      * Creates a keybind component with the passed internal keybind value.
      *
-     * @param keybindValue the keybind internal value
+     * @param keybind the keybind value
+     * @see {@link Keybind}
      */
-    public KeybindComponent(String keybindValue)
+    public KeybindComponent(String keybind)
     {
-        setKeybindValue( keybindValue );
+        setKeybind( keybind );
     }
 
     /**
@@ -61,30 +52,10 @@ public class KeybindComponent extends BaseComponent
         return new KeybindComponent( this );
     }
 
-    /**
-     * Returns the keybind for the internal keybind value or Keybind.CUSTOM if
-     * there is no keybind for the internal keybind value.
-     *
-     * @return the keybind for the interbal keybind value
-     */
-    public Keybind getKeybind() {
-        Keybind keybind = Keybind.getByValue( keybindValue );
-        return keybind == null ? Keybind.CUSTOM : keybind;
-    }
-
-    /**
-     * Sets the keykind to use.
-     *
-     * @param keybind the keybind
-     */
-    public void setKeybind(Keybind keybind) {
-        keybindValue = keybind.getValue();
-    }
-
     @Override
     protected void toPlainText(StringBuilder builder)
     {
-        builder.append( getKeybind().getDefaultKey() );
+        builder.append( getKeybind() );
         super.toPlainText( builder );
     }
 
@@ -112,7 +83,7 @@ public class KeybindComponent extends BaseComponent
         {
             builder.append( ChatColor.MAGIC );
         }
-        builder.append( getKeybind().getDefaultKey() );
+        builder.append( getKeybind() );
 
         super.toLegacyText( builder );
     }
@@ -120,6 +91,6 @@ public class KeybindComponent extends BaseComponent
     @Override
     public String toString()
     {
-        return String.format( "KeybindComponent{keybindValue=%s, %s}", keybindValue, super.toString() );
+        return String.format( "KeybindComponent{keybind=%s, %s}", keybind, super.toString() );
     }
 }

--- a/chat/src/main/java/net/md_5/bungee/api/chat/KeybindComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/KeybindComponent.java
@@ -14,10 +14,10 @@ public class KeybindComponent extends BaseComponent
 {
 
     /**
-     * The keybind to use. Will be replaced with the actual key the client is
-     * using.
+     * The internal keybind value to use. Will be replaced with the actual key
+     * the client is using.
      */
-    private Keybind keybind;
+    private String keybindValue;
 
     /**
      * Creates a keybind component from the original to clone it.
@@ -27,17 +27,27 @@ public class KeybindComponent extends BaseComponent
     public KeybindComponent(KeybindComponent original)
     {
         super( original );
-        setKeybind( original.getKeybind() );
+        setKeybindValue( original.getKeybindValue() );
     }
 
     /**
-     * Creates a keybind component with the passed keybind
+     * Creates a keybind component with the passed keybind.
      *
      * @param keybind the keybind
      */
     public KeybindComponent(Keybind keybind)
     {
-    	setKeybind( keybind );
+        setKeybind( keybind );
+    }
+
+    /**
+     * Creates a keybind component with the passed internal keybind value.
+     *
+     * @param keybindValue the keybind internal value
+     */
+    public KeybindComponent(String keybindValue)
+    {
+        setKeybindValue( keybindValue );
     }
 
     /**
@@ -51,10 +61,30 @@ public class KeybindComponent extends BaseComponent
         return new KeybindComponent( this );
     }
 
+    /**
+     * Returns the keybind for the internal keybind value or Keybind.CUSTOM if
+     * there is no keybind for the internal keybind value.
+     *
+     * @return the keybind for the interbal keybind value
+     */
+    public Keybind getKeybind() {
+        Keybind keybind = Keybind.getByValue( keybindValue );
+        return keybind == null ? Keybind.CUSTOM : keybind;
+    }
+
+    /**
+     * Sets the keykind to use.
+     *
+     * @param keybind the keybind
+     */
+    public void setKeybind(Keybind keybind) {
+        keybindValue = keybind.getValue();
+    }
+
     @Override
     protected void toPlainText(StringBuilder builder)
     {
-        builder.append( keybind.getDefaultKey() );
+        builder.append( getKeybind().getDefaultKey() );
         super.toPlainText( builder );
     }
 
@@ -82,7 +112,7 @@ public class KeybindComponent extends BaseComponent
         {
             builder.append( ChatColor.MAGIC );
         }
-        builder.append( keybind.getDefaultKey() );
+        builder.append( getKeybind().getDefaultKey() );
 
         super.toLegacyText( builder );
     }
@@ -90,6 +120,6 @@ public class KeybindComponent extends BaseComponent
     @Override
     public String toString()
     {
-        return String.format( "KeybindComponent{keybind=%s, %s}", keybind, super.toString() );
+        return String.format( "KeybindComponent{keybindValue=%s, %s}", keybindValue, super.toString() );
     }
 }

--- a/chat/src/main/java/net/md_5/bungee/chat/ComponentSerializer.java
+++ b/chat/src/main/java/net/md_5/bungee/chat/ComponentSerializer.java
@@ -8,6 +8,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.api.chat.KeybindComponent;
 import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.api.chat.TranslatableComponent;
 
@@ -21,6 +22,7 @@ public class ComponentSerializer implements JsonDeserializer<BaseComponent>
             registerTypeAdapter( BaseComponent.class, new ComponentSerializer() ).
             registerTypeAdapter( TextComponent.class, new TextComponentSerializer() ).
             registerTypeAdapter( TranslatableComponent.class, new TranslatableComponentSerializer() ).
+            registerTypeAdapter( KeybindComponent.class, new KeybindComponentSerializer() ).
             create();
 
     public final static ThreadLocal<HashSet<BaseComponent>> serializedComponents = new ThreadLocal<HashSet<BaseComponent>>();
@@ -58,6 +60,10 @@ public class ComponentSerializer implements JsonDeserializer<BaseComponent>
         if ( object.has( "translate" ) )
         {
             return context.deserialize( json, TranslatableComponent.class );
+        }
+        if ( object.has( "keybind" ) )
+        {
+            return context.deserialize( json, KeybindComponent.class );
         }
         return context.deserialize( json, TextComponent.class );
     }

--- a/chat/src/main/java/net/md_5/bungee/chat/KeybindComponentSerializer.java
+++ b/chat/src/main/java/net/md_5/bungee/chat/KeybindComponentSerializer.java
@@ -21,7 +21,7 @@ public class KeybindComponentSerializer extends BaseComponentSerializer implemen
         KeybindComponent component = new KeybindComponent();
         JsonObject object = json.getAsJsonObject();
         deserialize( object, component, context );
-        component.setKeybindValue( object.get( "keybind" ).getAsString() );
+        component.setKeybind( object.get( "keybind" ).getAsString() );
         return component;
     }
 
@@ -30,7 +30,7 @@ public class KeybindComponentSerializer extends BaseComponentSerializer implemen
     {
         JsonObject object = new JsonObject();
         serialize( object, src, context );
-        object.addProperty( "keybind", src.getKeybindValue() );
+        object.addProperty( "keybind", src.getKeybind() );
         return object;
     }
 }

--- a/chat/src/main/java/net/md_5/bungee/chat/KeybindComponentSerializer.java
+++ b/chat/src/main/java/net/md_5/bungee/chat/KeybindComponentSerializer.java
@@ -8,7 +8,6 @@ import com.google.gson.JsonParseException;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 
-import net.md_5.bungee.api.Keybind;
 import net.md_5.bungee.api.chat.KeybindComponent;
 
 import java.lang.reflect.Type;
@@ -22,7 +21,7 @@ public class KeybindComponentSerializer extends BaseComponentSerializer implemen
         KeybindComponent component = new KeybindComponent();
         JsonObject object = json.getAsJsonObject();
         deserialize( object, component, context );
-        component.setKeybind( Keybind.getByValue( object.get( "keybind" ).getAsString() ) );
+        component.setKeybindValue( object.get( "keybind" ).getAsString() );
         return component;
     }
 
@@ -31,7 +30,7 @@ public class KeybindComponentSerializer extends BaseComponentSerializer implemen
     {
         JsonObject object = new JsonObject();
         serialize( object, src, context );
-        object.addProperty( "keybind", src.getKeybind().getValue() );
+        object.addProperty( "keybind", src.getKeybindValue() );
         return object;
     }
 }

--- a/chat/src/main/java/net/md_5/bungee/chat/KeybindComponentSerializer.java
+++ b/chat/src/main/java/net/md_5/bungee/chat/KeybindComponentSerializer.java
@@ -1,0 +1,37 @@
+package net.md_5.bungee.chat;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+import net.md_5.bungee.api.Keybind;
+import net.md_5.bungee.api.chat.KeybindComponent;
+
+import java.lang.reflect.Type;
+
+public class KeybindComponentSerializer extends BaseComponentSerializer implements JsonSerializer<KeybindComponent>, JsonDeserializer<KeybindComponent>
+{
+
+    @Override
+    public KeybindComponent deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException
+    {
+        KeybindComponent component = new KeybindComponent();
+        JsonObject object = json.getAsJsonObject();
+        deserialize( object, component, context );
+        component.setKeybind( Keybind.getByValue( object.get( "keybind" ).getAsString() ) );
+        return component;
+    }
+
+    @Override
+    public JsonElement serialize(KeybindComponent src, Type typeOfSrc, JsonSerializationContext context)
+    {
+        JsonObject object = new JsonObject();
+        serialize( object, src, context );
+        object.addProperty( "keybind", src.getKeybind().getValue() );
+        return object;
+    }
+}


### PR DESCRIPTION
In 1.12 mojang added a new chat component type "keybind". It takes a "keybind" value and the client replaces it with the assigned key.

I added all possible values to an enum "Keybind". This should be easy to maintain as there ain't new key bindings in every version. This enum also uses a field for the default value used as a replacement while using toPlainText() or toLegacyText().

I testet that the component is serialized and deserialized correctly.