### PR TITLE
Further improve Netty channel closing code.

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -160,7 +160,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
             @Override
             public void done(ProxyPingEvent result, Throwable error)
             {
-                if ( ch.isClosed() )
+                if ( ch.isClosing() )
                 {
                     return;
                 }
@@ -184,8 +184,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
                             + '\u00a7' + legacy.getPlayers().getMax();
                 }
 
-                ch.getHandle().writeAndFlush( kickMessage );
-                ch.close();
+                ch.close( kickMessage );
             }
         };
 
@@ -364,7 +363,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
                     disconnect( result.getCancelReasonComponents() );
                     return;
                 }
-                if ( ch.isClosed() )
+                if ( ch.isClosing() )
                 {
                     return;
                 }
@@ -485,7 +484,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
                     disconnect( result.getCancelReasonComponents() );
                     return;
                 }
-                if ( ch.isClosed() )
+                if ( ch.isClosing() )
                 {
                     return;
                 }

--- a/proxy/src/main/java/net/md_5/bungee/netty/ChannelWrapper.java
+++ b/proxy/src/main/java/net/md_5/bungee/netty/ChannelWrapper.java
@@ -24,9 +24,6 @@ public class ChannelWrapper
     @Getter
     @Setter
     private InetSocketAddress remoteAddress;
-    @Getter
-    private volatile boolean closed;
-    @Getter
     private volatile boolean closing;
 
     public ChannelWrapper(ChannelHandlerContext ctx)
@@ -49,23 +46,32 @@ public class ChannelWrapper
 
     public void write(Object packet)
     {
-        if ( !closed )
+        if ( !isClosed() )
         {
             if ( packet instanceof PacketWrapper )
             {
                 ( (PacketWrapper) packet ).setReleased( true );
-                ch.write( ( (PacketWrapper) packet ).buf, ch.voidPromise() );
+                ch.writeAndFlush( ( (PacketWrapper) packet ).buf, ch.voidPromise() );
             } else
             {
-                ch.write( packet, ch.voidPromise() );
+                ch.writeAndFlush( packet, ch.voidPromise() );
             }
-            ch.flush();
         }
+    }
+
+    public boolean isClosing()
+    {
+        return closing || !ch.isActive();
+    }
+
+    public boolean isClosed()
+    {
+        return !ch.isActive();
     }
 
     public void markClosed()
     {
-        closed = closing = true;
+        closing = true;
     }
 
     public void close()
@@ -73,28 +79,19 @@ public class ChannelWrapper
         close( null );
     }
 
-    public void close(Object packet)
+    public void close(final Object packet)
     {
-        if ( !closed )
+        if ( !isClosed() )
         {
-            closed = closing = true;
-
-            if ( packet != null && ch.isActive() )
+            if ( packet != null )
             {
                 ch.writeAndFlush( packet ).addListeners( ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE, ChannelFutureListener.CLOSE );
-                ch.eventLoop().schedule( new Runnable()
-                {
-                    @Override
-                    public void run()
-                    {
-                        ch.close();
-                    }
-                }, 250, TimeUnit.MILLISECONDS );
             } else
             {
                 ch.flush();
-                ch.close();
             }
+            closing = true;
+            ch.close();
         }
     }
 


### PR DESCRIPTION
- Make Channel#close close without delay, as it defeats the purpose of delayedClose.
- Use Netty to check if Channel is already closed instead of local variable to prevent possible desyncs.
- Use Channel#writeAndFlush instead of a separate write and flush in ChannelWrapper#write.