### PR TITLE
Fix ComponentBuilder clone constructor #2255

### DIFF
--- a/chat/src/main/java/net/md_5/bungee/api/chat/BaseComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/BaseComponent.java
@@ -102,6 +102,13 @@ public abstract class BaseComponent
     public abstract BaseComponent duplicate();
 
     /**
+     * Clones the BaseComponent without formatting and returns the clone.
+     *
+     * @return The duplicate of this BaseComponent
+     */
+    public abstract BaseComponent duplicateWithoutFormatting();
+
+    /**
      * Converts the components to a string that uses the old formatting codes
      * ({@link net.md_5.bungee.api.ChatColor#COLOR_CHAR}
      *

--- a/chat/src/main/java/net/md_5/bungee/api/chat/BaseComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/BaseComponent.java
@@ -76,20 +76,25 @@ public abstract class BaseComponent
 
     BaseComponent(BaseComponent old)
     {
-        setColor( old.getColorRaw() );
-        setBold( old.isBoldRaw() );
-        setItalic( old.isItalicRaw() );
-        setUnderlined( old.isUnderlinedRaw() );
-        setStrikethrough( old.isStrikethroughRaw() );
-        setObfuscated( old.isObfuscatedRaw() );
-        setInsertion( old.getInsertion() );
-        setClickEvent( old.getClickEvent() );
-        setHoverEvent( old.getHoverEvent() );
-        if ( old.getExtra() != null )
+        copyFormatting( old );
+    }
+
+    public void copyFormatting( BaseComponent component )
+    {
+        setColor( component.getColorRaw() );
+        setBold( component.isBoldRaw() );
+        setItalic( component.isItalicRaw() );
+        setUnderlined( component.isUnderlinedRaw() );
+        setStrikethrough( component.isStrikethroughRaw() );
+        setObfuscated( component.isObfuscatedRaw() );
+        setInsertion( component.getInsertion() );
+        setClickEvent( component.getClickEvent() );
+        setHoverEvent( component.getHoverEvent() );
+        if ( component.getExtra() != null )
         {
-            for ( BaseComponent component : old.getExtra() )
+            for ( BaseComponent extra : component.getExtra() )
             {
-                addExtra( component.duplicate() );
+                addExtra( extra.duplicate() );
             }
         }
     }

--- a/chat/src/main/java/net/md_5/bungee/api/chat/ComponentBuilder.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/ComponentBuilder.java
@@ -37,7 +37,7 @@ public class ComponentBuilder
      */
     public ComponentBuilder(ComponentBuilder original)
     {
-        current = new TextComponent( original.current );
+        current = original.current.duplicate();
         for ( BaseComponent baseComponent : original.parts )
         {
             parts.add( baseComponent.duplicate() );
@@ -251,29 +251,13 @@ public class ComponentBuilder
         switch ( retention )
         {
             case NONE:
-                if ( current instanceof TextComponent )
-                {
-                    current = new TextComponent( ( (TextComponent) current ).getText() );
-                } else if ( current instanceof TranslatableComponent )
-                {
-                    TranslatableComponent oldComponent = (TranslatableComponent) current;
-                    current = new TranslatableComponent( oldComponent.getTranslate(), oldComponent.getWith() );
-                }
-
+                current = current.duplicateWithoutFormatting();
                 break;
             case ALL:
                 // No changes are required
                 break;
             case EVENTS:
-                if ( current instanceof TextComponent )
-                {
-                    current = new TextComponent( ( (TextComponent) current ).getText() );
-                } else if ( current instanceof TranslatableComponent )
-                {
-                    TranslatableComponent oldComponent = (TranslatableComponent) current;
-                    current = new TranslatableComponent( oldComponent.getTranslate(), oldComponent.getWith() );
-                }
-
+                current = current.duplicateWithoutFormatting();
                 current.setInsertion( previous.getInsertion() );
                 current.setClickEvent( previous.getClickEvent() );
                 current.setHoverEvent( previous.getHoverEvent() );

--- a/chat/src/main/java/net/md_5/bungee/api/chat/ComponentBuilder.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/ComponentBuilder.java
@@ -113,8 +113,9 @@ public class ComponentBuilder
     {
         parts.add( current );
 
-        current = new TextComponent( (TextComponent) current );
-        ( (TextComponent) current ).setText( text );
+        BaseComponent old = current;
+        current = new TextComponent( text );
+        current.copyFormatting( old );
         retain( retention );
 
         return this;

--- a/chat/src/main/java/net/md_5/bungee/api/chat/TextComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/TextComponent.java
@@ -178,6 +178,12 @@ public class TextComponent extends BaseComponent
     }
 
     @Override
+    public BaseComponent duplicateWithoutFormatting()
+    {
+        return new TextComponent( this.text );
+    }
+
+    @Override
     protected void toPlainText(StringBuilder builder)
     {
         builder.append( text );

--- a/chat/src/main/java/net/md_5/bungee/api/chat/TranslatableComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/TranslatableComponent.java
@@ -66,18 +66,21 @@ public class TranslatableComponent extends BaseComponent
     public TranslatableComponent(String translate, Object... with)
     {
         setTranslate( translate );
-        List<BaseComponent> temp = new ArrayList<BaseComponent>();
-        for ( Object w : with )
+        if ( with != null && with.length != 0 )
         {
-            if ( w instanceof String )
+            List<BaseComponent> temp = new ArrayList<BaseComponent>();
+            for ( Object w : with )
             {
-                temp.add( new TextComponent( (String) w ) );
-            } else
-            {
-                temp.add( (BaseComponent) w );
+                if ( w instanceof String )
+                {
+                    temp.add( new TextComponent( (String) w ) );
+                } else
+                {
+                    temp.add( (BaseComponent) w );
+                }
             }
+            setWith( temp );
         }
-        setWith( temp );
     }
 
     /**
@@ -89,6 +92,12 @@ public class TranslatableComponent extends BaseComponent
     public BaseComponent duplicate()
     {
         return new TranslatableComponent( this );
+    }
+
+    @Override
+    public BaseComponent duplicateWithoutFormatting()
+    {
+        return new TranslatableComponent( this.translate, this.with );
     }
 
     /**

--- a/proxy/src/test/java/net/md_5/bungee/chat/ComponentsTest.java
+++ b/proxy/src/test/java/net/md_5/bungee/chat/ComponentsTest.java
@@ -14,6 +14,15 @@ public class ComponentsTest
 {
 
     @Test
+    public void testBuilderClone()
+    {
+        ComponentBuilder builder = new ComponentBuilder("Hel").color(ChatColor.RED).append("lo").color(ChatColor.DARK_RED);
+        ComponentBuilder cloned = new ComponentBuilder( builder );
+
+        Assert.assertEquals( TextComponent.toLegacyText( builder.create() ), TextComponent.toLegacyText( cloned.create() ) );
+    }
+
+    @Test
     public void testBuilderAppend()
     {
         ClickEvent clickEvent = new ClickEvent( ClickEvent.Action.RUN_COMMAND, "/help " );


### PR DESCRIPTION
The cause was the following line ```current = new TextComponent( original.current );```. As the current variable was changed to a BaseComponent, the incorrect constructor was being used. A duplicate can be used instead which also provides support for custom BaseComponent implementations in plugins.

Also makes the retain() method more maintainable and flexible by adding a new method to duplicate a BaseComponent without formatting.
