### PR TITLE
Treat BaseComponent array appends as one. Fixes #2387

### DIFF
--- a/chat/src/main/java/net/md_5/bungee/api/chat/ComponentBuilder.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/ComponentBuilder.java
@@ -122,11 +122,11 @@ public final class ComponentBuilder
     {
         Preconditions.checkArgument( components.length != 0, "No components to append" );
 
+        BaseComponent previous = current;
         for ( BaseComponent component : components )
         {
             parts.add( current );
 
-            BaseComponent previous = current;
             current = component.duplicate();
             current.copyFormatting( previous, retention, false );
         }

--- a/chat/src/test/java/net/md_5/bungee/api/chat/ComponentsTest.java
+++ b/chat/src/test/java/net/md_5/bungee/api/chat/ComponentsTest.java
@@ -5,8 +5,28 @@ import net.md_5.bungee.chat.ComponentSerializer;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 public class ComponentsTest
 {
+
+    @Test
+    public void testLegacyComponentBuilderAppend()
+    {
+        String text = "§a§lHello §r§kworld§7!";
+        BaseComponent[] components = TextComponent.fromLegacyText( text );
+        BaseComponent[] builderComponents = new ComponentBuilder( "" ).append( components ).create();
+        List<BaseComponent> list = new ArrayList<BaseComponent>( Arrays.asList( builderComponents ) );
+        // Remove the first element (empty text component). This needs to be done because toLegacyText always
+        // appends &f regardless if the color is non null or not and would otherwise mess with our unit test.
+        list.remove( 0 );
+        Assert.assertEquals(
+            TextComponent.toLegacyText( components ),
+            TextComponent.toLegacyText( list.toArray( new BaseComponent[ list.size() ] ) )
+        );
+    }
 
     @Test
     public void testComponentFormatRetention()


### PR DESCRIPTION
Don't copy formatting of previous element in the array being appended
but instead from the last appended component in the builder.
Otherwise formatting will be overridden in an incorrect way from
legacy text conversions.

Added unit test failed before this change. Now passes.