### PR TITLE
Make command accessible by console.

### DIFF
--- a/module/cmd-server/src/main/java/net/md_5/bungee/module/cmd/server/CommandServer.java
+++ b/module/cmd-server/src/main/java/net/md_5/bungee/module/cmd/server/CommandServer.java
@@ -31,10 +31,6 @@ public class CommandServer extends Command implements TabExecutor
     @Override
     public void execute(CommandSender sender, String[] args)
     {
-        if ( !( sender instanceof ProxiedPlayer ) )
-        {
-            return;
-        }
         ProxiedPlayer player = (ProxiedPlayer) sender;
         Map<String, ServerInfo> servers = ProxyServer.getInstance().getServers();
         if ( args.length == 0 )
@@ -59,8 +55,11 @@ public class CommandServer extends Command implements TabExecutor
                 }
             }
             player.sendMessage( serverList );
-        } else
-        {
+        } else {
+            if ( !( sender instanceof ProxiedPlayer ) )
+            {
+               return;
+            }
             ServerInfo server = servers.get( args[0] );
             if ( server == null )
             {


### PR DESCRIPTION
Makes  the /server command accessible by the console when there are no arguments specified.
This allows the console to see a list of servers that are currently available. This is made more useful when servers are dynamically added.