### PR TITLE
Send the correct username when connecting to a server

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
+++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
@@ -34,6 +34,7 @@ import net.md_5.bungee.protocol.packet.EncryptionRequest;
 import net.md_5.bungee.protocol.packet.Handshake;
 import net.md_5.bungee.protocol.packet.Kick;
 import net.md_5.bungee.protocol.packet.Login;
+import net.md_5.bungee.protocol.packet.LoginRequest;
 import net.md_5.bungee.protocol.packet.LoginSuccess;
 import net.md_5.bungee.protocol.packet.PluginMessage;
 import net.md_5.bungee.protocol.packet.Respawn;
@@ -107,7 +108,7 @@ public class ServerConnector extends PacketHandler
         channel.write( copiedHandshake );
 
         channel.setProtocol( Protocol.LOGIN );
-        channel.write( user.getPendingConnection().getLoginRequest() );
+        channel.write( new LoginRequest( user.getName() ) );
     }
 
     @Override


### PR DESCRIPTION
#2130 fixed an issue where clients could change the casing on their usernames and be able to connect to servers with that name. BungeeCord still sends that username when connecting to a server. This fixes that by sending the updated username.