### PR TITLE
Add ServerConnectRequest accessor in ServerConnectEvent.

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/ServerConnectRequest.java
+++ b/api/src/main/java/net/md_5/bungee/api/ServerConnectRequest.java
@@ -3,6 +3,7 @@ package net.md_5.bungee.api;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NonNull;
+import lombok.Setter;
 import net.md_5.bungee.api.config.ServerInfo;
 import net.md_5.bungee.api.event.ServerConnectEvent;
 
@@ -59,12 +60,14 @@ public class ServerConnectRequest
     /**
      * Timeout in milliseconds for request.
      */
-    private final int connectTimeout;
+    @Setter
+    private int connectTimeout;
     /**
      * Should the player be attempted to connect to the next server in their
      * queue if the initial request fails.
      */
-    private final boolean retry;
+    @Setter
+    private boolean retry;
 
     /**
      * Class that sets default properties/adds methods to the lombok builder

--- a/api/src/main/java/net/md_5/bungee/api/event/ServerConnectEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/ServerConnectEvent.java
@@ -4,6 +4,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.ToString;
+import net.md_5.bungee.api.ServerConnectRequest;
 import net.md_5.bungee.api.config.ServerInfo;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.plugin.Cancellable;
@@ -31,10 +32,17 @@ public class ServerConnectEvent extends Event implements Cancellable
     @NonNull
     private ServerInfo target;
     /**
+     * Reason for connecting to a new server.
+     */
+    private final Reason reason;
+    /**
+     * Request used to connect to given server.
+     */
+    private final ServerConnectRequest request;
+    /**
      * Cancelled state.
      */
     private boolean cancelled;
-    private final Reason reason;
 
     @Deprecated
     public ServerConnectEvent(ProxiedPlayer player, ServerInfo target)
@@ -42,11 +50,18 @@ public class ServerConnectEvent extends Event implements Cancellable
         this( player, target, Reason.UNKNOWN );
     }
 
+    @Deprecated
     public ServerConnectEvent(ProxiedPlayer player, ServerInfo target, Reason reason)
+    {
+        this( player, target, reason, null );
+    }
+
+    public ServerConnectEvent(ProxiedPlayer player, ServerInfo target, Reason reason, ServerConnectRequest request)
     {
         this.player = player;
         this.target = target;
         this.reason = reason;
+        this.request = request;
     }
 
     public enum Reason

--- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
@@ -277,7 +277,7 @@ public final class UserConnection implements ProxiedPlayer
         Preconditions.checkNotNull( request, "request" );
 
         final Callback<ServerConnectRequest.Result> callback = request.getCallback();
-        ServerConnectEvent event = new ServerConnectEvent( this, request.getTarget(), request.getReason() );
+        ServerConnectEvent event = new ServerConnectEvent( this, request.getTarget(), request.getReason(), request );
         if ( bungee.getPluginManager().callEvent( event ).isCancelled() )
         {
             if ( callback != null )


### PR DESCRIPTION
- Adds a getter to the ServerConnectRequest that was used in the ServerConnectEvent.
- Make the timeout and retry status mutable so plugins can modify these values directly within the ServerConnectEvent.
- Added missed javadoc parameter from a past commit.

Example use case:
```
    @EventHandler
    public void onConnect(ServerConnectEvent event) {
        if (event.getReason() == ServerConnectEvent.Reason.COMMAND) {
            event.getRequest().setConnectTimeout(500);
        } else if (event.getReason() == ServerConnectEvent.Reason.SERVER_DOWN_REDIRECT) {
            event.getRequest().setConnectTimeout(8000);
        }
```