### PR TITLE
fromLegacyText: return formatted component even if empty otherwise

### DIFF
--- a/chat/src/main/java/net/md_5/bungee/api/chat/TextComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/TextComponent.java
@@ -132,17 +132,9 @@ public final class TextComponent extends BaseComponent
             }
             builder.append( c );
         }
-        if ( builder.length() > 0 )
-        {
-            component.setText( builder.toString() );
-            components.add( component );
-        }
-
-        // The client will crash if the array is empty
-        if ( components.isEmpty() )
-        {
-            components.add( new TextComponent( "" ) );
-        }
+        
+        component.setText( builder.toString() );
+        components.add( component );
 
         return components.toArray( new BaseComponent[ components.size() ] );
     }

--- a/chat/src/test/java/net/md_5/bungee/api/chat/ComponentsTest.java
+++ b/chat/src/test/java/net/md_5/bungee/api/chat/ComponentsTest.java
@@ -113,9 +113,9 @@ public class ComponentsTest
         BaseComponent[] test2 = TextComponent.fromLegacyText( "Text http://spigotmc.org " + ChatColor.GREEN + "google.com/test" );
 
         Assert.assertEquals( "Text http://spigotmc.org google.com/test", BaseComponent.toPlainText( test2 ) );
-        //The extra ChatColor.WHITEs are sometimes inserted when not needed but it doesn't change the result
+        //The extra ChatColor instances are sometimes inserted when not needed but it doesn't change the result
         Assert.assertEquals( ChatColor.WHITE + "Text " + ChatColor.WHITE + "http://spigotmc.org" + ChatColor.WHITE
-                + " " + ChatColor.GREEN + "google.com/test", BaseComponent.toLegacyText( test2 ) );
+                + " " + ChatColor.GREEN + "google.com/test" + ChatColor.GREEN, BaseComponent.toLegacyText( test2 ) );
 
         ClickEvent url1 = test2[1].getClickEvent();
         Assert.assertNotNull( url1 );
@@ -273,6 +273,20 @@ public class ComponentsTest
 
         // all invalid color codes and the trailing '§' should be ignored
         Assert.assertEquals( emptyLegacyText, invalidColorCodesLegacyText );
+    }
+
+    @Test
+    public void testFormattingOnlyTextConversion()
+    {
+        String text = "§a";
+        
+        BaseComponent[] converted = TextComponent.fromLegacyText( text );
+        Assert.assertEquals( ChatColor.GREEN, converted[0].getColor() );
+        
+        String roundtripLegacyText = BaseComponent.toLegacyText( converted );
+        
+        // color code should not be lost during conversion
+        Assert.assertEquals( text, roundtripLegacyText );
     }
 
     private String fromAndToLegacyText(String legacyText)


### PR DESCRIPTION
Before: TextComponent.fromLegacyText("§c") -> unformatted empty TextComponent
After: TextComponent.fromLegacyText("§c") -> formatted (red color) empty TextComponent

Reasoning:
* Plugins may implement APIs to allow custom placeholders, but require methods implementing to return a TextComponent for more flexibility. If a plugin implementing this interface must interact with legacy text, color codes may not carry over as they are lost if the text contains nothing else.
* -> If one wishes to append several TextComponent instances, ones that have been converted from text that only contains formatting codes will simply have no effect, even when they should.
* There is no reason to drop a formatted component simply because it has no text within - you may as well add the empty component that has the formatting converted over.

Spigot thread:
https://www.spigotmc.org/threads/fromlegacytext-does-not-return-color-for-text-with-only-color-codes.316158/