### PR TITLE
Fix ConcurrentModificationException when tasks are cancelled during shutdown

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/scheduler/BungeeScheduler.java
+++ b/proxy/src/main/java/net/md_5/bungee/scheduler/BungeeScheduler.java
@@ -62,9 +62,12 @@ public class BungeeScheduler implements TaskScheduler
     public int cancel(Plugin plugin)
     {
         Set<ScheduledTask> toRemove = new HashSet<>();
-        for ( ScheduledTask task : tasksByPlugin.get( plugin ) )
+        synchronized ( lock )
         {
-            toRemove.add( task );
+            for ( ScheduledTask task : tasksByPlugin.get( plugin ) )
+            {
+                toRemove.add( task );
+            }
         }
         for ( ScheduledTask task : toRemove )
         {


### PR DESCRIPTION
When BungeeCord cancels plugins during shutdown, it cancels all scheduled tasks. Now, if a task ends right during that, there will be an ConcurrentModificationException. This fixes it by synchronizing the iteration over all existing tasks, which is also encouraged when using a synchronized Set.