### PR TITLE
Various bug fixes

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/ServerConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/ServerConnection.java
@@ -81,4 +81,9 @@ public class ServerConnection implements Server
     {
         return unsafe;
     }
+
+    public ChannelWrapper getHandle()
+    {
+        return ch;
+    }
 }

--- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
+++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.api.config.ServerInfo;
 import net.md_5.bungee.api.event.ServerConnectedEvent;
 import net.md_5.bungee.api.event.ServerKickEvent;
@@ -100,7 +101,7 @@ public class ServerConnector extends PacketHandler
             copiedHandshake.setHost( newHost );
         } else if ( !user.getExtraDataInHandshake().isEmpty() )
         {
-            // Only restore the extra data if IP forwarding is off. 
+            // Only restore the extra data if IP forwarding is off.
             // TODO: Add support for this data with IP forwarding.
             copiedHandshake.setHost( copiedHandshake.getHost() + user.getExtraDataInHandshake() );
         }
@@ -298,13 +299,13 @@ public class ServerConnector extends PacketHandler
         String message = bungee.getTranslation( "connect_kick", target.getName(), event.getKickReason() );
         if ( user.isDimensionChange() )
         {
-            user.disconnect( message );
+            kick.setMessage( message );
+            user.disconnect0( false, TextComponent.fromLegacyText( message ) ); // Required to close channels and log message
         } else
         {
             user.sendMessage( message );
+            throw CancelSendSignal.INSTANCE;
         }
-
-        throw CancelSendSignal.INSTANCE;
     }
 
     @Override

--- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
@@ -358,12 +358,12 @@ public final class UserConnection implements ProxiedPlayer
                 getName(), BaseComponent.toLegacyText( reason )
             } );
 
-            ch.delayedClose( ( kick ) ? new Kick( ComponentSerializer.toString( reason ) ) : null );
+            ch.close( ( kick ) ? new Kick( ComponentSerializer.toString( reason ) ) : null );
 
             if ( server != null )
             {
                 server.setObsolete( true );
-                server.disconnect( "Quitting" );
+                server.getHandle().close( null );
             }
         }
     }

--- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
@@ -346,6 +346,11 @@ public final class UserConnection implements ProxiedPlayer
 
     public void disconnect0(final BaseComponent... reason)
     {
+        disconnect0( true, reason );
+    }
+
+    public void disconnect0(final boolean kick, final BaseComponent... reason)
+    {
         if ( !ch.isClosing() )
         {
             bungee.getLogger().log( Level.INFO, "[{0}] disconnected with: {1}", new Object[]
@@ -353,7 +358,7 @@ public final class UserConnection implements ProxiedPlayer
                 getName(), BaseComponent.toLegacyText( reason )
             } );
 
-            ch.delayedClose( new Kick( ComponentSerializer.toString( reason ) ) );
+            ch.delayedClose( ( kick ) ? new Kick( ComponentSerializer.toString( reason ) ) : null );
 
             if ( server != null )
             {

--- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
@@ -15,6 +15,7 @@ import net.md_5.bungee.api.event.TabCompleteResponseEvent;
 import net.md_5.bungee.UserConnection;
 import net.md_5.bungee.Util;
 import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.config.ServerInfo;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.event.PluginMessageEvent;
@@ -458,12 +459,15 @@ public class DownstreamBridge extends PacketHandler
         if ( event.isCancelled() && event.getCancelServer() != null )
         {
             con.connectNow( event.getCancelServer() );
+            server.setObsolete( true );
+            throw CancelSendSignal.INSTANCE;
         } else
         {
-            con.disconnect0( event.getKickReasonComponent() ); // TODO: Prefix our own stuff.
+            String reason = BaseComponent.toLegacyText( event.getKickReasonComponent() ); // TODO: Prefix our own stuff.
+            kick.setMessage( reason );
+            con.disconnect0( false, event.getKickReasonComponent() ); // Required to close channels and log message
         }
         server.setObsolete( true );
-        throw CancelSendSignal.INSTANCE;
     }
 
     @Override

--- a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
@@ -78,6 +78,7 @@ public class UpstreamBridge extends PacketHandler
                 player.unsafe().sendPacket( packet );
             }
             con.getServer().disconnect( "Quitting" );
+            con.setServer( null );
         }
     }
 


### PR DESCRIPTION
**Remove unnecessary scheduling:**
The purpose of this change is to remove unnecessary tasks. Field ```server``` is of class ServerConnection. If we look at ```ServerConnection#disconnect``` we can see that the only thing it does it invoke ```ch#delayedClose``` with arg null. So effectively the previous code was vars ```ch``` and ```server``` both calling method delayedClose.

Because the only purpose of ```delayedClose(Kick)``` is to call ```close(Object)``` with a delay, we might as well have just called ```close(Object)``` for both directly in the first place as the need for 2 runnables is not needed.

**Don't process non-cancelled kicks twice:**
If player was kicked from server, and a plugin **didn't cancel** it; ```UserConnect#disconnect0``` is invoked which then calls ```ch#close(Kick)``` _ this will actually cause the packet to be sent to client again. This patch intends to fix that by removing CancelSendSignal to let the packet get received the first time and stops the kick write packet to netty.

**Nullify users' server when disconnected:**
~~This fixes a memory leak - nowhere in the source code was the server nulled out previously.~~