### PR TITLE
Widen invalid username check, prevent empty usernames

### DIFF
--- a/api/src/main/java/net/md_5/bungee/Util.java
+++ b/api/src/main/java/net/md_5/bungee/Util.java
@@ -5,6 +5,7 @@ import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.UUID;
+import java.util.regex.Pattern;
 
 /**
  * Series of utility classes to perform various operations.
@@ -12,6 +13,8 @@ import java.util.UUID;
 public class Util
 {
 
+    private static final Pattern VALID_USERNAME_REGEX = Pattern
+            .compile( "^[a-zA-Z0-9-_]{1,16}$" );
     public static final int DEFAULT_PORT = 25565;
 
     /**
@@ -79,5 +82,16 @@ public class Util
     public static UUID getUUID(String uuid)
     {
         return UUID.fromString( uuid.substring( 0, 8 ) + "-" + uuid.substring( 8, 12 ) + "-" + uuid.substring( 12, 16 ) + "-" + uuid.substring( 16, 20 ) + "-" + uuid.substring( 20, 32 ) );
+    }
+
+    /**
+     * Returns if the a username is valid for a Minecraft account
+     *
+     * @param name the name to test
+     * @return true if username is valid
+     */
+    public static boolean testUsername(String name)
+    {
+        return VALID_USERNAME_REGEX.matcher( name ).matches();
     }
 }

--- a/proxy/src/main/java/net/md_5/bungee/conf/Configuration.java
+++ b/proxy/src/main/java/net/md_5/bungee/conf/Configuration.java
@@ -51,6 +51,11 @@ public class Configuration implements ProxyConfig
      * Whether we log proxy commands to the proxy log
      */
     private boolean logCommands;
+    /**
+     * If invalid names are strictly tested for invalid characters on offline
+     * mode.
+     */
+    private boolean strictOfflineNameValidate = false;
     private int playerLimit = -1;
     private Collection<String> disabledCommands;
     private int throttle = 4000;
@@ -88,7 +93,8 @@ public class Configuration implements ProxyConfig
         preventProxyConnections = adapter.getBoolean( "prevent_proxy_connections", preventProxyConnections );
 
         disabledCommands = new CaseInsensitiveSet( (Collection<String>) adapter.getList( "disabled_commands", Arrays.asList( "disabledcommandhere" ) ) );
-
+        strictOfflineNameValidate = adapter.getBoolean( "strict_offline_name_validate", strictOfflineNameValidate )
+        
         Preconditions.checkArgument( listeners != null && !listeners.isEmpty(), "No listeners defined." );
 
         Map<String, ServerInfo> newServers = adapter.getServers();

--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -325,15 +325,21 @@ public class InitialHandler extends PacketHandler implements PendingConnection
         Preconditions.checkState( thisState == State.USERNAME, "Not expecting USERNAME" );
         this.loginRequest = loginRequest;
 
-        if ( getName().contains( "." ) )
+        if ( getName().length() == 0 )
         {
-            disconnect( bungee.getTranslation( "name_invalid" ) );
+            disconnect( bungee.getTranslation( "name_empty" ) );
             return;
         }
 
         if ( getName().length() > 16 )
         {
             disconnect( bungee.getTranslation( "name_too_long" ) );
+            return;
+        }
+
+        if ( !Util.testUsername( getName() ) )
+        {
+            disconnect( bungee.getTranslation( "name_invalid" ) );
             return;
         }
 

--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -337,7 +337,16 @@ public class InitialHandler extends PacketHandler implements PendingConnection
             return;
         }
 
-        if ( !Util.testUsername( getName() ) )
+        boolean validName;
+        if ( isOnlineMode() || BungeeCord.getInstance().config.isStrictOfflineNameValidate() )
+        {
+            validName = Util.testUsername( getName() );
+        } else
+        {
+            validName = getName().contains( "." );
+        }
+
+        if ( validName )
         {
             disconnect( bungee.getTranslation( "name_invalid" ) );
             return;

--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -343,10 +343,10 @@ public class InitialHandler extends PacketHandler implements PendingConnection
             validName = Util.testUsername( getName() );
         } else
         {
-            validName = getName().contains( "." );
+            validName = !getName().contains( "." );
         }
 
-        if ( validName )
+        if ( !validName )
         {
             disconnect( bungee.getTranslation( "name_invalid" ) );
             return;

--- a/proxy/src/main/resources/messages.properties
+++ b/proxy/src/main/resources/messages.properties
@@ -20,6 +20,7 @@ server_kick=[Kicked]
 server_list=\u00a76You may connect to the following servers at this time: 
 server_went_down=\u00a7cThe server you were previously on went down, you have been connected to a fallback server
 total_players=Total players online: {0}
+name_empty=Cannot have an empty username
 name_too_long=Cannot have username longer than 16 characters
 name_invalid=Username contains invalid characters.
 ping_cannot_connect=\u00a7c[Bungee] Can't connect to server.


### PR DESCRIPTION
Regex allows the following.
- any alphanumerical character
- hyphens and underscores
- limits characters to 1-16, but this is already checked in InitialHandler anyway