### PR TITLE
Only log disconnect message once packet is sent

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
@@ -348,11 +348,6 @@ public final class UserConnection implements ProxiedPlayer
     {
         if ( !ch.isClosing() )
         {
-            bungee.getLogger().log( Level.INFO, "[{0}] disconnected with: {1}", new Object[]
-            {
-                getName(), BaseComponent.toLegacyText( reason )
-            } );
-
             ch.delayedClose( new Kick( ComponentSerializer.toString( reason ) ) );
 
             if ( server != null )

--- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
@@ -460,6 +460,10 @@ public class DownstreamBridge extends PacketHandler
             con.connectNow( event.getCancelServer() );
         } else
         {
+            BungeeCord.getInstance().getLogger().log( Level.INFO, "[{0}] disconnected with: {1}", new Object[]
+            {
+                con.getName(), event.getKickReason()
+            } );
             con.disconnect0( event.getKickReasonComponent() ); // TODO: Prefix our own stuff.
         }
         server.setObsolete( true );


### PR DESCRIPTION
This commit makes it so the proxy will only log a user has disconnected
once the kick packet has been fully sent, not just when the method is
called - otherwise the message will be sent 250ms early due to the delay

* The name of the packet handler will now be noted in log msg