### PR TITLE
Don't decode unnecessarily the Chat packets (those sent to the client)

### DIFF
--- a/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java
@@ -70,12 +70,6 @@ public enum Protocol
                     map( ProtocolConstants.MINECRAFT_1_12, 0x23 )
             );
             TO_CLIENT.registerPacket(
-                    Chat.class,
-                    map( ProtocolConstants.MINECRAFT_1_8, 0x02 ),
-                    map( ProtocolConstants.MINECRAFT_1_9, 0x0F ),
-                    map( ProtocolConstants.MINECRAFT_1_12, 0x0F )
-            );
-            TO_CLIENT.registerPacket(
                     Respawn.class,
                     map( ProtocolConstants.MINECRAFT_1_8, 0x07 ),
                     map( ProtocolConstants.MINECRAFT_1_9, 0x33 ),


### PR DESCRIPTION
Chat packets sent to the clients are decoded unnecessarily (because there are never handled).
The commit just removes them from the TO_CLIENT direction.