### PR TITLE
Add PlayerChangedSettingsEvent

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/event/SettingsChangedEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/SettingsChangedEvent.java
@@ -1,0 +1,30 @@
+package net.md_5.bungee.api.event;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import net.md_5.bungee.api.connection.ProxiedPlayer;
+import net.md_5.bungee.api.plugin.Event;
+
+/**
+ * Called after a {@link ProxiedPlayer} changed one or more of the following (client-side) settings:
+ *
+ * <ul>
+ *     <li>View distance</li>
+ *     <li>Locale</li>
+ *     <li>Displayed skin parts</li>
+ *     <li>Chat visibility</li>
+ *     <li>Chat colors</li>
+ *     <li>Main hand side (left or right)</li>
+ * </ul>
+ */
+@Data
+@ToString(callSuper = false)
+@EqualsAndHashCode(callSuper = false)
+public class SettingsChangedEvent extends Event {
+
+    /**
+     * Player who changed the settings.
+     */
+    private final ProxiedPlayer player;
+}

--- a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
@@ -12,6 +12,7 @@ import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.event.ChatEvent;
 import net.md_5.bungee.api.event.PlayerDisconnectEvent;
 import net.md_5.bungee.api.event.PluginMessageEvent;
+import net.md_5.bungee.api.event.SettingsChangedEvent;
 import net.md_5.bungee.api.event.TabCompleteEvent;
 import net.md_5.bungee.forge.ForgeConstants;
 import net.md_5.bungee.netty.ChannelWrapper;
@@ -175,6 +176,9 @@ public class UpstreamBridge extends PacketHandler
     public void handle(ClientSettings settings) throws Exception
     {
         con.setSettings( settings );
+
+        SettingsChangedEvent settingsEvent = new SettingsChangedEvent( con );
+        bungee.getPluginManager().callEvent( settingsEvent );
     }
 
     @Override


### PR DESCRIPTION
This pr adds a new PlayerChangedSettingsEvent similar to the one [in Spigot](https://hub.spigotmc.org/javadocs/spigot/org/bukkit/event/player/PlayerLocaleChangeEvent.html). It fires after the client changes the client-side settings (like view-distance or locale) or with a delay after joining the proxy server.

For example this could be relevant for plugins that send localized messages depending on the client locale. Instead of scheduling task that fetches the locale each X seconds, plugins could listen to this event and see changes immediately. 