### PR TITLE
Catch disconnects on login

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -515,6 +515,8 @@ public class InitialHandler extends PacketHandler implements PendingConnection
                             userCon.connect( server, null, true );
 
                             thisState = State.FINISHED;
+                        } else {
+                            bungee.getPluginManager().callEvent( new PlayerDisconnectEvent( userCon ) );
                         }
                     }
                 } );

--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -31,11 +31,7 @@ import net.md_5.bungee.api.config.ServerInfo;
 import net.md_5.bungee.api.connection.Connection.Unsafe;
 import net.md_5.bungee.api.connection.PendingConnection;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
-import net.md_5.bungee.api.event.LoginEvent;
-import net.md_5.bungee.api.event.PlayerHandshakeEvent;
-import net.md_5.bungee.api.event.PostLoginEvent;
-import net.md_5.bungee.api.event.PreLoginEvent;
-import net.md_5.bungee.api.event.ProxyPingEvent;
+import net.md_5.bungee.api.event.*;
 import net.md_5.bungee.chat.ComponentSerializer;
 import net.md_5.bungee.http.HttpClient;
 import net.md_5.bungee.jni.cipher.BungeeCipher;
@@ -481,8 +477,10 @@ public class InitialHandler extends PacketHandler implements PendingConnection
                     disconnect( result.getCancelReasonComponents() );
                     return;
                 }
+                final UserConnection userCon = new UserConnection( bungee, ch, getName(), InitialHandler.this );
                 if ( ch.isClosed() )
                 {
+                    bungee.getPluginManager().callEvent( new PlayerDisconnectEvent( userCon ) );
                     return;
                 }
 
@@ -493,7 +491,6 @@ public class InitialHandler extends PacketHandler implements PendingConnection
                     {
                         if ( !ch.isClosing() )
                         {
-                            UserConnection userCon = new UserConnection( bungee, ch, getName(), InitialHandler.this );
                             userCon.setCompressionThreshold( BungeeCord.getInstance().config.getCompressionThreshold() );
                             userCon.init();
 


### PR DESCRIPTION
Removes a race condition where a LoginEvent is fired, but no PlayerDisconnectEvent. Useful for invalidating caches (prevents memory leaks in plugins)

Old proposals: #1967, #1146 