### PR TITLE
Extend Chat module with `Joiner` functional interface support

### DIFF
--- a/chat/src/main/java/net/md_5/bungee/api/chat/ComponentBuilder.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/ComponentBuilder.java
@@ -167,6 +167,29 @@ public final class ComponentBuilder
     }
 
     /**
+     * Appends something to builder using appender given using {@link FormatRetention#ALL}.
+     * May come in handy especially in Java 8 due to functional interfaces support.
+     *
+     * @param appender appender used for operation
+     * @return this ComponentBuilder for chaining
+     */
+    public ComponentBuilder append(Appender appender) {
+        return appender.append(this, FormatRetention.ALL);
+    }
+
+    /**
+     * Appends something to builder using appender given using retention given.
+     * May come in handy especially in Java 8 due to functional interfaces support.
+     *
+     * @param appender appender used for operation
+     * @param retention the formatting to retain
+     * @return this ComponentBuilder for chaining
+     */
+    public ComponentBuilder append(Appender appender, FormatRetention retention) {
+        return appender.append(this, retention);
+    }
+
+    /**
      * Sets the color of the current part.
      *
      * @param color the new color
@@ -331,5 +354,21 @@ public final class ComponentBuilder
          * component.
          */
         ALL
+    }
+
+    /**
+     * Actually functional interface to append
+     */
+    public interface Appender
+    {
+
+        /**
+         * Appends something to {@code ComponentBuilder} given returning it for fulfilling chain pattern.
+         *
+         * @param componentBuilder to which to append something
+         * @param retention the formatting to retain
+         * @return ComponentBuilder given for chaining
+         */
+        ComponentBuilder append(ComponentBuilder componentBuilder, FormatRetention retention);
     }
 }

--- a/chat/src/main/java/net/md_5/bungee/api/chat/ComponentBuilder.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/ComponentBuilder.java
@@ -167,26 +167,27 @@ public final class ComponentBuilder
     }
 
     /**
-     * Appends something to builder using appender given using {@link FormatRetention#ALL}.
+     * Joins something to builder using joiner given using {@link FormatRetention#ALL}.
      * May come in handy especially in Java 8 due to functional interfaces support.
      *
-     * @param appender appender used for operation
+     * @param joiner joiner used for operation
      * @return this ComponentBuilder for chaining
      */
-    public ComponentBuilder append(Appender appender) {
-        return appender.append(this, FormatRetention.ALL);
+    public ComponentBuilder append(Joiner joiner) {
+        return joiner.join(this, FormatRetention.ALL);
     }
 
     /**
-     * Appends something to builder using appender given using retention given.
+     * Joins something to builder using Joiner using retention given.
      * May come in handy especially in Java 8 due to functional interfaces support.
+     * Retention may be ignored by Joiner.
      *
-     * @param appender appender used for operation
+     * @param joiner joiner used for operation
      * @param retention the formatting to retain
      * @return this ComponentBuilder for chaining
      */
-    public ComponentBuilder append(Appender appender, FormatRetention retention) {
-        return appender.append(this, retention);
+    public ComponentBuilder append(Joiner joiner, FormatRetention retention) {
+        return joiner.join(this, retention);
     }
 
     /**
@@ -332,7 +333,7 @@ public final class ComponentBuilder
         return result;
     }
 
-    public static enum FormatRetention
+    public enum FormatRetention
     {
 
         /**
@@ -359,16 +360,19 @@ public final class ComponentBuilder
     /**
      * Actually functional interface to append
      */
-    public interface Appender
+    public interface Joiner
     {
 
         /**
-         * Appends something to {@code ComponentBuilder} given returning it for fulfilling chain pattern.
+         * Joins something to {@code ComponentBuilder} given returning it for fulfilling chain pattern.
+         * Retention may be ignored and is to be understood as an optional recommendation for Joiner in case
+         * its behaviour can depend on it but not as a guarantee to hava previous component in builder unmodified.
          *
          * @param componentBuilder to which to append something
-         * @param retention the formatting to retain
+         * @param retention the formatting to retain.
+         *                  This does not guarantee that retention will be taken into account as
          * @return ComponentBuilder given for chaining
          */
-        ComponentBuilder append(ComponentBuilder componentBuilder, FormatRetention retention);
+        ComponentBuilder join(ComponentBuilder componentBuilder, FormatRetention retention);
     }
 }


### PR DESCRIPTION
Add support for functional interfaces in ComponentBuilder using inner Appender class which lets implement complex constructions without breaking chain pattern.

For example for method
```Java
public ComponentBuilder appendAuthors(ComponentBuilder builder, JavaPlugin plugin) {
    Iterable<String> authors = getDescription().getAuthors();
    int lastIndex = authors.size() - 1;
    for (var i = 0; i < authors.size(); i++) {
        builder.append(authors.get(i)).color(AQUA);
        if (i == lastIndex) continue;
        builder.append(" & " ).color(WHITE);
    }
}
```
Before:
```Java
appendAuthors(new ComponentBuilder("Game ").color(ChatColor.BLUE)
        .append(" by").color(ChatColor.WHITE), plugin)
.append(" <3").color(ChatColor.RED);
```
After:
```Java
new ComponentBuilder("Game ").color(ChatColor.BLUE).append(" by").color(ChatColor.WHITE)
.append((builder, r) -> appendAuthors(builder, plugin)).append(" <3").color(ChatColor.RED);
```
This may seem to be longer in some cases but helps avoid nesting statements in cases like 
```Java
appendBaz(
        appendBar(
                appendFoo(new ComponentBuilder("Lorem")/*appenders, colors and more*//*, fooParams*/)/*.append(...)..more appenders x1*//*, barParams*/
        )/*.append(...)..more appenders x3*//*, bazParams*/
)/*.append(...)..more appenders x3*/
```