### PR TITLE
Fix lookup of default configuration values for nested paths

### DIFF
--- a/config/src/main/java/net/md_5/bungee/config/Configuration.java
+++ b/config/src/main/java/net/md_5/bungee/config/Configuration.java
@@ -56,7 +56,7 @@ public final class Configuration
         Object section = self.get( root );
         if ( section == null )
         {
-            section = new Configuration( ( defaults == null ) ? null : defaults.getSection( path ) );
+            section = new Configuration( ( defaults == null ) ? null : defaults.getSection( root ) );
             self.put( root, section );
         }
 

--- a/config/src/test/java/net/md_5/bungee/config/DefaultConfigurationTest.java
+++ b/config/src/test/java/net/md_5/bungee/config/DefaultConfigurationTest.java
@@ -1,0 +1,22 @@
+package net.md_5.bungee.config;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DefaultConfigurationTest
+{
+    @Test
+    public void testDefaultValues()
+    {
+        Configuration defaultConfig = new Configuration();
+        defaultConfig.set( "setting", 10 );
+        defaultConfig.set( "nested.setting", 11 );
+        defaultConfig.set( "double.nested.setting", 12 );
+
+        Configuration actualConfig = new Configuration( defaultConfig );
+
+        Assert.assertEquals( 10, actualConfig.getInt( "setting" ) );
+        Assert.assertEquals( 11, actualConfig.getInt( "nested.setting" ) );
+        Assert.assertEquals( 12, actualConfig.getInt( "double.nested.setting" ) );
+    }
+}


### PR DESCRIPTION
The lookup of default configuration values with multiple path segments currently failes with a class cast exception because the full path was treated as a new configuration section instead of only the root

Minimal failing test
```java
@Test
public void nestedDefault() {
    Configuration defaultConfig = new Configuration();
    defaultConfig.set("config.setting", 10);
    Configuration actualConfig = new Configuration(defaultConfig);
    assertEquals(10, actualConfig.getInt("config.setting"));
}
```

Stacktrace:
```
java.lang.ClassCastException: java.lang.Integer cannot be cast to net.md_5.bungee.config.Configuration

	at net.md_5.bungee.config.Configuration.getSection(Configuration.java:136)
	at net.md_5.bungee.config.Configuration.getSectionFor(Configuration.java:59)
	at net.md_5.bungee.config.Configuration.get(Configuration.java:76)
	at net.md_5.bungee.config.Configuration.getInt(Configuration.java:214)
	at net.md_5.bungee.config.Configuration.getInt(Configuration.java:209)
```

Not sure about the policy for test cases - feel free to keep or discard them.