### PR TITLE
Fix NPE caused by a strange build behavior

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/util/ChatComponentTransformer.java
+++ b/proxy/src/main/java/net/md_5/bungee/util/ChatComponentTransformer.java
@@ -51,7 +51,7 @@ public final class ChatComponentTransformer
      */
     public BaseComponent[] transform(ProxiedPlayer player, BaseComponent... component)
     {
-        if ( component == null || component.length < 1 || component[0] == null  )
+        if ( component == null || component.length < 1 || ( component.length == 1 && component[0] == null )  )
         {
             return new BaseComponent[]
             {

--- a/proxy/src/main/java/net/md_5/bungee/util/ChatComponentTransformer.java
+++ b/proxy/src/main/java/net/md_5/bungee/util/ChatComponentTransformer.java
@@ -51,7 +51,7 @@ public final class ChatComponentTransformer
      */
     public BaseComponent[] transform(ProxiedPlayer player, BaseComponent... component)
     {
-        if ( component == null || component.length < 1 )
+        if ( component == null || component[0] == null || component.length < 1 )
         {
             return new BaseComponent[]
             {

--- a/proxy/src/main/java/net/md_5/bungee/util/ChatComponentTransformer.java
+++ b/proxy/src/main/java/net/md_5/bungee/util/ChatComponentTransformer.java
@@ -51,7 +51,7 @@ public final class ChatComponentTransformer
      */
     public BaseComponent[] transform(ProxiedPlayer player, BaseComponent... component)
     {
-        if ( component == null || component[0] == null || component.length < 1 )
+        if ( component == null || component.length < 1 || component[0] == null  )
         {
             return new BaseComponent[]
             {


### PR DESCRIPTION
How to reproduce the problem ?
Call the method **player.resetTabHeader()** or **player.setTabHeader(null, null)**

What happens ?
After some investigation i found that this part of code is compiled a little different. I don't know why, if an expert knows what is happening please let me know.

The real code
![code](https://user-images.githubusercontent.com/11512792/42466129-6f22a72a-8384-11e8-8f35-569b09c5d19f.png)

Decompiled code
![descompiled](https://user-images.githubusercontent.com/11512792/42466608-c2dde89c-8385-11e8-8b3a-8571c5a63efc.png)


As you can see, instead of passing a null value to **transform** method, is passing an array with a null entry and that is not predicted by the method.


The described NPE
![error](https://user-images.githubusercontent.com/11512792/42465941-dab43270-8383-11e8-929f-4f230f2ebf44.png)


Thanks,
Lucas Dallabona