### PR TITLE
Add json configuration provider.

### DIFF
--- a/config/pom.xml
+++ b/config/pom.xml
@@ -25,5 +25,13 @@
             <version>1.19</version>
             <scope>compile</scope>
         </dependency>
+
+        <!-- Gson -->
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.8.2</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/config/src/main/java/net/md_5/bungee/config/ConfigurationProvider.java
+++ b/config/src/main/java/net/md_5/bungee/config/ConfigurationProvider.java
@@ -8,9 +8,6 @@ import java.io.Writer;
 import java.util.HashMap;
 import java.util.Map;
 
-/**
- * @author Felix 'SasukeKawaii' Klauke <info@felix-klauke.de>
- */
 public abstract class ConfigurationProvider
 {
 

--- a/config/src/main/java/net/md_5/bungee/config/ConfigurationProvider.java
+++ b/config/src/main/java/net/md_5/bungee/config/ConfigurationProvider.java
@@ -8,6 +8,9 @@ import java.io.Writer;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * @author Felix 'SasukeKawaii' Klauke <info@felix-klauke.de>
+ */
 public abstract class ConfigurationProvider
 {
 
@@ -16,6 +19,7 @@ public abstract class ConfigurationProvider
     static
     {
         providers.put( YamlConfiguration.class, new YamlConfiguration() );
+        providers.put( JsonConfiguration.class, new JsonConfiguration() );
     }
 
     public static ConfigurationProvider getProvider(Class<? extends ConfigurationProvider> provider)

--- a/config/src/main/java/net/md_5/bungee/config/JsonConfiguration.java
+++ b/config/src/main/java/net/md_5/bungee/config/JsonConfiguration.java
@@ -9,9 +9,6 @@ import java.io.*;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-/**
- * @author Felix 'SasukeKawaii' Klauke <info@felix-klauke.de>
- */
 public class JsonConfiguration extends ConfigurationProvider {
 
     /**

--- a/config/src/main/java/net/md_5/bungee/config/JsonConfiguration.java
+++ b/config/src/main/java/net/md_5/bungee/config/JsonConfiguration.java
@@ -1,0 +1,115 @@
+package net.md_5.bungee.config;
+
+import com.google.common.collect.Maps;
+import com.google.gson.*;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.*;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * @author Felix 'SasukeKawaii' Klauke <info@felix-klauke.de>
+ */
+public class JsonConfiguration extends ConfigurationProvider {
+
+    /**
+     * Needed to prettify the json after the {@link JsonWriter} wrote wrong indentations in
+     * {@link #save(Configuration, Writer)}.
+     */
+    private static final JsonParser JSON_PARSER = new JsonParser();
+
+    /**
+     * The gson instance used for serialization.
+     */
+    private static final Gson GSON = new GsonBuilder()
+            .registerTypeAdapter(Configuration.class, new TypeAdapter<Configuration>() {
+                @Override
+                public void write(JsonWriter jsonWriter, Configuration configuration) throws IOException {
+                    jsonWriter.jsonValue(GSON.toJson(configuration.self));
+                }
+
+                @Override
+                public Configuration read(JsonReader jsonReader) {
+                    return null;
+                }
+            })
+            .setPrettyPrinting()
+            .serializeNulls()
+            .create();
+
+    @Override
+    public void save(Configuration config, File file) throws IOException {
+        try (FileWriter fileWriter = new FileWriter(file)) {
+            save(config, fileWriter);
+        }
+    }
+
+    @Override
+    public void save(Configuration config, Writer writer) {
+        String toJson = GSON.toJson(config);
+        JsonObject jsonObject = JSON_PARSER.parse(toJson).getAsJsonObject();
+        GSON.toJson(jsonObject, writer);
+    }
+
+    @Override
+    public Configuration load(File file) throws IOException {
+        return load(file, null);
+    }
+
+    @Override
+    public Configuration load(File file, Configuration defaults) throws IOException {
+        try (FileReader fileReader = new FileReader(file)) {
+            return load(fileReader, defaults);
+        }
+    }
+
+    @Override
+    public Configuration load(Reader reader) {
+        return load(reader, null);
+    }
+
+    @Override
+    public Configuration load(Reader reader, Configuration defaults) {
+        Map map = GSON.fromJson(reader, LinkedHashMap.class);
+
+        if (map == null) {
+            map = Maps.newLinkedHashMap();
+        }
+
+        return new Configuration(map, defaults);
+    }
+
+    @Override
+    public Configuration load(InputStream is) {
+        return load(is, null);
+    }
+
+    @Override
+    public Configuration load(InputStream is, Configuration defaults) {
+        try (InputStreamReader inputStreamReader = new InputStreamReader(is)) {
+            return load(inputStreamReader);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        return new Configuration(Maps.newLinkedHashMap(), null);
+    }
+
+    @Override
+    public Configuration load(String string) {
+        return load(string, null);
+    }
+
+    @Override
+    public Configuration load(String string, Configuration defaults) {
+        Map map = GSON.fromJson(string, LinkedHashMap.class);
+
+        if (map == null) {
+            map = Maps.newLinkedHashMap();
+        }
+
+        return new Configuration(map, defaults);
+    }
+}

--- a/config/src/test/java/net/md_5/bungee/config/JsonConfigurationTest.java
+++ b/config/src/test/java/net/md_5/bungee/config/JsonConfigurationTest.java
@@ -11,9 +11,6 @@ import java.util.List;
 
 import static org.junit.Assert.*;
 
-/**
- * @author Felix 'SasukeKawaii' Klauke <info@felix-klauke.de>
- */
 public class JsonConfigurationTest {
 
     private static final ConfigurationProvider CONFIGURATION_PROVIDER = ConfigurationProvider.getProvider(JsonConfiguration.class);

--- a/config/src/test/java/net/md_5/bungee/config/JsonConfigurationTest.java
+++ b/config/src/test/java/net/md_5/bungee/config/JsonConfigurationTest.java
@@ -1,0 +1,103 @@
+package net.md_5.bungee.config;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Felix 'SasukeKawaii' Klauke <info@felix-klauke.de>
+ */
+public class JsonConfigurationTest {
+
+    private static final ConfigurationProvider CONFIGURATION_PROVIDER = ConfigurationProvider.getProvider(JsonConfiguration.class);
+    private static final String TEST_DOCUMENT = "{\n" +
+            "  \"array\": [\n" +
+            "    1.0,\n" +
+            "    2.0,\n" +
+            "    3.0\n" +
+            "  ],\n" +
+            "  \"boolean\": true,\n" +
+            "  \"null\": null,\n" +
+            "  \"number\": 123.0,\n" +
+            "  \"object\": {\n" +
+            "    \"a\": \"b\",\n" +
+            "    \"c\": 1.0,\n" +
+            "    \"e\": 2.1\n" +
+            "  },\n" +
+            "  \"string\": \"Hello World\"\n" +
+            "}";
+
+    private Configuration configuration;
+
+    @Before
+    public void setUp() {
+        configuration = CONFIGURATION_PROVIDER.load(TEST_DOCUMENT);
+    }
+
+    @Test
+    public void testArray() {
+        List<Integer> array = configuration.getIntList("array");
+
+        assertEquals(3, array.size());
+        assertEquals(1, array.get(0).intValue());
+        assertEquals(2, array.get(1).intValue());
+        assertEquals(3, array.get(2).intValue());
+    }
+
+    @Test
+    public void testBoolean() {
+        boolean configurationBoolean = configuration.getBoolean("boolean");
+
+        assertTrue(configurationBoolean);
+    }
+
+    @Test
+    public void testNull() {
+        Object aNull = configuration.get("null");
+
+        assertNull(aNull);
+    }
+
+    @Test
+    public void testString() {
+        String string = configuration.getString("string");
+
+        assertEquals("Hello World", string);
+    }
+
+    @Test
+    public void testObject() {
+        Object object = configuration.get("object");
+
+        assertEquals(Configuration.class, object.getClass());
+
+        Configuration configuration = (Configuration) object;
+
+        assertEquals("b", configuration.getString("a"));
+        assertEquals(1, configuration.getShort("c"));
+        assertEquals(2.1F, configuration.getFloat("e"), 0.0000001);
+    }
+
+    @Test
+    public void testSave() {
+        try {
+            File file = new File("test.json");
+            CONFIGURATION_PROVIDER.save(configuration, file);
+
+            byte[] bytes = Files.readAllBytes(Paths.get("test.json"));
+
+            assertArrayEquals(TEST_DOCUMENT.getBytes(), bytes);
+
+            file.delete();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}


### PR DESCRIPTION
Signed-off-by: Felix Klauke <info@felix-klauke.de>

Add  possibility to use 'Json' as a configuration format. Gson is used for serialization. One arguable section is at https://github.com/SpigotMC/BungeeCord/compare/master...FelixKlauke:feature/json_configuration_provider?expand=1#diff-4dc2d0f3f2770d9269ab7ffad74cf408R52 whats actually needed because the json writer in https://github.com/SpigotMC/BungeeCord/compare/master...FelixKlauke:feature/json_configuration_provider?expand=1#diff-4dc2d0f3f2770d9269ab7ffad74cf408R30 is unable to use correct indents.

Feel free to comment and give feedback, yaml sucks. @md-5 @Thinkofname 