### PR TITLE
TranslatableComponent: Allow objects in `with` to be translated into a string

### DIFF
--- a/chat/src/main/java/net/md_5/bungee/api/chat/TranslatableComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/TranslatableComponent.java
@@ -71,12 +71,12 @@ public final class TranslatableComponent extends BaseComponent
             List<BaseComponent> temp = new ArrayList<BaseComponent>();
             for ( Object w : with )
             {
-                if ( w instanceof String )
-                {
-                    temp.add( new TextComponent( (String) w ) );
-                } else
+                if ( w instanceof BaseComponent )
                 {
                     temp.add( (BaseComponent) w );
+                } else
+                {
+                    temp.add( new TextComponent( String.valueOf(w) ) );
                 }
             }
             setWith( temp );

--- a/chat/src/test/java/net/md_5/bungee/api/chat/TranslatableComponentTest.java
+++ b/chat/src/test/java/net/md_5/bungee/api/chat/TranslatableComponentTest.java
@@ -9,7 +9,7 @@ public class TranslatableComponentTest
     @Test
     public void testMissingPlaceholdersAdded()
     {
-        TranslatableComponent testComponent = new TranslatableComponent( "Test string with %s placeholders: %s", "2", "aoeu" );
+        TranslatableComponent testComponent = new TranslatableComponent( "Test string with %s placeholders: %s", 2, "aoeu" );
         assertEquals( "Test string with 2 placeholders: aoeu", testComponent.toPlainText() );
         assertEquals( "§fTest string with §f2§f placeholders: §faoeu", testComponent.toLegacyText() );
     }


### PR DESCRIPTION
This should allow for integer, float, etc. to be added to "with" parameter.  This should allow `int` or any primitive variables to be cast into string without raising any exception.

In addition, I modified the test to test such case.
