### PR TITLE
Rework dimension change system

### DIFF
--- a/protocol/src/main/java/net/md_5/bungee/protocol/AbstractPacketHandler.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/AbstractPacketHandler.java
@@ -25,6 +25,7 @@ import net.md_5.bungee.protocol.packet.LegacyPing;
 import net.md_5.bungee.protocol.packet.LoginRequest;
 import net.md_5.bungee.protocol.packet.LoginSuccess;
 import net.md_5.bungee.protocol.packet.PingPacket;
+import net.md_5.bungee.protocol.packet.PositionLook;
 import net.md_5.bungee.protocol.packet.StatusRequest;
 import net.md_5.bungee.protocol.packet.StatusResponse;
 import net.md_5.bungee.protocol.packet.TabCompleteResponse;
@@ -146,6 +147,10 @@ public abstract class AbstractPacketHandler
     }
 
     public void handle(BossBar bossBar) throws Exception
+    {
+    }
+
+    public void handle(PositionLook positionLook) throws Exception
     {
     }
 }

--- a/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java
@@ -26,6 +26,7 @@ import net.md_5.bungee.protocol.packet.PingPacket;
 import net.md_5.bungee.protocol.packet.PlayerListHeaderFooter;
 import net.md_5.bungee.protocol.packet.PlayerListItem;
 import net.md_5.bungee.protocol.packet.PluginMessage;
+import net.md_5.bungee.protocol.packet.PositionLook;
 import net.md_5.bungee.protocol.packet.Respawn;
 import net.md_5.bungee.protocol.packet.ScoreboardDisplay;
 import net.md_5.bungee.protocol.packet.ScoreboardObjective;
@@ -153,6 +154,12 @@ public enum Protocol
                     map( ProtocolConstants.MINECRAFT_1_9_4, 0x47 ),
                     map( ProtocolConstants.MINECRAFT_1_12, 0x49 ),
                     map( ProtocolConstants.MINECRAFT_1_12_1, 0x4A )
+            );
+            TO_CLIENT.registerPacket(
+                PositionLook.class,
+                map( ProtocolConstants.MINECRAFT_1_8, 0x08 ),
+                map( ProtocolConstants.MINECRAFT_1_9, 0x2E ),
+                map( ProtocolConstants.MINECRAFT_1_12, 0x2F )
             );
 
             TO_SERVER.registerPacket(

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/PositionLook.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/PositionLook.java
@@ -1,0 +1,62 @@
+package net.md_5.bungee.protocol.packet;
+
+import net.md_5.bungee.protocol.DefinedPacket;
+import io.netty.buffer.ByteBuf;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import net.md_5.bungee.protocol.AbstractPacketHandler;
+import net.md_5.bungee.protocol.ProtocolConstants;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
+public class PositionLook extends DefinedPacket
+{
+
+    private double x;
+    private double y;
+    private double z;
+    private float yaw;
+    private float pitch;
+    private byte flags;
+    private int teleportId;
+
+    @Override
+    public void read(ByteBuf buf, ProtocolConstants.Direction direction, int protocolVersion)
+    {
+        x = buf.readDouble();
+        y = buf.readDouble();
+        z = buf.readDouble();
+        yaw = buf.readFloat();
+        pitch = buf.readFloat();
+        flags = buf.readByte();
+        if ( protocolVersion >= ProtocolConstants.MINECRAFT_1_9 )
+        {
+            teleportId = readVarInt( buf );
+        }
+    }
+
+    @Override
+    public void write(ByteBuf buf, ProtocolConstants.Direction direction, int protocolVersion)
+    {
+        buf.writeDouble( x );
+        buf.writeDouble( y );
+        buf.writeDouble( z );
+        buf.writeFloat( yaw );
+        buf.writeFloat( pitch );
+        buf.writeByte( flags );
+        if ( protocolVersion >= ProtocolConstants.MINECRAFT_1_9 )
+        {
+            writeVarInt( teleportId, buf );
+        }
+    }
+
+    @Override
+    public void handle(AbstractPacketHandler handler) throws Exception
+    {
+        handler.handle( this );
+    }
+}

--- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
+++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
@@ -236,6 +236,7 @@ public class ServerConnector extends PacketHandler
             user.setDimensionChange( true );
             if ( login.getDimension() == user.getDimension() )
             {
+                // dimensionChange update to Bungee.
                 user.unsafe().sendPacket( new Respawn( ( login.getDimension() >= 0 ? -1 : 0 ), login.getDifficulty(), login.getGameMode(), login.getLevelType() ) );
             }
 

--- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
+++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
@@ -100,7 +100,7 @@ public class ServerConnector extends PacketHandler
             copiedHandshake.setHost( newHost );
         } else if ( !user.getExtraDataInHandshake().isEmpty() )
         {
-            // Only restore the extra data if IP forwarding is off. 
+            // Only restore the extra data if IP forwarding is off.
             // TODO: Add support for this data with IP forwarding.
             copiedHandshake.setHost( copiedHandshake.getHost() + user.getExtraDataInHandshake() );
         }
@@ -192,6 +192,8 @@ public class ServerConnector extends PacketHandler
             user.setClientEntityId( login.getEntityId() );
             user.setServerEntityId( login.getEntityId() );
 
+            user.setDimensionChange( true );
+
             // Set tab list size, this sucks balls, TODO: what shall we do about packet mutability
             Login modLogin = new Login( login.getEntityId(), login.getGameMode(), (byte) login.getDimension(), login.getDifficulty(),
                     (byte) user.getPendingConnection().getListener().getTabListSize(), login.getLevelType(), login.isReducedDebugInfo() );
@@ -259,6 +261,7 @@ public class ServerConnector extends PacketHandler
         target.addPlayer( user );
         user.getPendingConnects().remove( target );
         user.setServerJoinQueue( null );
+        user.setLastKickReason( null );
         user.setDimensionChange( false );
 
         user.setServer( server );
@@ -290,6 +293,7 @@ public class ServerConnector extends PacketHandler
         bungee.getPluginManager().callEvent( event );
         if ( event.isCancelled() && event.getCancelServer() != null )
         {
+            user.setLastKickReason( event.getKickReasonComponent() );
             obsolete = true;
             user.connect( event.getCancelServer() );
             throw CancelSendSignal.INSTANCE;

--- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
@@ -36,6 +36,7 @@ import net.md_5.bungee.protocol.packet.Respawn;
 import net.md_5.bungee.protocol.packet.ScoreboardObjective;
 import net.md_5.bungee.protocol.packet.ScoreboardScore;
 import net.md_5.bungee.protocol.packet.ScoreboardDisplay;
+import net.md_5.bungee.protocol.packet.PositionLook;
 import net.md_5.bungee.protocol.packet.PluginMessage;
 import net.md_5.bungee.protocol.packet.Kick;
 import net.md_5.bungee.protocol.packet.SetCompression;
@@ -100,6 +101,12 @@ public class DownstreamBridge extends PacketHandler
     {
         con.getEntityRewrite().rewriteClientbound( packet.buf, con.getServerEntityId(), con.getClientEntityId() );
         con.sendPacket( packet );
+    }
+
+    @Override
+    public void handle(PositionLook positionLook)
+    {
+        con.setDimensionChange( false );
     }
 
     @Override
@@ -504,6 +511,11 @@ public class DownstreamBridge extends PacketHandler
     @Override
     public void handle(Respawn respawn)
     {
+        if ( respawn.getDimension() != con.getDimension() )
+        {
+            con.setDimensionChange( true );
+        }
+
         con.setDimension( respawn.getDimension() );
     }
 

--- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
@@ -63,8 +63,7 @@ public class DownstreamBridge extends PacketHandler
         if ( def != null )
         {
             server.setObsolete( true );
-            con.connectNow( def );
-            con.sendMessage( bungee.getTranslation( "server_went_down" ) );
+            con.connect( def );
         } else
         {
             con.disconnect( Util.exception( t ) );
@@ -457,7 +456,8 @@ public class DownstreamBridge extends PacketHandler
         ServerKickEvent event = bungee.getPluginManager().callEvent( new ServerKickEvent( con, server.getInfo(), ComponentSerializer.parse( kick.getMessage() ), def, ServerKickEvent.State.CONNECTED ) );
         if ( event.isCancelled() && event.getCancelServer() != null )
         {
-            con.connectNow( event.getCancelServer() );
+            con.setLastKickReason( event.getKickReasonComponent() );
+            con.connect( event.getCancelServer() );
         } else
         {
             con.disconnect0( event.getKickReasonComponent() ); // TODO: Prefix our own stuff.

--- a/proxy/src/main/resources/messages.properties
+++ b/proxy/src/main/resources/messages.properties
@@ -19,6 +19,7 @@ restart=[Proxy] Proxy restarting.
 server_kick=[Kicked] 
 server_list=\u00a76You may connect to the following servers at this time: 
 server_went_down=\u00a7cThe server you were previously on went down, you have been connected to a fallback server
+server_went_down_no_reconnect=\u00a7cThe server you were previously on went down
 total_players=Total players online: {0}
 name_too_long=Cannot have username longer than 16 characters
 name_invalid=Username contains invalid characters.


### PR DESCRIPTION
dimensionChange not updated from ServerKickEvent cancelling because
that should be separated from this.

ServerKickEvent cancellation:
If the connect to the cancel server fails, it will now show the original
kick event message and disconnect player cleanly instead of sending
message when they are about to time out anyway.