### PR TITLE
Only synchronize on the packetQueue when actually using it

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/BungeeServerInfo.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeServerInfo.java
@@ -101,19 +101,19 @@ public class BungeeServerInfo implements ServerInfo
         Preconditions.checkNotNull( channel, "channel" );
         Preconditions.checkNotNull( data, "data" );
 
-        synchronized ( packetQueue )
+        Server server = ( players.isEmpty() ) ? null : players.iterator().next().getServer();
+        if ( server != null )
         {
-            Server server = ( players.isEmpty() ) ? null : players.iterator().next().getServer();
-            if ( server != null )
-            {
-                server.sendData( channel, data );
-                return true;
-            } else if ( queue )
+            server.sendData( channel, data );
+            return true;
+        } else if ( queue )
+        {
+            synchronized ( packetQueue )
             {
                 packetQueue.add( new PluginMessage( channel, data, false ) );
             }
-            return false;
         }
+        return false;
     }
 
     @Override


### PR DESCRIPTION
Since packets can be sent asynchronously, we shouldn't bother
synchronizing where we don't need to

Especially true when queue is false.