### PR TITLE
Add API for fluent server connect requests

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/ServerConnectRequest.java
+++ b/api/src/main/java/net/md_5/bungee/api/ServerConnectRequest.java
@@ -14,11 +14,23 @@ import net.md_5.bungee.api.event.ServerConnectEvent;
 public class ServerConnectRequest
 {
 
+    /**
+     * A class that creates a callback system for executing code after a result has been computed.
+     */
     public interface Callback
     {
 
+        /**
+         * Called when the result is done.
+         *
+         * @param result the result of the computation
+         * @param error the error(s) that occurred, if any
+         */
         void done(Result result, Throwable error);
 
+        /**
+         * The result from this callback after request has been executed by proxy.
+         */
         enum Result {
 
             /**
@@ -44,6 +56,9 @@ public class ServerConnectRequest
         }
     }
 
+    /**
+     * Legacy wrapper for converting {@link net.md_5.bungee.api.Callback} into {@link Callback}
+     */
     public static class LegacyCallback implements net.md_5.bungee.api.Callback<Boolean>, Callback
     {
 
@@ -78,7 +93,7 @@ public class ServerConnectRequest
     @NonNull
     private final ServerConnectEvent.Reason reason;
     /**
-     * Callback sent back from request.
+     * Callback to execute post request.
      */
     private final ServerConnectRequest.Callback callback;
     /**
@@ -91,11 +106,14 @@ public class ServerConnectRequest
      */
     private final boolean retry;
 
+    /**
+     * Class that sets default properties/adds methods to the lombok builder generated class.
+     */
     public static class ServerConnectRequestBuilder
     {
 
         private ServerConnectRequest.Callback callback;
-        private int connectTimeout = 5000; //TODO: Configurable
+        private int connectTimeout = 5000; // TODO: Configurable
 
         // Backwards compat callback.
         public ServerConnectRequestBuilder callback(final net.md_5.bungee.api.Callback<Boolean> callback)

--- a/api/src/main/java/net/md_5/bungee/api/ServerConnectRequest.java
+++ b/api/src/main/java/net/md_5/bungee/api/ServerConnectRequest.java
@@ -10,7 +10,7 @@ import net.md_5.bungee.api.event.ServerConnectEvent;
  * A request to connect a server
  */
 @Getter
-@Builder
+@Builder(builderClassName = "Builder")
 public class ServerConnectRequest
 {
 

--- a/api/src/main/java/net/md_5/bungee/api/ServerConnectRequest.java
+++ b/api/src/main/java/net/md_5/bungee/api/ServerConnectRequest.java
@@ -1,4 +1,4 @@
-package net.md_5.bungee;
+package net.md_5.bungee.api;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/api/src/main/java/net/md_5/bungee/api/ServerConnectRequest.java
+++ b/api/src/main/java/net/md_5/bungee/api/ServerConnectRequest.java
@@ -54,7 +54,7 @@ public class ServerConnectRequest
     /**
      * Callback to execute post request.
      */
-    private final Callback<Result> result;
+    private final Callback<Result> callback;
     /**
      * Timeout in milliseconds for request.
      */
@@ -71,28 +71,6 @@ public class ServerConnectRequest
     public static class ServerConnectRequestBuilder
     {
 
-        private Callback<Result> result;
         private int connectTimeout = 5000; // TODO: Configurable
-
-        /**
-         * Sets the callback to execute on explicit succession of the request.
-         *
-         * @param callback the callback to execute
-         * @return this builder for chaining
-         * @deprecated recommended to use callback providing generic type of {@link Result}
-         */
-        @Deprecated
-        public ServerConnectRequestBuilder callback(final Callback<Boolean> callback)
-        {
-            this.result = new Callback<Result>()
-            {
-                @Override
-                public void done(Result result, Throwable error)
-                {
-                    callback.done( ( result == Result.SUCCESS ) ? Boolean.TRUE : Boolean.FALSE, error );
-                }
-            };
-            return this;
-        }
     }
 }

--- a/api/src/main/java/net/md_5/bungee/api/ServerConnectRequest.java
+++ b/api/src/main/java/net/md_5/bungee/api/ServerConnectRequest.java
@@ -78,8 +78,8 @@ public class ServerConnectRequest
          * Sets the callback to execute on explicit succession of the request.
          *
          * @param callback the callback to execute
-         * @return this builder
-         * @deprecated recommended to use callback with result
+         * @return this builder for chaining
+         * @deprecated recommended to use callback providing generic type of {@link Result}
          */
         @Deprecated
         public ServerConnectRequestBuilder callback(final Callback<Boolean> callback)

--- a/api/src/main/java/net/md_5/bungee/api/ServerConnectRequest.java
+++ b/api/src/main/java/net/md_5/bungee/api/ServerConnectRequest.java
@@ -54,7 +54,7 @@ public class ServerConnectRequest
     /**
      * Callback to execute post request.
      */
-    private final Callback<Result> callback;
+    private final Callback<Result> result;
     /**
      * Timeout in milliseconds for request.
      */
@@ -71,7 +71,7 @@ public class ServerConnectRequest
     public static class ServerConnectRequestBuilder
     {
 
-        private Callback<Result> callback;
+        private Callback<Result> result;
         private int connectTimeout = 5000; // TODO: Configurable
 
         /**
@@ -84,7 +84,7 @@ public class ServerConnectRequest
         @Deprecated
         public ServerConnectRequestBuilder callback(final Callback<Boolean> callback)
         {
-            this.callback = new Callback<Result>()
+            this.result = new Callback<Result>()
             {
                 @Override
                 public void done(Result result, Throwable error)

--- a/api/src/main/java/net/md_5/bungee/api/connection/ProxiedPlayer.java
+++ b/api/src/main/java/net/md_5/bungee/api/connection/ProxiedPlayer.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 import net.md_5.bungee.api.Callback;
 import net.md_5.bungee.api.ChatMessageType;
 import net.md_5.bungee.api.CommandSender;
+import net.md_5.bungee.api.ServerConnectRequest;
 import net.md_5.bungee.api.SkinConfiguration;
 import net.md_5.bungee.api.Title;
 import net.md_5.bungee.api.chat.BaseComponent;
@@ -122,6 +123,15 @@ public interface ProxiedPlayer extends Connection, CommandSender
      * @param reason the reason for connecting to the new server
      */
     void connect(ServerInfo target, Callback<Boolean> callback, ServerConnectEvent.Reason reason);
+
+    /**
+     * Connects / transfers this user to the specified connection, gracefully
+     * closing the current one. Depending on the implementation, this method
+     * might return before the user has been connected.
+     *
+     * @param request request to connect with
+     */
+    void connect(ServerConnectRequest request);
 
     /**
      * Gets the server this player is connected to.

--- a/proxy/src/main/java/net/md_5/bungee/ServerConnectRequest.java
+++ b/proxy/src/main/java/net/md_5/bungee/ServerConnectRequest.java
@@ -1,0 +1,107 @@
+package net.md_5.bungee;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NonNull;
+import net.md_5.bungee.api.config.ServerInfo;
+import net.md_5.bungee.api.event.ServerConnectEvent;
+
+/**
+ * A request to connect a server
+ */
+@Getter
+@Builder
+public class ServerConnectRequest
+{
+
+    public interface Callback
+    {
+
+        void done(Result result, Throwable error);
+
+        enum Result {
+
+            /**
+             * ServerConnectEvent to the new server was canceled.
+             */
+            EVENT_CANCEL,
+            /**
+             * Already connected to target server.
+             */
+            ALREADY_CONNECTED,
+            /**
+             * Already connecting to target server.
+             */
+            ALREADY_CONNECTING,
+            /**
+             * Successfully connected to server.
+             */
+            SUCCESS,
+            /**
+             * Connection failed, error can be accessed from callback method handle.
+             */
+            FAIL
+        }
+    }
+
+    public static class LegacyCallback implements net.md_5.bungee.api.Callback<Boolean>, Callback
+    {
+
+        private final net.md_5.bungee.api.Callback<Boolean> callback;
+
+        public LegacyCallback(net.md_5.bungee.api.Callback<Boolean> callback)
+        {
+            this.callback = callback;
+        }
+
+        @Override
+        public final void done(Result result, Throwable error)
+        {
+            done( ( result == Result.SUCCESS ) ? Boolean.TRUE : Boolean.FALSE, error );
+        }
+
+        @Override
+        public void done(Boolean result, Throwable error)
+        {
+            callback.done( result, error );
+        }
+    }
+
+    /**
+     * Target server to connect to.
+     */
+    @NonNull
+    private final ServerInfo target;
+    /**
+     * Reason for connecting to server.
+     */
+    @NonNull
+    private final ServerConnectEvent.Reason reason;
+    /**
+     * Callback sent back from request.
+     */
+    private final ServerConnectRequest.Callback callback;
+    /**
+     * Timeout in milliseconds for request.
+     */
+    private final int connectTimeout;
+    /**
+     * Should the player be attempted to connect to the next server
+     * in their queue if the initial request fails.
+     */
+    private final boolean retry;
+
+    public static class ServerConnectRequestBuilder
+    {
+
+        private ServerConnectRequest.Callback callback;
+        private int connectTimeout = 5000; //TODO: Configurable
+
+        // Backwards compat callback.
+        public ServerConnectRequestBuilder callback(final net.md_5.bungee.api.Callback<Boolean> callback)
+        {
+            this.callback = new LegacyCallback( callback );
+            return this;
+        }
+    }
+}

--- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
@@ -254,7 +254,7 @@ public final class UserConnection implements ProxiedPlayer
     {
         Preconditions.checkNotNull( info, "info" );
 
-        ServerConnectRequest.ServerConnectRequestBuilder builder = ServerConnectRequest.builder().retry( retry ).reason( reason ).target( info );
+        ServerConnectRequest.Builder builder = ServerConnectRequest.builder().retry( retry ).reason( reason ).target( info );
         if ( callback != null )
         {
             // Convert the Callback<Boolean> to be compatible with Callback<Result> from ServerConnectRequest.

--- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
@@ -257,11 +257,7 @@ public final class UserConnection implements ProxiedPlayer
         connect( ServerConnectRequest.builder().callback( callback ).retry( retry ).reason( reason ).target( info ).build() );
     }
 
-    /**
-     * Connects to a server with given request info
-     *
-     * @param request request to connect with
-     */
+    @Override
     public void connect(final ServerConnectRequest request)
     {
         Preconditions.checkNotNull( request, "request" );

--- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
@@ -27,6 +27,7 @@ import lombok.Setter;
 import net.md_5.bungee.api.Callback;
 import net.md_5.bungee.api.ChatMessageType;
 import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.ServerConnectRequest;
 import net.md_5.bungee.api.SkinConfiguration;
 import net.md_5.bungee.api.Title;
 import net.md_5.bungee.api.chat.BaseComponent;

--- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
@@ -266,13 +266,13 @@ public final class UserConnection implements ProxiedPlayer
     {
         Preconditions.checkNotNull( request, "request" );
 
-        final ServerConnectRequest.Callback callback = request.getCallback();
+        final Callback<ServerConnectRequest.Result> callback = request.getCallback();
         ServerConnectEvent event = new ServerConnectEvent( this, request.getTarget(), request.getReason() );
         if ( bungee.getPluginManager().callEvent( event ).isCancelled() )
         {
             if ( callback != null )
             {
-                callback.done( ServerConnectRequest.Callback.Result.EVENT_CANCEL, null );
+                callback.done( ServerConnectRequest.Result.EVENT_CANCEL, null );
             }
 
             if ( getServer() == null && !ch.isClosing() )
@@ -288,7 +288,7 @@ public final class UserConnection implements ProxiedPlayer
         {
             if ( callback != null )
             {
-                callback.done( ServerConnectRequest.Callback.Result.ALREADY_CONNECTED, null );
+                callback.done( ServerConnectRequest.Result.ALREADY_CONNECTED, null );
             }
 
             sendMessage( bungee.getTranslation( "already_connected" ) );
@@ -298,7 +298,7 @@ public final class UserConnection implements ProxiedPlayer
         {
             if ( callback != null )
             {
-                callback.done( ServerConnectRequest.Callback.Result.ALREADY_CONNECTING, null );
+                callback.done( ServerConnectRequest.Result.ALREADY_CONNECTING, null );
             }
 
             sendMessage( bungee.getTranslation( "already_connecting" ) );
@@ -326,7 +326,7 @@ public final class UserConnection implements ProxiedPlayer
             {
                 if ( callback != null )
                 {
-                    callback.done( ( future.isSuccess() ) ? ServerConnectRequest.Callback.Result.SUCCESS : ServerConnectRequest.Callback.Result.FAIL, future.cause() );
+                    callback.done( ( future.isSuccess() ) ? ServerConnectRequest.Result.SUCCESS : ServerConnectRequest.Result.FAIL, future.cause() );
                 }
 
                 if ( !future.isSuccess() )

--- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
@@ -257,6 +257,11 @@ public final class UserConnection implements ProxiedPlayer
         connect( ServerConnectRequest.builder().callback( callback ).retry( retry ).reason( reason ).target( info ).build() );
     }
 
+    /**
+     * Connects to a server with given request info
+     *
+     * @param request request to connect with
+     */
     public void connect(final ServerConnectRequest request)
     {
         Preconditions.checkNotNull( request, "request" );

--- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
@@ -262,7 +262,7 @@ public final class UserConnection implements ProxiedPlayer
     {
         Preconditions.checkNotNull( request, "request" );
 
-        final Callback<ServerConnectRequest.Result> callback = request.getCallback();
+        final Callback<ServerConnectRequest.Result> callback = request.getResult();
         ServerConnectEvent event = new ServerConnectEvent( this, request.getTarget(), request.getReason() );
         if ( bungee.getPluginManager().callEvent( event ).isCancelled() )
         {


### PR DESCRIPTION
Prevents the need to constantly overload the connect method when new flags/variables are added and can instead just be added to the request builder.

New callback system allows for more control to see specifically why the callback was executed, whilst maintaining backwards compatibility.