### PR TITLE
Disable plugins before shutting down EventLoops

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
@@ -404,15 +404,6 @@ public class BungeeCord extends ProxyServer
                 {
                 }
 
-                getLogger().info( "Closing IO threads" );
-                eventLoops.shutdownGracefully();
-                try
-                {
-                    eventLoops.awaitTermination( Long.MAX_VALUE, TimeUnit.NANOSECONDS );
-                } catch ( InterruptedException ex )
-                {
-                }
-
                 if ( reconnectHandler != null )
                 {
                     getLogger().info( "Saving reconnect locations" );
@@ -439,6 +430,15 @@ public class BungeeCord extends ProxyServer
                     }
                     getScheduler().cancel( plugin );
                     plugin.getExecutorService().shutdownNow();
+                }
+
+                getLogger().info( "Closing IO threads" );
+                eventLoops.shutdownGracefully();
+                try
+                {
+                    eventLoops.awaitTermination( Long.MAX_VALUE, TimeUnit.NANOSECONDS );
+                } catch ( InterruptedException ex )
+                {
                 }
 
                 getLogger().info( "Thank you and goodbye" );


### PR DESCRIPTION
Because disabling plugins also cancels any pending tasks, there will be no task accessing the eventLoops.

Reimplementation of #1578, fixes #1403

EDIT: Sorry about reference spam, rebase.