### PR TITLE
Fix compilation error caused by recent pull request.

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/ServerConnectRequest.java
+++ b/api/src/main/java/net/md_5/bungee/api/ServerConnectRequest.java
@@ -1,6 +1,7 @@
 package net.md_5.bungee.api;
 
 import lombok.Builder;
+import lombok.Builder.Default;
 import lombok.Getter;
 import lombok.NonNull;
 import net.md_5.bungee.api.config.ServerInfo;
@@ -59,7 +60,7 @@ public class ServerConnectRequest
     /**
      * Timeout in milliseconds for request.
      */
-    @Builder.Default
+    @Default
     private final int connectTimeout = 5000; // TODO: Configurable
     /**
      * Should the player be attempted to connect to the next server in their


### PR DESCRIPTION
`builderClassName = "Builder"` causes a name collision with annotation `Builder` and a compilation error.
```
[ERROR] /var/lib/jenkins/jobs/BungeeCord/workspace/api/src/main/java/net/md_5/bungee/api/ServerConnectRequest.java:[62,13] cannot find symbol
  symbol:   class Default
  location: class net.md_5.bungee.api.ServerConnectRequest.Builder
[INFO] 1 error
```

There are two ways to fix this issue:
1. Use another name of builder (or get rid of this and use the default one)
2. Import `lombok.Builder.Default` and use `@Default` instead of `@Builder.Default`

I have used the second option.