### PR TITLE
Chat Component API Improvements

### DIFF
--- a/chat/src/main/java/net/md_5/bungee/api/chat/BaseComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/BaseComponent.java
@@ -89,8 +89,8 @@ public abstract class BaseComponent
     }
 
     /**
-     * Copies the events and formatting of a BaseComponent without replacing
-     * already set formatting.
+     * Copies the events and formatting of a BaseComponent.
+     * Already set formatting will be replaced.
      *
      * @param component the component to copy from
      */
@@ -116,7 +116,7 @@ public abstract class BaseComponent
      *
      * @param component the component to copy from
      * @param retention the formatting to copy
-     * @param replace if already defined formats should be replaced by the new
+     * @param replace if already set formatting should be replaced by the new
      * component
      */
     public void copyFormatting(BaseComponent component, FormatRetention retention, boolean replace)

--- a/chat/src/main/java/net/md_5/bungee/api/chat/BaseComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/BaseComponent.java
@@ -89,6 +89,19 @@ public abstract class BaseComponent
     }
 
     /**
+     * Copies the formatting of another BaseComponent with every format style
+     * without replacing already formatted components.
+     *
+     * @param component the component to copy from
+     * @param replace if already defined formats should be replaced by the new
+     * component
+     */
+    public void copyFormatting(BaseComponent component)
+    {
+        copyFormatting( component, FormatRetention.ALL, false );
+    }
+
+    /**
     * Copies the formatting of another BaseComponent with every format style.
     *
     * @param component the component to copy from

--- a/chat/src/main/java/net/md_5/bungee/api/chat/BaseComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/BaseComponent.java
@@ -89,36 +89,36 @@ public abstract class BaseComponent
     }
 
     /**
-     * Copies the formatting of another BaseComponent with every format style
-     * without replacing already formatted components.
+     * Copies the events and formatting of a BaseComponent without replacing
+     * already set formatting.
      *
      * @param component the component to copy from
-     * @param replace if already defined formats should be replaced by the new
-     * component
      */
     public void copyFormatting(BaseComponent component)
     {
-        copyFormatting( component, FormatRetention.ALL, false );
+        copyFormatting( component, FormatRetention.ALL, true );
     }
 
     /**
-    * Copies the formatting of another BaseComponent with every format style.
-    *
-    * @param component the component to copy from
-    * @param replace if already defined formats should be replaced by the new component
-    */
+     * Copies the events and formatting of a BaseComponent.
+     *
+     * @param component the component to copy from
+     * @param replace if already set formatting should be replaced by the new
+     * component
+     */
     public void copyFormatting(BaseComponent component, boolean replace)
     {
         copyFormatting( component, FormatRetention.ALL, replace );
     }
 
     /**
-    * Copies the formatting of another BaseComponent with a specified format style.
-    *
-    * @param component the component to copy from
-    * @param retention the formatting to copy
-    * @param replace if already defined formats should be replaced by the new component
-    */
+     * Copies the specified formatting of a BaseComponent.
+     *
+     * @param component the component to copy from
+     * @param retention the formatting to copy
+     * @param replace if already defined formats should be replaced by the new
+     * component
+     */
     public void copyFormatting(BaseComponent component, FormatRetention retention, boolean replace)
     {
         if ( retention == FormatRetention.EVENTS || retention == FormatRetention.ALL )
@@ -166,7 +166,7 @@ public abstract class BaseComponent
     }
 
     /**
-     * Retains only the specified formatting. Text is not modified.
+     * Retains only the specified formatting.
      *
      * @param retention the formatting to retain
      */

--- a/chat/src/main/java/net/md_5/bungee/api/chat/BaseComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/BaseComponent.java
@@ -9,6 +9,7 @@ import net.md_5.bungee.api.ChatColor;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.ToString;
+import net.md_5.bungee.api.chat.ComponentBuilder.FormatRetention;
 
 @Setter
 @ToString(exclude = "parent")
@@ -62,13 +63,13 @@ public abstract class BaseComponent
     private List<BaseComponent> extra;
 
     /**
-     * The action to preform when this component (and child components) are
+     * The action to perform when this component (and child components) are
      * clicked
      */
     @Getter
     private ClickEvent clickEvent;
     /**
-     * The action to preform when this component (and child components) are
+     * The action to perform when this component (and child components) are
      * hovered over
      */
     @Getter
@@ -76,26 +77,73 @@ public abstract class BaseComponent
 
     BaseComponent(BaseComponent old)
     {
-        copyFormatting( old );
-    }
+        copyFormatting( old, FormatRetention.ALL );
 
-    public void copyFormatting(BaseComponent component)
-    {
-        setColor( component.getColorRaw() );
-        setBold( component.isBoldRaw() );
-        setItalic( component.isItalicRaw() );
-        setUnderlined( component.isUnderlinedRaw() );
-        setStrikethrough( component.isStrikethroughRaw() );
-        setObfuscated( component.isObfuscatedRaw() );
-        setInsertion( component.getInsertion() );
-        setClickEvent( component.getClickEvent() );
-        setHoverEvent( component.getHoverEvent() );
-        if ( component.getExtra() != null )
+        if ( old.getExtra() != null )
         {
-            for ( BaseComponent extra : component.getExtra() )
+            for ( BaseComponent extra : old.getExtra() )
             {
                 addExtra( extra.duplicate() );
             }
+        }
+    }
+
+    /**
+    * Copies the formatting of another BaseComponent with every format style.
+    *
+    * @param component the component to copy from
+    */
+    public void copyFormatting(BaseComponent component)
+    {
+        copyFormatting( component, FormatRetention.ALL );
+    }
+
+    /**
+    * Copies the formatting of another BaseComponent with a specified format style.
+    *
+    * @param component the component to copy from
+    * @param retention the formatting to copy
+    */
+    public void copyFormatting(BaseComponent component, FormatRetention retention)
+    {
+        if ( retention == FormatRetention.EVENTS || retention == FormatRetention.ALL )
+        {
+            setClickEvent( component.getClickEvent() );
+            setHoverEvent( component.getHoverEvent() );
+        }
+        if ( retention == FormatRetention.FORMATTING || retention == FormatRetention.ALL )
+        {
+            setColor( component.getColorRaw() );
+            setBold( component.isBoldRaw() );
+            setItalic( component.isItalicRaw() );
+            setUnderlined( component.isUnderlinedRaw() );
+            setStrikethrough( component.isStrikethroughRaw() );
+            setObfuscated( component.isObfuscatedRaw() );
+            setInsertion( component.getInsertion() );
+        }
+    }
+
+    /**
+     * Retains only the specified formatting. Text is not modified.
+     *
+     * @param retention the formatting to retain
+     */
+    public void retain(FormatRetention retention)
+    {
+        if ( retention == FormatRetention.FORMATTING || retention == FormatRetention.NONE )
+        {
+            setClickEvent( null );
+            setHoverEvent( null );
+        }
+        if ( retention == FormatRetention.EVENTS || retention == FormatRetention.NONE )
+        {
+            setColor( null );
+            setBold( null );
+            setItalic( null );
+            setUnderlined( null );
+            setStrikethrough( null );
+            setObfuscated( null );
+            setInsertion( null );
         }
     }
 
@@ -110,8 +158,15 @@ public abstract class BaseComponent
      * Clones the BaseComponent without formatting and returns the clone.
      *
      * @return The duplicate of this BaseComponent
+     * @deprecated API use discouraged, use traditional duplicate
      */
-    public abstract BaseComponent duplicateWithoutFormatting();
+    @Deprecated
+    public BaseComponent duplicateWithoutFormatting()
+    {
+        BaseComponent component = duplicate();
+        component.retain( FormatRetention.NONE );
+        return component;
+    }
 
     /**
      * Converts the components to a string that uses the old formatting codes

--- a/chat/src/main/java/net/md_5/bungee/api/chat/BaseComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/BaseComponent.java
@@ -77,7 +77,7 @@ public abstract class BaseComponent
 
     BaseComponent(BaseComponent old)
     {
-        copyFormatting( old, FormatRetention.ALL );
+        copyFormatting( old, FormatRetention.ALL, true );
 
         if ( old.getExtra() != null )
         {
@@ -92,10 +92,11 @@ public abstract class BaseComponent
     * Copies the formatting of another BaseComponent with every format style.
     *
     * @param component the component to copy from
+    * @param replace if already defined formats should be replaced by the new component
     */
-    public void copyFormatting(BaseComponent component)
+    public void copyFormatting(BaseComponent component, boolean replace)
     {
-        copyFormatting( component, FormatRetention.ALL );
+        copyFormatting( component, FormatRetention.ALL, replace );
     }
 
     /**
@@ -103,23 +104,51 @@ public abstract class BaseComponent
     *
     * @param component the component to copy from
     * @param retention the formatting to copy
+    * @param replace if already defined formats should be replaced by the new component
     */
-    public void copyFormatting(BaseComponent component, FormatRetention retention)
+    public void copyFormatting(BaseComponent component, FormatRetention retention, boolean replace)
     {
         if ( retention == FormatRetention.EVENTS || retention == FormatRetention.ALL )
         {
-            setClickEvent( component.getClickEvent() );
-            setHoverEvent( component.getHoverEvent() );
+            if ( replace || clickEvent == null )
+            {
+                setClickEvent( component.getClickEvent() );
+            }
+            if ( replace || hoverEvent == null )
+            {
+                setHoverEvent( component.getHoverEvent() );
+            }
         }
         if ( retention == FormatRetention.FORMATTING || retention == FormatRetention.ALL )
         {
-            setColor( component.getColorRaw() );
-            setBold( component.isBoldRaw() );
-            setItalic( component.isItalicRaw() );
-            setUnderlined( component.isUnderlinedRaw() );
-            setStrikethrough( component.isStrikethroughRaw() );
-            setObfuscated( component.isObfuscatedRaw() );
-            setInsertion( component.getInsertion() );
+            if ( replace || color == null )
+            {
+                setColor( component.getColorRaw() );
+            }
+            if ( replace || bold == null )
+            {
+                setBold( component.isBoldRaw() );
+            }
+            if ( replace || italic == null )
+            {
+                setItalic( component.isItalicRaw() );
+            }
+            if ( replace || underlined == null )
+            {
+                setUnderlined( component.isUnderlinedRaw() );
+            }
+            if ( replace || strikethrough == null )
+            {
+                setStrikethrough( component.isStrikethroughRaw() );
+            }
+            if ( replace || obfuscated == null )
+            {
+                setObfuscated( component.isObfuscatedRaw() );
+            }
+            if ( replace || insertion == null )
+            {
+                setInsertion( component.getInsertion() );
+            }
         }
     }
 

--- a/chat/src/main/java/net/md_5/bungee/api/chat/ComponentBuilder.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/ComponentBuilder.java
@@ -80,7 +80,7 @@ public final class ComponentBuilder
 
         BaseComponent previous = current;
         current = component.duplicate();
-        current.copyFormatting( previous, retention );
+        current.copyFormatting( previous, retention, false );
         return this;
     }
 
@@ -114,7 +114,7 @@ public final class ComponentBuilder
 
             BaseComponent previous = current;
             current = component.duplicate();
-            current.copyFormatting( previous, retention );
+            current.copyFormatting( previous, retention, false );
         }
 
         return this;
@@ -146,7 +146,7 @@ public final class ComponentBuilder
 
         BaseComponent old = current;
         current = new TextComponent( text );
-        current.copyFormatting( old, retention );
+        current.copyFormatting( old, retention, false );
 
         return this;
     }

--- a/chat/src/main/java/net/md_5/bungee/api/chat/ComponentBuilder.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/ComponentBuilder.java
@@ -55,10 +55,10 @@ public final class ComponentBuilder
     }
 
      /**
-     * Appends the component to the builder and makes it the current target for
+     * Appends a component to the builder and makes it the current target for
      * formatting. The text will have all the formatting from the previous part.
      *
-     * @param components the components to append
+     * @param component the component to append
      * @return this ComponentBuilder for chaining
      */
     public ComponentBuilder append(BaseComponent component)
@@ -67,7 +67,7 @@ public final class ComponentBuilder
     }
 
     /**
-     * Appends the component to the builder and makes it the current target for
+     * Appends a component to the builder and makes it the current target for
      * formatting. You can specify the amount of formatting retained.
      *
      * @param component the component to append

--- a/chat/src/main/java/net/md_5/bungee/api/chat/ComponentBuilder.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/ComponentBuilder.java
@@ -78,8 +78,9 @@ public final class ComponentBuilder
     {
         parts.add( current );
 
+        BaseComponent previous = current;
         current = component.duplicate();
-        retain( retention );
+        current.copyFormatting( previous, retention );
         return this;
     }
 
@@ -111,8 +112,9 @@ public final class ComponentBuilder
         {
             parts.add( current );
 
+            BaseComponent previous = current;
             current = component.duplicate();
-            retain( retention );
+            current.copyFormatting( previous, retention );
         }
 
         return this;

--- a/chat/src/main/java/net/md_5/bungee/api/chat/ComponentBuilder.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/ComponentBuilder.java
@@ -54,9 +54,10 @@ public final class ComponentBuilder
         current = new TextComponent( text );
     }
 
-     /**
+    /**
      * Appends a component to the builder and makes it the current target for
-     * formatting. The text will have all the formatting from the previous part.
+     * formatting. The component will have all the formatting from previous
+     * part.
      *
      * @param component the component to append
      * @return this ComponentBuilder for chaining
@@ -68,7 +69,8 @@ public final class ComponentBuilder
 
     /**
      * Appends a component to the builder and makes it the current target for
-     * formatting. You can specify the amount of formatting retained.
+     * formatting. You can specify the amount of formatting retained from
+     * previous part.
      *
      * @param component the component to append
      * @param retention the formatting to retain
@@ -85,8 +87,9 @@ public final class ComponentBuilder
     }
 
     /**
-     * Appends the components to the builder and makes it the current target for
-     * formatting. The text will have all the formatting from the previous part.
+     * Appends the components to the builder and makes the last element the
+     * current target for formatting. The components will have all the
+     * formatting from previous part.
      *
      * @param components the components to append
      * @return this ComponentBuilder for chaining
@@ -97,8 +100,9 @@ public final class ComponentBuilder
     }
 
     /**
-     * Appends the components to the builder and makes it the current target for
-     * formatting. You can specify the amount of formatting retained.
+     * Appends the components to the builder and makes the last element the
+     * current target for formatting. You can specify the amount of formatting
+     * retained from previous part.
      *
      * @param components the components to append
      * @param retention the formatting to retain
@@ -122,7 +126,7 @@ public final class ComponentBuilder
 
     /**
      * Appends the text to the builder and makes it the current target for
-     * formatting. The text will have all the formatting from the previous part.
+     * formatting. The text will have all the formatting from previous part.
      *
      * @param text the text to append
      * @return this ComponentBuilder for chaining
@@ -134,7 +138,8 @@ public final class ComponentBuilder
 
     /**
      * Appends the text to the builder and makes it the current target for
-     * formatting. You can specify the amount of formatting retained.
+     * formatting. You can specify the amount of formatting retained from
+     * previous part.
      *
      * @param text the text to append
      * @param retention the formatting to retain

--- a/chat/src/main/java/net/md_5/bungee/api/chat/ComponentBuilder.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/ComponentBuilder.java
@@ -54,6 +54,35 @@ public final class ComponentBuilder
         current = new TextComponent( text );
     }
 
+     /**
+     * Appends the component to the builder and makes it the current target for
+     * formatting. The text will have all the formatting from the previous part.
+     *
+     * @param components the components to append
+     * @return this ComponentBuilder for chaining
+     */
+    public ComponentBuilder append(BaseComponent component)
+    {
+        return append( component, FormatRetention.ALL );
+    }
+
+    /**
+     * Appends the component to the builder and makes it the current target for
+     * formatting. You can specify the amount of formatting retained.
+     *
+     * @param component the component to append
+     * @param retention the formatting to retain
+     * @return this ComponentBuilder for chaining
+     */
+    public ComponentBuilder append(BaseComponent component, FormatRetention retention)
+    {
+        parts.add( current );
+
+        current = component.duplicate();
+        retain( retention );
+        return this;
+    }
+
     /**
      * Appends the components to the builder and makes it the current target for
      * formatting. The text will have all the formatting from the previous part.
@@ -115,8 +144,7 @@ public final class ComponentBuilder
 
         BaseComponent old = current;
         current = new TextComponent( text );
-        current.copyFormatting( old );
-        retain( retention );
+        current.copyFormatting( old, retention );
 
         return this;
     }
@@ -247,27 +275,7 @@ public final class ComponentBuilder
      */
     public ComponentBuilder retain(FormatRetention retention)
     {
-        BaseComponent previous = current;
-
-        switch ( retention )
-        {
-            case NONE:
-                current = current.duplicateWithoutFormatting();
-                break;
-            case ALL:
-                // No changes are required
-                break;
-            case EVENTS:
-                current = current.duplicateWithoutFormatting();
-                current.setInsertion( previous.getInsertion() );
-                current.setClickEvent( previous.getClickEvent() );
-                current.setHoverEvent( previous.getHoverEvent() );
-                break;
-            case FORMATTING:
-                current.setClickEvent( null );
-                current.setHoverEvent( null );
-                break;
-        }
+        current.retain( retention );
         return this;
     }
 

--- a/chat/src/main/java/net/md_5/bungee/api/chat/ComponentBuilder.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/ComponentBuilder.java
@@ -55,6 +55,16 @@ public final class ComponentBuilder
     }
 
     /**
+     * Creates a ComponentBuilder with the given component as the first part.
+     *
+     * @param component the first component element
+     */
+    public ComponentBuilder(BaseComponent component)
+    {
+        current = component.duplicate();
+    }
+
+    /**
      * Appends a component to the builder and makes it the current target for
      * formatting. The component will have all the formatting from previous
      * part.

--- a/chat/src/main/java/net/md_5/bungee/api/chat/KeybindComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/KeybindComponent.java
@@ -49,12 +49,6 @@ public final class KeybindComponent extends BaseComponent
     }
 
     @Override
-    public BaseComponent duplicateWithoutFormatting()
-    {
-        return new KeybindComponent( keybind );
-    }
-
-    @Override
     protected void toPlainText(StringBuilder builder)
     {
         builder.append( getKeybind() );

--- a/chat/src/main/java/net/md_5/bungee/api/chat/ScoreComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/ScoreComponent.java
@@ -83,12 +83,6 @@ public final class ScoreComponent extends BaseComponent
     }
 
     @Override
-    public ScoreComponent duplicateWithoutFormatting()
-    {
-        return new ScoreComponent( this.name, this.objective, this.value );
-    }
-
-    @Override
     protected void toLegacyText(StringBuilder builder)
     {
         builder.append( this.value );

--- a/chat/src/main/java/net/md_5/bungee/api/chat/SelectorComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/SelectorComponent.java
@@ -49,12 +49,6 @@ public final class SelectorComponent extends BaseComponent
     }
 
     @Override
-    public SelectorComponent duplicateWithoutFormatting()
-    {
-        return new SelectorComponent( this.selector );
-    }
-
-    @Override
     protected void toLegacyText(StringBuilder builder)
     {
         builder.append( this.selector );

--- a/chat/src/main/java/net/md_5/bungee/api/chat/TextComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/TextComponent.java
@@ -181,12 +181,6 @@ public final class TextComponent extends BaseComponent
     }
 
     @Override
-    public BaseComponent duplicateWithoutFormatting()
-    {
-        return new TextComponent( this.text );
-    }
-
-    @Override
     protected void toPlainText(StringBuilder builder)
     {
         builder.append( text );

--- a/chat/src/main/java/net/md_5/bungee/api/chat/TranslatableComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/TranslatableComponent.java
@@ -94,12 +94,6 @@ public final class TranslatableComponent extends BaseComponent
         return new TranslatableComponent( this );
     }
 
-    @Override
-    public BaseComponent duplicateWithoutFormatting()
-    {
-        return new TranslatableComponent( this.translate, this.with );
-    }
-
     /**
      * Sets the translation substitutions to be used in this component. Removes
      * any previously set substitutions

--- a/chat/src/main/java/net/md_5/bungee/chat/ComponentSerializer.java
+++ b/chat/src/main/java/net/md_5/bungee/chat/ComponentSerializer.java
@@ -50,7 +50,13 @@ public class ComponentSerializer implements JsonDeserializer<BaseComponent>
 
     public static String toString(BaseComponent... components)
     {
-        return gson.toJson( new TextComponent( components ) );
+        if ( components.length == 1 )
+        {
+           return gson.toJson( components[ 0 ] );
+        } else
+        {
+            return gson.toJson( new TextComponent( components ) );
+        }
     }
 
     @Override

--- a/chat/src/main/java/net/md_5/bungee/chat/ComponentSerializer.java
+++ b/chat/src/main/java/net/md_5/bungee/chat/ComponentSerializer.java
@@ -7,6 +7,7 @@ import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
+import com.google.gson.JsonParser;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.KeybindComponent;
 import net.md_5.bungee.api.chat.ScoreComponent;
@@ -20,6 +21,7 @@ import java.util.HashSet;
 public class ComponentSerializer implements JsonDeserializer<BaseComponent>
 {
 
+    private final static JsonParser JSON_PARSER = new JsonParser();
     private final static Gson gson = new GsonBuilder().
             registerTypeAdapter( BaseComponent.class, new ComponentSerializer() ).
             registerTypeAdapter( TextComponent.class, new TextComponentSerializer() ).
@@ -33,14 +35,18 @@ public class ComponentSerializer implements JsonDeserializer<BaseComponent>
 
     public static BaseComponent[] parse(String json)
     {
-        if ( json.startsWith( "[" ) )
-        { //Array
-            return gson.fromJson( json, BaseComponent[].class );
-        }
-        return new BaseComponent[]
+        JsonElement jsonElement = JSON_PARSER.parse( json );
+
+        if ( jsonElement.isJsonArray() )
         {
-            gson.fromJson( json, BaseComponent.class )
-        };
+            return gson.fromJson( jsonElement, BaseComponent[].class );
+        } else
+        {
+            return new BaseComponent[]
+            {
+                gson.fromJson( jsonElement, BaseComponent.class )
+            };
+        }
     }
 
     public static String toString(BaseComponent component)

--- a/chat/src/test/java/net/md_5/bungee/api/chat/ComponentsTest.java
+++ b/chat/src/test/java/net/md_5/bungee/api/chat/ComponentsTest.java
@@ -9,12 +9,48 @@ public class ComponentsTest
 {
 
     @Test
+    public void testComponentFormatRetention()
+    {
+        TextComponent first = new TextComponent( "Hello" );
+        first.setBold( true );
+        first.setColor( ChatColor.RED );
+        first.setClickEvent( new ClickEvent( ClickEvent.Action.RUN_COMMAND, "test" ) );
+        first.setHoverEvent( new HoverEvent( HoverEvent.Action.SHOW_TEXT, new ComponentBuilder( "Test" ).create() ) );
+
+        TextComponent second = new TextComponent( " world" );
+        second.copyFormatting( first, ComponentBuilder.FormatRetention.ALL, true );
+        Assert.assertEquals( first.isBold(), second.isBold() );
+        Assert.assertEquals( first.getColor(), second.getColor() );
+        Assert.assertEquals( first.getClickEvent(), second.getClickEvent() );
+        Assert.assertEquals( first.getHoverEvent(), second.getHoverEvent() );
+    }
+
+    @Test
     public void testBuilderClone()
     {
         ComponentBuilder builder = new ComponentBuilder( "Hel" ).color( ChatColor.RED ).append( "lo" ).color( ChatColor.DARK_RED );
         ComponentBuilder cloned = new ComponentBuilder( builder );
 
         Assert.assertEquals( TextComponent.toLegacyText( builder.create() ), TextComponent.toLegacyText( cloned.create() ) );
+    }
+
+    @Test
+    public void testBuilderAppendMixedComponents()
+    {
+        ComponentBuilder builder = new ComponentBuilder( "Hello " );
+        TextComponent textComponent = new TextComponent( "world " );
+        TranslatableComponent translatableComponent = new TranslatableComponent( "item.swordGold.name" );
+        builder.append( new BaseComponent[] { // array based BaseComponent append
+            textComponent,
+            translatableComponent
+        } );
+        ScoreComponent scoreComponent = new ScoreComponent( "myscore", "myobjective" );
+        builder.append( scoreComponent ); // non array based BaseComponent append
+        BaseComponent[] components = builder.create();
+        Assert.assertEquals( "Hello ", components[0].toPlainText() );
+        Assert.assertEquals( textComponent.toPlainText(), components[1].toPlainText() );
+        Assert.assertEquals( translatableComponent.toPlainText(), components[2].toPlainText() );
+        Assert.assertEquals( scoreComponent.toPlainText(), components[3].toPlainText() );
     }
 
     @Test


### PR DESCRIPTION
- Deprecated ```duplicateWithoutFormatting```. It was a lazy workaround in one of my previous PRs and this PR removes the need for the method. It now includes the ```extra``` part of a BaseComponent to prevent inconsistencies and BaseComponent implementations don't have to override anymore.

- Updated the ```copyFormatting``` API:
  - Since ```ComponentBuilder``` supports ```BaseComponent``` appends, if an already formatted (ex. colours) component is appended, the formatting of the previous component would copy over. This was updated to only do so if the formatting wasn't set.
  - ```copyFormatting``` isn't supposed to copy ```extra```.
- Support appending a single ```BaseComponent``` without having to create a single element array.
- Copied retain API into ```BaseComponent``` to easily remove formatting or events.