### PR TITLE
Fix OutOfBounds in TextComponent.fromLegacy

### DIFF
--- a/chat/src/main/java/net/md_5/bungee/api/chat/TextComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/TextComponent.java
@@ -39,7 +39,10 @@ public final class TextComponent extends BaseComponent
             char c = message.charAt( i );
             if ( c == ChatColor.COLOR_CHAR )
             {
-                i++;
+                if (++i >= message.length())
+                {
+                    break;
+                }
                 c = message.charAt( i );
                 if ( c >= 'A' && c <= 'Z' )
                 {

--- a/chat/src/test/java/net/md_5/bungee/api/chat/TextComponentTest.java
+++ b/chat/src/test/java/net/md_5/bungee/api/chat/TextComponentTest.java
@@ -1,0 +1,39 @@
+package net.md_5.bungee.api.chat;
+
+import net.md_5.bungee.api.ChatColor;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
+public class TextComponentTest
+{
+
+    @Test
+    public void testInvalidColorCodes()
+    {
+        StringBuilder allInvalidColorCodes = new StringBuilder();
+
+        // collect all invalid color codes (e.g. §z, §g, ...)
+        for (char alphChar : "0123456789abcdefghijklmnopqrstuvwxyz".toCharArray())
+        {
+            if (ChatColor.ALL_CODES.indexOf(alphChar) == -1)
+            {
+                allInvalidColorCodes.append(ChatColor.COLOR_CHAR);
+                allInvalidColorCodes.append(alphChar);
+            }
+        }
+
+        // last char is a single '§'
+        allInvalidColorCodes.append(ChatColor.COLOR_CHAR);
+
+        String invalidColorCodesLegacyText = fromAndToLegacyText(allInvalidColorCodes.toString());
+        String emptyLegacyText = fromAndToLegacyText("");
+
+        // all invalid color codes and the trailing '§' should be ignored
+        assertEquals(emptyLegacyText, invalidColorCodesLegacyText);
+    }
+
+    private String fromAndToLegacyText(String legacyText)
+    {
+        return BaseComponent.toLegacyText(TextComponent.fromLegacyText(legacyText));
+    }
+}


### PR DESCRIPTION
If a message ends with '§' `TextComponent.fromLegacy(String)` will throw an IndexOutOfBoundsException.