### PR TITLE
Implement LoginAbortedEvent.

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/event/LoginAbortedEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/LoginAbortedEvent.java
@@ -1,0 +1,27 @@
+package net.md_5.bungee.api.event;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import net.md_5.bungee.api.connection.PendingConnection;
+import net.md_5.bungee.api.plugin.Cancellable;
+import net.md_5.bungee.api.plugin.Event;
+
+/**
+ * Event called when login process is interrupted by player in result of
+ * clicking Cancel button.
+ *
+ * This event isn't called when {@link PreLoginEvent} or {@link LoginEvent}
+ * are cancelled by {@link Cancellable#setCancelled(boolean)}.
+ */
+@Data
+@ToString
+@EqualsAndHashCode(callSuper = false)
+public class LoginAbortedEvent extends Event
+{
+
+    /**
+     * Connection which aborted their login process.
+     */
+    private final PendingConnection connection;
+}


### PR DESCRIPTION
If user clicks `Cancel` button on `Logging In` screen, connection is going to close and no event will be called (after LoginEvent).
It causes weird bugs when we're marking player presence in databases like Redis, because we don't even know that player failed to fully login.
Event proposed in this PR allows to handle this case properly (e.g. remove loaded player data from DB).