### PR TITLE
Avoid stopping if already in progress

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
@@ -378,8 +378,14 @@ public class BungeeCord extends ProxyServer
     }
 
     @Override
-    public void stop(final String reason)
+    public synchronized void stop(final String reason)
     {
+        if ( !isRunning )
+        {
+            return;
+        }
+        isRunning = false;
+
         new Thread( "Shutdown Thread" )
         {
             @Override
@@ -387,8 +393,6 @@ public class BungeeCord extends ProxyServer
             @SuppressWarnings("TooBroadCatch")
             public void run()
             {
-                BungeeCord.this.isRunning = false;
-
                 stopListeners();
                 getLogger().info( "Closing pending connections" );
 


### PR DESCRIPTION
Currently it is possible to stop the proxy multiple times, causing the shutdown routines to be called twice. This doesn't make any sense and may even cause problems with some plugins.

Cancel early if stopping is already in progress to avoid this.

Example log (after I managed to run `end` twice):

```
>end
15:49:36 [INFO] Closing listener [id: 0x7ee60395, L:/0:0:0:0:0:0:0:0%0:25577]
15:49:36 [INFO] Closing pending connections
15:49:36 [INFO] Disconnecting 0 connections
>end
15:49:36 [INFO] Closing pending connections
15:49:36 [INFO] Disconnecting 0 connections
15:49:36 [INFO] Saving reconnect locations
15:49:36 [INFO] Disabling plugins
15:49:36 [INFO] Closing IO threads
15:49:37 [INFO] Saving reconnect locations
15:49:37 [INFO] Disabling plugins
15:49:37 [INFO] Closing IO threads
15:49:39 [INFO] Thank you and goodbye
15:49:39 [INFO] Thank you and goodbye
```