### PR TITLE
Remove deprecated guava function in config

### DIFF
--- a/config/src/main/java/net/md_5/bungee/config/Configuration.java
+++ b/config/src/main/java/net/md_5/bungee/config/Configuration.java
@@ -1,10 +1,10 @@
 package net.md_5.bungee.config;
 
-import com.google.common.collect.Sets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -30,7 +30,8 @@ public final class Configuration
         this.self = new LinkedHashMap<>();
         this.defaults = defaults;
 
-        for ( Map.Entry<?, ?> entry : map.entrySet() )
+        for ( Map.Entry<?, ?> entry : map.entry
+             () )
         {
             String key = ( entry.getKey() == null ) ? "null" : entry.getKey().toString();
 
@@ -143,7 +144,7 @@ public final class Configuration
      */
     public Collection<String> getKeys()
     {
-        return Sets.newLinkedHashSet( self.keySet() );
+        return new LinkedHashSet<>( self.keySet() );
     }
 
     /*------------------------------------------------------------------------*/

--- a/config/src/main/java/net/md_5/bungee/config/Configuration.java
+++ b/config/src/main/java/net/md_5/bungee/config/Configuration.java
@@ -30,7 +30,7 @@ public final class Configuration
         this.self = new LinkedHashMap<>();
         this.defaults = defaults;
 
-        for ( Map.Entry<?, ?> entry : map.entry() )
+        for ( Map.Entry<?, ?> entry : map.entrySet() )
         {
             String key = ( entry.getKey() == null ) ? "null" : entry.getKey().toString();
 

--- a/config/src/main/java/net/md_5/bungee/config/Configuration.java
+++ b/config/src/main/java/net/md_5/bungee/config/Configuration.java
@@ -30,8 +30,7 @@ public final class Configuration
         this.self = new LinkedHashMap<>();
         this.defaults = defaults;
 
-        for ( Map.Entry<?, ?> entry : map.entry
-             () )
+        for ( Map.Entry<?, ?> entry : map.entry() )
         {
             String key = ( entry.getKey() == null ) ? "null" : entry.getKey().toString();
 


### PR DESCRIPTION
This removes the need to shade in the full guava library if a java program only uses bungeecord-config.

https://google.github.io/guava/releases/21.0/api/docs/com/google/common/collect/Sets.html#newLinkedHashSet--

**Note for Java 7 and later:** `this method is now unnecessary and should be treated as deprecated. Instead, use the LinkedHashSet constructor directly, taking advantage of the new "diamond" syntax.`