### PR TITLE
Add CONTRIBUTING.md, PR and ISSUE templates, and CODE_OF_CONDUCT

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,27 @@
+# Before you post an issue make sure you have read and understand the [issue submission guidelines](https://github.com/SpigotMC/BungeeCord/blob/master/CONTRIBUTING.md#submit-issue).
+
+### Requirements
+
+* Filling out the template is required. Any issue that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
+
+### Description
+
+[Description of the issue]
+
+### Steps to Reproduce
+
+1. [First Step]
+2. [Second Step]
+3. [and so on...]
+
+**Expected behavior:** [What you expect to happen]
+
+**Actual behavior:** [What actually happens]
+
+### Environment
+
+You can get this information from copy and pasting the output of `/bungee` from the command line.
+
+### Additional Information
+
+Any additional information, configuration or data that might be necessary to reproduce the issue.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+### Requirements
+
+* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
+
+### Description
+
+[Description of the change]
+
+### Benefits
+
+[ What benefits will be realized by the code change? ]

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,74 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+education, socio-economic status, nationality, personal appearance, race,
+religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at @spigotmc.org. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,65 @@
+# Contributing to BungeeCord
+
+Thanks for getting involved with the project, we'd love for you to help improve our software.
+
+* [Code of Conduct](#coc)
+* [Issues and Bugs](#issue)
+* [Issue Submission Guidelines](#submit-issue)
+* [Pull Request Submission Guidelines](#submit-pr)
+* [Codestyle](#codestyle)
+
+## <a name="coc"></a> Code of Conduct
+
+Help us keep BungeeCord open and inclusive. Please read and follow our [Code of Conduct][coc].
+
+## <a name="issue"></a> Issues and Bugs
+
+If you find a bug in the source code, you can help us by submitting an issue to our [GitHub Repository][github]. Even better, you can submit a Pull Request with a fix.
+
+**Please see the [Submission Guidelines](#submit-issue) below.**
+
+## <a name="submit-issue"></a> Issue Submission Guidelines
+Please check our [wiki](https://www.spigotmc.org/wiki/index/) as you may find the cause of a problem has already been documented and you will be able to fix it yourself.
+
+For issues with configuration or Spigot plugins, post on our forums at [SpigotMC](https://www.spigotmc.org/) instead.
+
+Before you submit your issue search the archive, maybe your question was already answered. If your issue appears to be a bug, and hasn't been reported, open a new issue. Help us to maximize
+the effort we can spend fixing issues and adding new features, by not reporting duplicate issues.
+
+The "[new issue][github-new-issue]" form contains a number of prompts that you should fill out to make it easier to understand and categorize the issue. In general, providing the following information will increase the chances of your issue being dealt
+with quickly.
+
+## <a name="submit-pr"></a> Pull Request Submission Guidelines
+Before you submit your pull request consider the following guidelines:
+
+* Search [GitHub](github-pulls) for an open or closed Pull Request that relates to your submission. You don't want to duplicate effort.
+* Follow our [Codestyle](#codestyle).
+* If the changes affect public APIs, change or add relevant documentation.
+
+## <a name="codestyle"></a> Codestyle
+
+* Use parenthesis around conditional check.
+  * ```var = ( boolean ) ? a : b``` instead of ```var = boolean ? a : b```
+* Use spaces around operators.
+  * ```count + 1``` instead of ```count+1```
+* Use spaces within function parameters:
+  * ```if ( test )``` instead of ```if (test)```
+* Use spaces after commas (unless separated by newlines).
+* Use spaces inside the curly-braces of hash literals:
+  * ```{ a, b }``` instead of ```{a, b}```
+* Include a single line of whitespace between methods.
+* Capitalize initialisms and acronyms in names, except for the first word, which should be lower-case:
+  * getURI instead of getUri
+  * uriToOpen instead of URIToOpen
+* Place braces associated with a control statement on the next line, indented to the same level as the control statement:
+  * ```
+    while ( x == y )
+    {
+        something();
+    }
+    ```
+
+[coc]: CODE_OF_CONDUCT.md
+[github]: https://github.com/SpigotMC/BungeeCord/
+[github-pulls]: https://github.com/SpigotMC/BungeeCord/pulls
+[github-new-issue]: https://github.com/SpigotMC/BungeeCord/issues/new


### PR DESCRIPTION
The purpose of this PR is to provide contributors with a set of guidelines to help maintain high quality issues and pull requests.

When creating issue forms, users will now be informed to check the Issue Submission Guidelines which will link to the forums and documentation, which will help cutt down on false reports (e.g. configuration not working, etc.).

Pull requests will include more descriptive information about what it intends to change.