### PR TITLE
Fix EventBus logger (it don't use the BungeeLogger!)

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
@@ -138,7 +138,7 @@ public class BungeeCord extends ProxyServer
      * Plugin manager.
      */
     @Getter
-    public final PluginManager pluginManager = new PluginManager( this );
+    public final PluginManager pluginManager;
     @Getter
     @Setter
     private ReconnectHandler reconnectHandler;
@@ -170,12 +170,6 @@ public class BungeeCord extends ProxyServer
     
     {
         // TODO: Proper fallback when we interface the manager
-        getPluginManager().registerCommand( null, new CommandReload() );
-        getPluginManager().registerCommand( null, new CommandEnd() );
-        getPluginManager().registerCommand( null, new CommandIP() );
-        getPluginManager().registerCommand( null, new CommandBungee() );
-        getPluginManager().registerCommand( null, new CommandPerms() );
-
         registerChannel( "BungeeCord" );
     }
 
@@ -219,6 +213,13 @@ public class BungeeCord extends ProxyServer
         logger = new BungeeLogger( "BungeeCord", "proxy.log", consoleReader );
         System.setErr( new PrintStream( new LoggingOutputStream( logger, Level.SEVERE ), true ) );
         System.setOut( new PrintStream( new LoggingOutputStream( logger, Level.INFO ), true ) );
+
+        pluginManager = new PluginManager( this );
+        getPluginManager().registerCommand( null, new CommandReload() );
+        getPluginManager().registerCommand( null, new CommandEnd() );
+        getPluginManager().registerCommand( null, new CommandIP() );
+        getPluginManager().registerCommand( null, new CommandBungee() );
+        getPluginManager().registerCommand( null, new CommandPerms() );
 
         if ( !Boolean.getBoolean( "net.md_5.bungee.native.disable" ) )
         {


### PR DESCRIPTION
Currently, the `PluginManager` is instantiated before the `Logger` (in [BungeeCord.java](https://github.com/SpigotMC/BungeeCord/blob/master/proxy/src/main/java/net/md_5/bungee/BungeeCord.java#L141)).
So when `PluginManager` is instantiated, it call the `BungeeCord#getLogger()` ([PluginManager.java#L69](https://github.com/SpigotMC/BungeeCord/blob/master/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java#L69)) method to instantiate the `EventBus`. But because the logger is not instantiated, the method returns `null`.
So the `EventBus` ask for a global j.u.l.Logger instead ([EventBus.java#L33](https://github.com/SpigotMC/BungeeCord/blob/master/event/src/main/java/net/md_5/bungee/event/EventBus.java#L33)).

This fix simply moves the instantiation of the `PluginManager` after the instantiation of the `BungeeLogger` (this also involves moving calls to `getPluginManager().registerCommand`).