### PR TITLE
Upgrade lombok to 1.18.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.16.16</version>
+            <version>1.18.0</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
This allows BungeeCord to be built on Java 10.

Support for Java 9 was added in 1.16.18, support for Java 10 was added in 1.18.0. BungeeCord is currently running 1.16.16. Running without upgrading causes the following error on newer versions of Java:
```
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 5.126 s
[INFO] Finished at: 2018-08-11T20:46:41+02:00
[INFO] Final Memory: 16M/60M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.1:compile (default-compile) on project bungeecord-chat: Fatal error compiling: java.lang.ExceptionInInitializerError: com.sun.tools.javac.code.TypeTags -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
```