### PR TITLE
Fix class name to match with Lombok class name

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/ServerConnectRequest.java
+++ b/api/src/main/java/net/md_5/bungee/api/ServerConnectRequest.java
@@ -59,20 +59,11 @@ public class ServerConnectRequest
     /**
      * Timeout in milliseconds for request.
      */
-    private final int connectTimeout;
+    @lombok.Builder.Default
+    private final int connectTimeout = 5000; // TODO: Configurable
     /**
      * Should the player be attempted to connect to the next server in their
      * queue if the initial request fails.
      */
     private final boolean retry;
-
-    /**
-     * Class that sets default properties/adds methods to the lombok builder
-     * generated class.
-     */
-    public static class ServerConnectRequestBuilder
-    {
-
-        private int connectTimeout = 5000; // TODO: Configurable
-    }
 }

--- a/api/src/main/java/net/md_5/bungee/api/ServerConnectRequest.java
+++ b/api/src/main/java/net/md_5/bungee/api/ServerConnectRequest.java
@@ -59,11 +59,20 @@ public class ServerConnectRequest
     /**
      * Timeout in milliseconds for request.
      */
-    @lombok.Builder.Default
-    private final int connectTimeout = 5000; // TODO: Configurable
+    private final int connectTimeout;
     /**
      * Should the player be attempted to connect to the next server in their
      * queue if the initial request fails.
      */
     private final boolean retry;
+
+    /**
+     * Class that sets default properties/adds methods to the lombok builder
+     * generated class.
+     */
+    public static class Builder
+    {
+
+        private int connectTimeout = 5000; // TODO: Configurable
+    }
 }

--- a/api/src/test/java/net/md_5/bungee/api/ServerConnectRequestTest.java
+++ b/api/src/test/java/net/md_5/bungee/api/ServerConnectRequestTest.java
@@ -1,0 +1,81 @@
+package net.md_5.bungee.api;
+
+import java.net.InetSocketAddress;
+import java.util.Collection;
+import net.md_5.bungee.api.config.ServerInfo;
+import net.md_5.bungee.api.connection.ProxiedPlayer;
+import net.md_5.bungee.api.event.ServerConnectEvent;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ServerConnectRequestTest
+{
+
+    private static final ServerInfo DUMMY_INFO = new ServerInfo()
+    {
+        @Override
+        public String getName()
+        {
+            return null;
+        }
+
+        @Override
+        public InetSocketAddress getAddress()
+        {
+            return null;
+        }
+
+        @Override
+        public Collection<ProxiedPlayer> getPlayers()
+        {
+            return null;
+        }
+
+        @Override
+        public String getMotd()
+        {
+            return null;
+        }
+
+        @Override
+        public boolean canAccess(CommandSender sender)
+        {
+            return false;
+        }
+
+        @Override
+        public void sendData(String channel, byte[] data)
+        {
+        }
+
+        @Override
+        public boolean sendData(String channel, byte[] data, boolean queue)
+        {
+            return false;
+        }
+
+        @Override
+        public void ping(Callback<ServerPing> callback)
+        {
+        }
+    };
+
+    @Test
+    public void testDefaultConnectTimeout()
+    {
+        ServerConnectRequest request = ServerConnectRequest.builder().target( DUMMY_INFO ).reason( ServerConnectEvent.Reason.JOIN_PROXY ).build();
+        Assert.assertEquals( request.getConnectTimeout(), 5000 );
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testNullTarget()
+    {
+        ServerConnectRequest.builder().target( null ).reason( ServerConnectEvent.Reason.JOIN_PROXY ).build();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testNullReason()
+    {
+        ServerConnectRequest.builder().target( DUMMY_INFO ).reason( null ).build();
+    }
+}


### PR DESCRIPTION
During commit https://github.com/SpigotMC/BungeeCord/pull/2447/commits/84a820d04f3fe40a203678d139c13077211fd06c I never changed the manually written inner class name to sync in with the lombok "Builder" class name compile at https://github.com/SpigotMC/BungeeCord/blob/715ec07a289c74bb7639194048b4e3fd2b50f0ad/api/src/main/java/net/md_5/bungee/api/ServerConnectRequest.java#L73 which didn't immediately show up in the testing I did.

This PR uses the recommended Lombok method introduced in 1.16.6 by using an annotation and would appear to be more reliable of compiling as intended. Decompiling produces the expected behaviour.

Previously the connect timeout initial value would always have been 0.