### PR TITLE
Expand ChatComponent API

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/connection/ProxiedPlayer.java
+++ b/api/src/main/java/net/md_5/bungee/api/connection/ProxiedPlayer.java
@@ -10,6 +10,7 @@ import net.md_5.bungee.api.SkinConfiguration;
 import net.md_5.bungee.api.Title;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.config.ServerInfo;
+import net.md_5.bungee.api.score.Scoreboard;
 
 /**
  * Represents a player who's connection is being connected to somewhere else,
@@ -275,4 +276,11 @@ public interface ProxiedPlayer extends Connection, CommandSender
      * not occurred for this {@link ProxiedPlayer} yet.
      */
     Map<String, String> getModList();
+
+    /**
+     * Get the {@link Scoreboard} that belongs to this player.
+     *
+     * @return this player's {@link Scoreboard}
+     */
+    Scoreboard getScoreboard();
 }

--- a/api/src/main/java/net/md_5/bungee/api/score/Scoreboard.java
+++ b/api/src/main/java/net/md_5/bungee/api/score/Scoreboard.java
@@ -62,6 +62,11 @@ public class Scoreboard
         scores.put( score.getItemName(), score );
     }
 
+    public Score getScore(String name)
+    {
+        return scores.get( name );
+    }
+
     public void addTeam(Team team)
     {
         Preconditions.checkNotNull( team, "team" );

--- a/chat/src/main/java/net/md_5/bungee/api/chat/KeybindComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/KeybindComponent.java
@@ -35,7 +35,7 @@ public class KeybindComponent extends BaseComponent
      * Creates a keybind component with the passed internal keybind value.
      *
      * @param keybind the keybind value
-     * @see Keybind
+     * @see Keybinds
      */
     public KeybindComponent(String keybind)
     {

--- a/chat/src/main/java/net/md_5/bungee/api/chat/ScoreComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/ScoreComponent.java
@@ -5,8 +5,6 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 
-import javax.annotation.Nullable;
-
 /**
  * This component displays the score based on a player score on the scoreboard.<br>
  * The <b>name</b> is the name of the player stored on the scoreboard, which may be a "fake" player.
@@ -37,7 +35,6 @@ public final class ScoreComponent extends BaseComponent
     /**
      * The optional value to use instead of the one present in the Scoreboard.
      */
-    @Nullable
     private String value = "";
 
     /**

--- a/chat/src/main/java/net/md_5/bungee/api/chat/ScoreComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/ScoreComponent.java
@@ -1,0 +1,65 @@
+package net.md_5.bungee.api.chat;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@ToString
+@AllArgsConstructor
+@RequiredArgsConstructor
+public final class ScoreComponent extends BaseComponent
+{
+
+    /**
+     * The name of the player whose score should be displayed. Selectors can be used (such as "@p"),
+     * though BungeeCord does not guarantee the state of said entity or the validity of the selector. <br>
+     * The wildcard '*' can be used to show the reader's own score.
+     * (i.e. in a tellraw command to everyone, '*' will show each player their own score in the given objective)<br>
+     * BungeeCord makes no guarantees about using wildcards or selectors in this component.
+     */
+    private final String name;
+
+    /**
+     * The internal name of the objective the score is attached to.
+     */
+    private final String objective;
+
+    /**
+     * The optional value to use instead of the one present in the Scoreboard.<br>
+     */
+    @Setter
+    private String value = "";
+
+    /**
+     * Creates a score component from the original to clone it.
+     *
+     * @param original the original for the new score component
+     */
+    public ScoreComponent(ScoreComponent original)
+    {
+        super( original );
+        this.name = original.getName();
+        this.objective = original.getObjective();
+        this.value = original.getValue();
+    }
+
+    @Override
+    public ScoreComponent duplicate()
+    {
+        return new ScoreComponent( this );
+    }
+
+    @Override
+    public ScoreComponent duplicateWithoutFormatting()
+    {
+        return new ScoreComponent( this.name, this.objective, this.value );
+    }
+
+    protected void toLegacyText(StringBuilder builder)
+    {
+        builder.append(this.value);
+    }
+}

--- a/chat/src/main/java/net/md_5/bungee/api/chat/ScoreComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/ScoreComponent.java
@@ -6,6 +6,16 @@ import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 
+/**
+ * This component displays the score based on a player score on the scoreboard.<br>
+ * The <b>name</b> is the name of the player stored on the scoreboard, which may be a "fake" player.
+ * It can also be a target selector that <b>must</b> resolve to 1 target, and may target non-player entities.<br>
+ * With a book, /tellraw, or /title, using the wildcard '*' in the place of a name or target selector will cause all
+ * players to see their own score in the specified objective.<br>
+ * <b>Signs cannot use the wildcard ('*')</b><br>
+ *
+ * As of 1.12.2, a bug ( MC-56373 ) prevents full usage within hover events.
+ */
 @Getter
 @ToString
 @AllArgsConstructor
@@ -14,11 +24,7 @@ public final class ScoreComponent extends BaseComponent
 {
 
     /**
-     * The name of the player whose score should be displayed. Selectors can be used (such as "@p"),
-     * though BungeeCord does not guarantee the state of said entity or the validity of the selector. <br>
-     * The wildcard '*' can be used to show the reader's own score.
-     * (i.e. in a tellraw command to everyone, '*' will show each player their own score in the given objective)<br>
-     * BungeeCord makes no guarantees about using wildcards or selectors in this component.
+     * The name of the player whose score should be displayed.
      */
     private final String name;
 

--- a/chat/src/main/java/net/md_5/bungee/api/chat/ScoreComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/ScoreComponent.java
@@ -2,9 +2,10 @@ package net.md_5.bungee.api.chat;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
+
+import javax.annotation.Nullable;
 
 /**
  * This component displays the score based on a player score on the scoreboard.<br>
@@ -12,32 +13,46 @@ import lombok.ToString;
  * It can also be a target selector that <b>must</b> resolve to 1 target, and may target non-player entities.<br>
  * With a book, /tellraw, or /title, using the wildcard '*' in the place of a name or target selector will cause all
  * players to see their own score in the specified objective.<br>
- * <b>Signs cannot use the wildcard ('*')</b><br>
- *
+ * <b>Signs cannot use the '*' wildcard</b><br>
+ * These values are filled in by the server-side implementation.<br>
  * As of 1.12.2, a bug ( MC-56373 ) prevents full usage within hover events.
  */
 @Getter
+@Setter
 @ToString
 @AllArgsConstructor
-@RequiredArgsConstructor
 public final class ScoreComponent extends BaseComponent
 {
 
     /**
-     * The name of the player whose score should be displayed.
+     * The name of the entity whose score should be displayed.
      */
-    private final String name;
+    private String name;
 
     /**
      * The internal name of the objective the score is attached to.
      */
-    private final String objective;
+    private String objective;
 
     /**
-     * The optional value to use instead of the one present in the Scoreboard.<br>
+     * The optional value to use instead of the one present in the Scoreboard.
      */
-    @Setter
+    @Nullable
     private String value = "";
+
+    /**
+     * Creates a new score component with the specified name and objective.<br>
+     * If not specifically set, value will default to an empty string; signifying that the scoreboard value should
+     * take precedence. If not null, nor empty, {@code value} will override any value found in the scoreboard.<br>
+     * The value defaults to an empty string.
+     * @param name the name of the entity, or an entity selector, whose score should be displayed
+     * @param objective the internal name of the objective the entity's score is attached to
+     */
+    public ScoreComponent(String name, String objective)
+    {
+        setName( name );
+        setObjective( objective );
+    }
 
     /**
      * Creates a score component from the original to clone it.
@@ -47,9 +62,9 @@ public final class ScoreComponent extends BaseComponent
     public ScoreComponent(ScoreComponent original)
     {
         super( original );
-        this.name = original.getName();
-        this.objective = original.getObjective();
-        this.value = original.getValue();
+        setName( original.getName() );
+        setObjective( original.getObjective() );
+        setValue( original.getValue() );
     }
 
     @Override
@@ -64,8 +79,10 @@ public final class ScoreComponent extends BaseComponent
         return new ScoreComponent( this.name, this.objective, this.value );
     }
 
+    @Override
     protected void toLegacyText(StringBuilder builder)
     {
-        builder.append(this.value);
+        builder.append( this.value );
+        super.toLegacyText( builder );
     }
 }

--- a/chat/src/main/java/net/md_5/bungee/api/chat/SelectorComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/SelectorComponent.java
@@ -1,0 +1,44 @@
+package net.md_5.bungee.api.chat;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@RequiredArgsConstructor
+public final class SelectorComponent extends BaseComponent
+{
+    /**
+     * A string containing a selector (@p, @a, @r, @e, or @s) and, optionally, selector arguments.
+     */
+    private final String selector;
+
+    /**
+     * Creates a selector component from the original to clone it.
+     *
+     * @param original the original for the new selector component
+     */
+    public SelectorComponent(SelectorComponent original)
+    {
+        super(original);
+        this.selector = original.getSelector();
+    }
+
+    @Override
+    public SelectorComponent duplicate()
+    {
+        return new SelectorComponent(this);
+    }
+
+    @Override
+    public SelectorComponent duplicateWithoutFormatting()
+    {
+        return new SelectorComponent(this.selector);
+    }
+
+    protected void toLegacyText(StringBuilder builder)
+    {
+        builder.append(this.selector);
+    }
+}

--- a/chat/src/main/java/net/md_5/bungee/api/chat/SelectorComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/SelectorComponent.java
@@ -1,24 +1,28 @@
 package net.md_5.bungee.api.chat;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 import lombok.ToString;
 
 /**
  * This component processes a target selector into a pre-formatted set of discovered names.<br>
  * Multiple targets may be obtained, and with commas seperating each one and a final "and" for the last target.
  * The resulting format cannot be overwritten. This includes all styling from team prefixes, insertions, click events, and hover events.<br>
+ * These values are filled in by the server-side implementation.<br>
  * A bug (MC-53673) currently prevents full usage within hover events.
  */
 @Getter
+@Setter
 @ToString
-@RequiredArgsConstructor
+@AllArgsConstructor
 public final class SelectorComponent extends BaseComponent
 {
     /**
      * An entity target selector (@p, @a, @r, @e, or @s) and, optionally, selector arguments (e.g. @e[r=10,type=Creeper]).
      */
-    private final String selector;
+    private String selector;
 
     /**
      * Creates a selector component from the original to clone it.
@@ -27,24 +31,26 @@ public final class SelectorComponent extends BaseComponent
      */
     public SelectorComponent(SelectorComponent original)
     {
-        super(original);
-        this.selector = original.getSelector();
+        super( original );
+        setSelector( original.getSelector() );
     }
 
     @Override
     public SelectorComponent duplicate()
     {
-        return new SelectorComponent(this);
+        return new SelectorComponent( this );
     }
 
     @Override
     public SelectorComponent duplicateWithoutFormatting()
     {
-        return new SelectorComponent(this.selector);
+        return new SelectorComponent( this.selector );
     }
 
+    @Override
     protected void toLegacyText(StringBuilder builder)
     {
-        builder.append(this.selector);
+        builder.append( this.selector );
+        super.toLegacyText( builder );
     }
 }

--- a/chat/src/main/java/net/md_5/bungee/api/chat/SelectorComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/SelectorComponent.java
@@ -4,13 +4,19 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 
+/**
+ * This component processes a target selector into a pre-formatted set of discovered names.<br>
+ * Multiple targets may be obtained, and with commas seperating each one and a final "and" for the last target.
+ * The resulting format cannot be overwritten. This includes all styling from team prefixes, insertions, click events, and hover events.<br>
+ * A bug (MC-53673) currently prevents full usage within hover events.
+ */
 @Getter
 @ToString
 @RequiredArgsConstructor
 public final class SelectorComponent extends BaseComponent
 {
     /**
-     * A string containing a selector (@p, @a, @r, @e, or @s) and, optionally, selector arguments.
+     * An entity target selector (@p, @a, @r, @e, or @s) and, optionally, selector arguments (e.g. @e[r=10,type=Creeper]).
      */
     private final String selector;
 

--- a/chat/src/main/java/net/md_5/bungee/chat/ComponentSerializer.java
+++ b/chat/src/main/java/net/md_5/bungee/chat/ComponentSerializer.java
@@ -9,6 +9,8 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.KeybindComponent;
+import net.md_5.bungee.api.chat.ScoreComponent;
+import net.md_5.bungee.api.chat.SelectorComponent;
 import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.api.chat.TranslatableComponent;
 
@@ -23,6 +25,8 @@ public class ComponentSerializer implements JsonDeserializer<BaseComponent>
             registerTypeAdapter( TextComponent.class, new TextComponentSerializer() ).
             registerTypeAdapter( TranslatableComponent.class, new TranslatableComponentSerializer() ).
             registerTypeAdapter( KeybindComponent.class, new KeybindComponentSerializer() ).
+            registerTypeAdapter( ScoreComponent.class, new ScoreComponentSerializer() ).
+            registerTypeAdapter( SelectorComponent.class, new SelectorComponentSerializer() ).
             create();
 
     public final static ThreadLocal<HashSet<BaseComponent>> serializedComponents = new ThreadLocal<HashSet<BaseComponent>>();
@@ -64,6 +68,14 @@ public class ComponentSerializer implements JsonDeserializer<BaseComponent>
         if ( object.has( "keybind" ) )
         {
             return context.deserialize( json, KeybindComponent.class );
+        }
+        if( object.has( "score") )
+        {
+            return context.deserialize( json, ScoreComponent.class );
+        }
+        if( object.has( "selector" ) )
+        {
+            return context.deserialize( json, SelectorComponent.class );
         }
         return context.deserialize( json, TextComponent.class );
     }

--- a/chat/src/main/java/net/md_5/bungee/chat/ComponentSerializer.java
+++ b/chat/src/main/java/net/md_5/bungee/chat/ComponentSerializer.java
@@ -69,7 +69,7 @@ public class ComponentSerializer implements JsonDeserializer<BaseComponent>
         {
             return context.deserialize( json, KeybindComponent.class );
         }
-        if( object.has( "score") )
+        if( object.has( "score" ) )
         {
             return context.deserialize( json, ScoreComponent.class );
         }

--- a/chat/src/main/java/net/md_5/bungee/chat/ScoreComponentSerializer.java
+++ b/chat/src/main/java/net/md_5/bungee/chat/ScoreComponentSerializer.java
@@ -24,9 +24,9 @@ public class ScoreComponentSerializer extends BaseComponentSerializer implements
         String name = json.get( "name" ).getAsString();
         String objective = json.get( "objective" ).getAsString();
         ScoreComponent component = new ScoreComponent( name, objective );
-        if( json.has("value") )
+        if( json.has("value" ) && !json.get( "value" ).getAsString().isEmpty() )
         {
-            component.setValue( json.get("value").getAsString() );
+            component.setValue( json.get( "value" ).getAsString() );
         }
         deserialize( json, component, context );
         return component;

--- a/chat/src/main/java/net/md_5/bungee/chat/ScoreComponentSerializer.java
+++ b/chat/src/main/java/net/md_5/bungee/chat/ScoreComponentSerializer.java
@@ -1,0 +1,50 @@
+package net.md_5.bungee.chat;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import net.md_5.bungee.api.chat.ScoreComponent;
+
+import java.lang.reflect.Type;
+
+public class ScoreComponentSerializer extends BaseComponentSerializer implements JsonSerializer<ScoreComponent>, JsonDeserializer<ScoreComponent>
+{
+    @Override
+    public ScoreComponent deserialize(JsonElement element, Type type, JsonDeserializationContext context) throws JsonParseException
+    {
+        JsonObject json = element.getAsJsonObject();
+        if( !json.has( "name" ) || !json.has( "objective" ) )
+        {
+            throw new JsonParseException( "A score component needs at least a name and an objective" );
+        }
+        String name = json.get( "name" ).getAsString();
+        String objective = json.get( "objective" ).getAsString();
+        ScoreComponent component = new ScoreComponent( name, objective );
+        if( json.has("value") )
+        {
+            component.setValue( json.get("value").getAsString() );
+        }
+        deserialize( json, component, context );
+        return component;
+    }
+
+    @Override
+    public JsonElement serialize(ScoreComponent component, Type type, JsonSerializationContext context)
+    {
+        JsonObject root = new JsonObject();
+        serialize( root, component, context );
+        JsonObject json = new JsonObject();
+        json.addProperty( "name", component.getName() );
+        json.addProperty( "objective", component.getObjective() );
+        if( component.getValue() != null && !component.getValue().isEmpty() )
+        {
+            json.addProperty( "value", component.getValue() );
+        }
+        root.add( "score", json );
+        return root;
+    }
+}

--- a/chat/src/main/java/net/md_5/bungee/chat/ScoreComponentSerializer.java
+++ b/chat/src/main/java/net/md_5/bungee/chat/ScoreComponentSerializer.java
@@ -40,10 +40,7 @@ public class ScoreComponentSerializer extends BaseComponentSerializer implements
         JsonObject json = new JsonObject();
         json.addProperty( "name", component.getName() );
         json.addProperty( "objective", component.getObjective() );
-        if( component.getValue() != null && !component.getValue().isEmpty() )
-        {
-            json.addProperty( "value", component.getValue() );
-        }
+        json.addProperty( "value", component.getValue() );
         root.add( "score", json );
         return root;
     }

--- a/chat/src/main/java/net/md_5/bungee/chat/SelectorComponentSerializer.java
+++ b/chat/src/main/java/net/md_5/bungee/chat/SelectorComponentSerializer.java
@@ -19,7 +19,7 @@ public class SelectorComponentSerializer extends BaseComponentSerializer impleme
     {
         JsonObject object = element.getAsJsonObject();
         SelectorComponent component = new SelectorComponent( object.get( "selector" ).getAsString() );
-        deserialize(object, component, context);
+        deserialize( object, component, context );
         return component;
     }
 
@@ -27,8 +27,8 @@ public class SelectorComponentSerializer extends BaseComponentSerializer impleme
     public JsonElement serialize(SelectorComponent component, Type type, JsonSerializationContext context)
     {
         JsonObject object = new JsonObject();
-        serialize(object, component, context);
-        object.addProperty("selector", component.getSelector());
+        serialize( object, component, context );
+        object.addProperty( "selector", component.getSelector() );
         return object;
     }
 }

--- a/chat/src/main/java/net/md_5/bungee/chat/SelectorComponentSerializer.java
+++ b/chat/src/main/java/net/md_5/bungee/chat/SelectorComponentSerializer.java
@@ -1,0 +1,34 @@
+package net.md_5.bungee.chat;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import net.md_5.bungee.api.chat.SelectorComponent;
+
+import java.lang.reflect.Type;
+
+public class SelectorComponentSerializer extends BaseComponentSerializer implements JsonSerializer<SelectorComponent>, JsonDeserializer<SelectorComponent>
+{
+
+    @Override
+    public SelectorComponent deserialize(JsonElement element, Type type, JsonDeserializationContext context) throws JsonParseException
+    {
+        JsonObject object = element.getAsJsonObject();
+        SelectorComponent component = new SelectorComponent( object.get( "selector" ).getAsString() );
+        deserialize(object, component, context);
+        return component;
+    }
+
+    @Override
+    public JsonElement serialize(SelectorComponent component, Type type, JsonSerializationContext context)
+    {
+        JsonObject object = new JsonObject();
+        serialize(object, component, context);
+        object.addProperty("selector", component.getSelector());
+        return object;
+    }
+}

--- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
@@ -55,6 +55,9 @@ import net.md_5.bungee.api.ReconnectHandler;
 import net.md_5.bungee.api.ServerPing;
 import net.md_5.bungee.api.Title;
 import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.api.chat.KeybindComponent;
+import net.md_5.bungee.api.chat.ScoreComponent;
+import net.md_5.bungee.api.chat.SelectorComponent;
 import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.api.chat.TranslatableComponent;
 import net.md_5.bungee.api.config.ConfigurationAdapter;
@@ -64,6 +67,9 @@ import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.plugin.Plugin;
 import net.md_5.bungee.api.plugin.PluginManager;
 import net.md_5.bungee.chat.ComponentSerializer;
+import net.md_5.bungee.chat.KeybindComponentSerializer;
+import net.md_5.bungee.chat.ScoreComponentSerializer;
+import net.md_5.bungee.chat.SelectorComponentSerializer;
 import net.md_5.bungee.chat.TextComponentSerializer;
 import net.md_5.bungee.chat.TranslatableComponentSerializer;
 import net.md_5.bungee.command.CommandBungee;
@@ -151,13 +157,16 @@ public class BungeeCord extends ProxyServer
             .registerTypeAdapter( BaseComponent.class, new ComponentSerializer() )
             .registerTypeAdapter( TextComponent.class, new TextComponentSerializer() )
             .registerTypeAdapter( TranslatableComponent.class, new TranslatableComponentSerializer() )
+            .registerTypeAdapter( KeybindComponent.class, new KeybindComponentSerializer() )
+            .registerTypeAdapter( ScoreComponent.class, new ScoreComponentSerializer() )
+            .registerTypeAdapter( SelectorComponent.class, new SelectorComponentSerializer() )
             .registerTypeAdapter( ServerPing.PlayerInfo.class, new PlayerInfoSerializer() )
             .registerTypeAdapter( Favicon.class, Favicon.getFaviconTypeAdapter() ).create();
     @Getter
     private ConnectionThrottle connectionThrottle;
     private final ModuleManager moduleManager = new ModuleManager();
 
-    
+
     {
         // TODO: Proper fallback when we interface the manager
         getPluginManager().registerCommand( null, new CommandReload() );

--- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
@@ -420,7 +420,7 @@ public final class UserConnection implements ProxiedPlayer
     public void sendMessage(ChatMessageType position, BaseComponent... message)
     {
         // transform score components
-        message = ChatComponentTransformer.getInstance().transform( getScoreboard(), this, message );
+        message = ChatComponentTransformer.getInstance().transform( this, message );
         // Action bar doesn't display the new JSON formattings, legacy works - send it using this for now
         if ( position == ChatMessageType.ACTION_BAR )
         {
@@ -434,7 +434,7 @@ public final class UserConnection implements ProxiedPlayer
     @Override
     public void sendMessage(ChatMessageType position, BaseComponent message)
     {
-        message = ChatComponentTransformer.getInstance().transform( getScoreboard(), this, message )[0];
+        message = ChatComponentTransformer.getInstance().transform( this, message )[0];
         // Action bar doesn't display the new JSON formattings, legacy works - send it using this for now
         if ( position == ChatMessageType.ACTION_BAR )
         {
@@ -617,8 +617,8 @@ public final class UserConnection implements ProxiedPlayer
     @Override
     public void setTabHeader(BaseComponent header, BaseComponent footer)
     {
-        header = ChatComponentTransformer.getInstance().transform( getServerSentScoreboard(), this, header )[0];
-        footer = ChatComponentTransformer.getInstance().transform( getServerSentScoreboard(), this, footer )[0];
+        header = ChatComponentTransformer.getInstance().transform( this, header )[0];
+        footer = ChatComponentTransformer.getInstance().transform( this, footer )[0];
         unsafe().sendPacket( new PlayerListHeaderFooter(
                 ComponentSerializer.toString( header ),
                 ComponentSerializer.toString( footer )
@@ -628,8 +628,8 @@ public final class UserConnection implements ProxiedPlayer
     @Override
     public void setTabHeader(BaseComponent[] header, BaseComponent[] footer)
     {
-        header = ChatComponentTransformer.getInstance().transform( getServerSentScoreboard(), this, header );
-        footer = ChatComponentTransformer.getInstance().transform( getServerSentScoreboard(), this, footer );
+        header = ChatComponentTransformer.getInstance().transform( this, header );
+        footer = ChatComponentTransformer.getInstance().transform( this, footer );
         unsafe().sendPacket( new PlayerListHeaderFooter(
                 ComponentSerializer.toString( header ),
                 ComponentSerializer.toString( footer )

--- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
@@ -61,6 +61,7 @@ import net.md_5.bungee.protocol.packet.SetCompression;
 import net.md_5.bungee.tab.ServerUnique;
 import net.md_5.bungee.tab.TabList;
 import net.md_5.bungee.util.CaseInsensitiveSet;
+import net.md_5.bungee.util.ChatComponentTransformer;
 
 @RequiredArgsConstructor
 public final class UserConnection implements ProxiedPlayer
@@ -418,6 +419,8 @@ public final class UserConnection implements ProxiedPlayer
     @Override
     public void sendMessage(ChatMessageType position, BaseComponent... message)
     {
+        // transform score components
+        message = ChatComponentTransformer.getInstance().transform( getScoreboard(), this, message );
         // Action bar doesn't display the new JSON formattings, legacy works - send it using this for now
         if ( position == ChatMessageType.ACTION_BAR )
         {
@@ -431,6 +434,8 @@ public final class UserConnection implements ProxiedPlayer
     @Override
     public void sendMessage(ChatMessageType position, BaseComponent message)
     {
+        // transform score components
+        message = ChatComponentTransformer.getInstance().transform( getScoreboard(), this, message )[0];
         // Action bar doesn't display the new JSON formattings, legacy works - send it using this for now
         if ( position == ChatMessageType.ACTION_BAR )
         {
@@ -613,19 +618,23 @@ public final class UserConnection implements ProxiedPlayer
     @Override
     public void setTabHeader(BaseComponent header, BaseComponent footer)
     {
-        unsafe().sendPacket( new PlayerListHeaderFooter(
-                ( header != null ) ? ComponentSerializer.toString( header ) : EMPTY_TEXT,
-                ( footer != null ) ? ComponentSerializer.toString( footer ) : EMPTY_TEXT
-        ) );
+        // transform score components
+        header = ChatComponentTransformer.getInstance().transform( getServerSentScoreboard(), this, header )[0];
+        footer = ChatComponentTransformer.getInstance().transform( getServerSentScoreboard(), this, footer )[0];
+        unsafe().sendPacket( new PlayerListHeaderFooter( ComponentSerializer.toString( header ),
+                                                         ComponentSerializer.toString( footer )
+                                                       ) );
     }
 
     @Override
     public void setTabHeader(BaseComponent[] header, BaseComponent[] footer)
     {
-        unsafe().sendPacket( new PlayerListHeaderFooter(
-                ( header != null ) ? ComponentSerializer.toString( header ) : EMPTY_TEXT,
-                ( footer != null ) ? ComponentSerializer.toString( footer ) : EMPTY_TEXT
-        ) );
+        // transform score components
+        header = ChatComponentTransformer.getInstance().transform( getServerSentScoreboard(), this, header );
+        footer = ChatComponentTransformer.getInstance().transform( getServerSentScoreboard(), this, footer );
+        unsafe().sendPacket( new PlayerListHeaderFooter( ComponentSerializer.toString( header ),
+                                                         ComponentSerializer.toString( footer )
+                                                       ) );
     }
 
     @Override
@@ -660,5 +669,9 @@ public final class UserConnection implements ProxiedPlayer
     public boolean isConnected()
     {
         return !ch.isClosed();
+    }
+
+    public Scoreboard getScoreboard() {
+        return serverSentScoreboard;
     }
 }

--- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
@@ -434,7 +434,6 @@ public final class UserConnection implements ProxiedPlayer
     @Override
     public void sendMessage(ChatMessageType position, BaseComponent message)
     {
-        // transform score components
         message = ChatComponentTransformer.getInstance().transform( getScoreboard(), this, message )[0];
         // Action bar doesn't display the new JSON formattings, legacy works - send it using this for now
         if ( position == ChatMessageType.ACTION_BAR )
@@ -618,23 +617,23 @@ public final class UserConnection implements ProxiedPlayer
     @Override
     public void setTabHeader(BaseComponent header, BaseComponent footer)
     {
-        // transform score components
         header = ChatComponentTransformer.getInstance().transform( getServerSentScoreboard(), this, header )[0];
         footer = ChatComponentTransformer.getInstance().transform( getServerSentScoreboard(), this, footer )[0];
-        unsafe().sendPacket( new PlayerListHeaderFooter( ComponentSerializer.toString( header ),
-                                                         ComponentSerializer.toString( footer )
-                                                       ) );
+        unsafe().sendPacket( new PlayerListHeaderFooter(
+                ComponentSerializer.toString( header ),
+                ComponentSerializer.toString( footer )
+        ) );
     }
 
     @Override
     public void setTabHeader(BaseComponent[] header, BaseComponent[] footer)
     {
-        // transform score components
         header = ChatComponentTransformer.getInstance().transform( getServerSentScoreboard(), this, header );
         footer = ChatComponentTransformer.getInstance().transform( getServerSentScoreboard(), this, footer );
-        unsafe().sendPacket( new PlayerListHeaderFooter( ComponentSerializer.toString( header ),
-                                                         ComponentSerializer.toString( footer )
-                                                       ) );
+        unsafe().sendPacket( new PlayerListHeaderFooter(
+                ComponentSerializer.toString( header ),
+                ComponentSerializer.toString( footer )
+        ) );
     }
 
     @Override

--- a/proxy/src/main/java/net/md_5/bungee/util/ChatComponentTransformer.java
+++ b/proxy/src/main/java/net/md_5/bungee/util/ChatComponentTransformer.java
@@ -41,7 +41,7 @@ public final class ChatComponentTransformer
      * @return the transformed component, or an array containing a single empty TextComponent if the components are null or empty
      * @throws IllegalArgumentException if an entity selector pattern is present
      */
-    public BaseComponent[] transform(Scoreboard scoreboard, ProxiedPlayer player, BaseComponent... component)
+    public BaseComponent[] transform(ProxiedPlayer player, BaseComponent... component)
     {
         if( component == null || component.length < 1 )
         {
@@ -52,20 +52,15 @@ public final class ChatComponentTransformer
         {
             if( root.getExtra() != null && !root.getExtra().isEmpty() )
             {
-                List<BaseComponent> list = Lists.newArrayList( transform( scoreboard, player, root.getExtra().toArray( new BaseComponent[]{} ) ) );
+                List<BaseComponent> list = Lists.newArrayList( transform( player, root.getExtra().toArray( new BaseComponent[root.getExtra().size()] ) ) );
                 root.setExtra( list );
             }
-            transformComponent(scoreboard, player, root);
+            if( root instanceof ScoreComponent )
+            {
+                transformScoreComponent( player,  ( ScoreComponent ) root );
+            }
         }
         return component;
-    }
-
-    private void transformComponent(Scoreboard scoreboard, ProxiedPlayer player, BaseComponent component)
-    {
-        if( component instanceof ScoreComponent )
-        {
-            transformScoreComponent( scoreboard, player, (ScoreComponent) component );
-        }
     }
 
     /**
@@ -75,7 +70,7 @@ public final class ChatComponentTransformer
      * @param scoreboard the scoreboard to retrieve scores from
      * @param player the player to use for the component's name
      */
-    private void transformScoreComponent(Scoreboard scoreboard, ProxiedPlayer player, ScoreComponent component)
+    private void transformScoreComponent(ProxiedPlayer player, ScoreComponent component)
     {
         Preconditions.checkArgument( !isSelectorPattern( component.getName() ), "Cannot transform entity selector patterns" );
 
@@ -90,9 +85,9 @@ public final class ChatComponentTransformer
             component.setName( player.getName() );
         }
 
-        if( scoreboard.getObjective( component.getObjective() ) != null )
+        if( player.getScoreboard().getObjective( component.getObjective() ) != null )
         {
-            Score score = scoreboard.getScore( component.getName() );
+            Score score = player.getScoreboard().getScore( component.getName() );
             if ( score != null )
             {
                 component.setValue( Integer.toString( score.getValue() ) );

--- a/proxy/src/main/java/net/md_5/bungee/util/ChatComponentTransformer.java
+++ b/proxy/src/main/java/net/md_5/bungee/util/ChatComponentTransformer.java
@@ -11,8 +11,8 @@ import java.util.regex.Pattern;
 
 /**
  * This class transforms chat components by attempting to replace transformable fields with the appropriate value.<br>
- * ScoreComponents are transformed by replacing their {@link ScoreComponent#getName()}} into the matching entity's name.
- * As well as replacing the {@link ScoreComponent#getValue()} with the matching value in the {@link net.md_5.bungee.api.score.Scoreboard}
+ * ScoreComponents are transformed by replacing their {@link ScoreComponent#getName()}} into the matching entity's name
+ * as well as replacing the {@link ScoreComponent#getValue()} with the matching value in the {@link net.md_5.bungee.api.score.Scoreboard}
  * if and only if the {@link ScoreComponent#getValue()} is not present.
  */
 public final class ChatComponentTransformer
@@ -31,7 +31,7 @@ public final class ChatComponentTransformer
      */
     public BaseComponent transform(BaseComponent component, Scoreboard scoreboard, ProxiedPlayer player)
     {
-        if(component instanceof ScoreComponent)
+        if( component instanceof ScoreComponent )
         {
             return transformScoreComponent( (ScoreComponent) component, scoreboard, player );
         }

--- a/proxy/src/main/java/net/md_5/bungee/util/ChatComponentTransformer.java
+++ b/proxy/src/main/java/net/md_5/bungee/util/ChatComponentTransformer.java
@@ -1,0 +1,85 @@
+package net.md_5.bungee.util;
+
+import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.api.chat.ScoreComponent;
+import net.md_5.bungee.api.connection.ProxiedPlayer;
+import net.md_5.bungee.api.score.Score;
+import net.md_5.bungee.api.score.Scoreboard;
+import org.apache.commons.lang.Validate;
+
+import java.util.regex.Pattern;
+
+/**
+ * This class transforms chat components by attempting to replace transformable fields with the appropriate value.<br>
+ * ScoreComponents are transformed by replacing their {@link ScoreComponent#getName()}} into the matching entity's name.
+ * As well as replacing the {@link ScoreComponent#getValue()} with the matching value in the {@link net.md_5.bungee.api.score.Scoreboard}
+ * if and only if the {@link ScoreComponent#getValue()} is not present.
+ */
+public final class ChatComponentTransformer
+{
+    /**
+     * The Pattern to match entity selectors.
+     */
+    private static final Pattern SELECTOR_PATTERN = Pattern.compile( "^@([pares])(?:\\[([^ ]*)\\])?$" );
+
+    /**
+     * Transform a given component, and attempt to transform the transformable fields.<br>
+     * Entity selectors <b>cannot</b> be evaluated.
+     * @param component the component to transform
+     * @return the transformed component
+     * @throws IllegalArgumentException if an entity selector pattern is present
+     */
+    public BaseComponent transform(BaseComponent component, Scoreboard scoreboard, ProxiedPlayer player)
+    {
+        if(component instanceof ScoreComponent)
+        {
+            return transformScoreComponent( (ScoreComponent) component, scoreboard, player );
+        }
+        return component;
+    }
+
+    /**
+     * Transform a ScoreComponent by replacing the name and value with the appropriate values.
+     * @param component the component to transform
+     * @param scoreboard the scoreboard to retrieve scores from
+     * @param player the player to use for the component's name
+     * @return the transformed component
+     */
+    private BaseComponent transformScoreComponent(ScoreComponent component, Scoreboard scoreboard, ProxiedPlayer player)
+    {
+        Validate.isTrue( !isSelectorPattern( component.getName() ), "Cannot transform entity selector patterns" );
+
+        if( component.getValue() != null && !component.getValue().isEmpty() )
+        {
+            return component; // pre-defined values override scoreboard values
+        }
+
+        // check for '*' wildcard
+        if( component.getName().equals( "*" ) )
+        {
+            component.setName( player.getName() );
+        }
+
+        if( scoreboard.getObjective( component.getObjective() ) != null )
+        {
+            for ( Score boardScore : scoreboard.getScores() )
+            {
+                if( boardScore.getScoreName().equals( component.getName() ) )
+                {
+                    component.setValue( Integer.toString( boardScore.getValue() ) );
+                }
+            }
+        }
+        return component;
+    }
+
+    /**
+     * Checks if the given string is an entity selector.
+     * @param pattern the pattern to check
+     * @return true if it is an entity selector
+     */
+    public boolean isSelectorPattern(String pattern)
+    {
+        return SELECTOR_PATTERN.matcher( pattern ).matches();
+    }
+}


### PR DESCRIPTION
This PR adds the two missing ChatComponents as well as their appropriate serializers.

ScoreComponent is used for getting the score for a player(or a dummy player, or entity) from a given objective.
SelectorComponent is used to pass in an entity selector ("@p", "@s", etc.) including an optional arguments.

I usually don't use this formatting style so if I missed some formatting let me know and I can fix it.

9 FEB:
Nested recursion: https://i.imgur.com/GGkOw7M.png
Nested recursion + tab header/footer: https://i.imgur.com/y1jpyxv.png
The formatting of the text is a bit off but it's still pretty much the same.
Code used: https://gist.github.com/Senmori/bf4d94205933d6f50f3085b7deba031e

14 FEB: More edits. (Sorry md_5)
I didn't change anything that would have broken anything; just removed the Scoreboard argument from the chat transformer since you can get it via ProxiedPlayer. As well as removing a useless method (as pointed out by @Mystiflow)
Regardless, here's proof: https://i.imgur.com/lGOjc6G.png
Same code used as before.