### PR TITLE
Fix Direction in a BadPacketException message

### DIFF
--- a/protocol/src/main/java/net/md_5/bungee/protocol/MinecraftDecoder.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/MinecraftDecoder.java
@@ -34,7 +34,7 @@ public class MinecraftDecoder extends MessageToMessageDecoder<ByteBuf>
 
                 if ( in.isReadable() )
                 {
-                    throw new BadPacketException( "Did not read all bytes from packet " + packet.getClass() + " " + packetId + " Protocol " + protocol + " Direction " + prot );
+                    throw new BadPacketException( "Did not read all bytes from packet " + packet.getClass() + " " + packetId + " Protocol " + protocol + " Direction " + prot.getDirection() );
                 }
             } else
             {


### PR DESCRIPTION
Fix the "Direction" in a BadPacketException message.

Before:
`bad packet ID, are mods in use!? Did not read all bytes from packet class net.md_5.bungee.protocol.packet.Chat 15 Protocol GAME Direction net.md_5.bungee.protocol.Protocol$DirectionData@108af7e0`

After:
`bad packet ID, are mods in use!? Did not read all bytes from packet class net.md_5.bungee.protocol.packet.Chat 15 Protocol GAME Direction TO_CLIENT`