### PR TITLE
Add Brigadier Support in TabCompleteEvent and TabCompleteResponseEvent

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -44,4 +44,17 @@
             <scope>compile</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/api/src/main/java/net/md_5/bungee/api/event/TabCompleteEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/TabCompleteEvent.java
@@ -1,6 +1,11 @@
 package net.md_5.bungee.api.event;
 
+import java.util.ArrayList;
 import java.util.List;
+
+import com.mojang.brigadier.context.StringRange;
+import com.mojang.brigadier.suggestion.Suggestion;
+import com.mojang.brigadier.suggestion.Suggestions;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -20,20 +25,56 @@ public class TabCompleteEvent extends TargetedEvent implements Cancellable
      * Cancelled state.
      */
     private boolean cancelled;
+
     /**
      * The message the player has already entered.
      */
     private final String cursor;
+
     /**
-     * The suggestions that will be sent to the client. This list is mutable. If
-     * this list is empty, the request will be forwarded to the server.
+     * Whether force brigadier has been enabled in the BungeeCord config.
+     */
+    private final boolean brigadier;
+
+    /**
+     *  Suggestions provided by minecrafts brigadier.
+     *  Note: this variable is not named suggestions caused by the method getSuggestions()
+     */
+    private final Suggestions brigadierSuggestions;
+
+    /**
+     * List of affected commands from the tab completion.
+     * If brigadier is present this value will be null.
      */
     private final List<String> suggestions;
 
-    public TabCompleteEvent(Connection sender, Connection receiver, String cursor, List<String> suggestions)
+    /**
+     * Returns a list of suggestions.
+     * @return list of suggestions
+     */
+    public List<String> getSuggestions() {
+        if (!brigadier) return this.suggestions;
+        List<String> list = new ArrayList<>(brigadierSuggestions.getList().size());
+        for (Suggestion suggestion : brigadierSuggestions.getList()) {
+            list.add(suggestion.getText());
+        }
+        return list;
+    }
+
+    public TabCompleteEvent(Connection sender, Connection receiver,
+                            String cursor, List<String> suggestions, boolean brigadier)
     {
         super( sender, receiver );
         this.cursor = cursor;
         this.suggestions = suggestions;
+        this.brigadierSuggestions = new Suggestions(
+                StringRange.between(cursor.lastIndexOf( ' ' ) + 1, cursor.length() ),
+                new ArrayList<Suggestion>());
+        if(brigadier) {
+            for(String suggestion : suggestions) {
+                this.brigadierSuggestions.getList().add(new Suggestion(this.brigadierSuggestions.getRange(), suggestion));
+            }
+        }
+        this.brigadier = brigadier;
     }
 }

--- a/api/src/main/java/net/md_5/bungee/api/event/TabCompleteResponseEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/TabCompleteResponseEvent.java
@@ -31,37 +31,39 @@ public class TabCompleteResponseEvent extends TargetedEvent implements Cancellab
     private boolean cancelled;
 
     /**
-     * List of affected commands from the tab completion.
+     * If brigadier support is enabled.
      */
-    private final List<String> commands;
+    private final boolean brigadier;
+
+    /**
+     * List of affected commands from the tab completion.
+     * If brigadier is present this value will be null.
+     */
+    private final List<String> suggestions;
 
     /**
      *  Suggestions provided by minecrafts brigadier.
-     *  Note: this variable is not named suggestions caused by the deprecated method getSuggestions()
+     *  Note: this variable is not named suggestions caused by the method getSuggestions()
      */
     private final Suggestions brigadierSuggestions;
 
     /**
-     * List of suggestions sent back to the player.
-     * If this list is empty, an empty list is sent back to the client.
-     * Changes at this list don't affect the suggested list.
-     *
-     * @return list from suggestions
-     * @deprecated
+     * Returns a list of suggestions. The list is mutable for versions < Minecraft 1.13 or if brigadier support is disabled
+     * @return list of suggestions
      */
-    @Deprecated
     public List<String> getSuggestions() {
-        if(commands != null) return commands;
-        List<String> list = new ArrayList<>();
-        for (Suggestion suggestion : brigadierSuggestions.getList()) {
+        if(!brigadier) return suggestions;
+        List<String> list = new ArrayList<>(brigadierSuggestions.getList().size());
+        for(Suggestion suggestion : brigadierSuggestions.getList())
             list.add(suggestion.getText());
-        }
         return list;
     }
 
-    public TabCompleteResponseEvent(Connection sender, Connection receiver, List<String> commands, Suggestions suggestions) {
+    public TabCompleteResponseEvent(Connection sender, Connection receiver,
+                                    List<String> commands, Suggestions suggestions, boolean brigadier) {
         super( sender, receiver );
-        this.commands = commands;
+        this.suggestions = commands;
         this.brigadierSuggestions = suggestions;
+        this.brigadier = brigadier;
     }
 }

--- a/api/src/main/java/net/md_5/bungee/api/event/TabCompleteResponseEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/TabCompleteResponseEvent.java
@@ -51,6 +51,7 @@ public class TabCompleteResponseEvent extends TargetedEvent implements Cancellab
      */
     @Deprecated
     public List<String> getSuggestions() {
+        if(commands != null) return commands;
         List<String> list = new ArrayList<>();
         for (Suggestion suggestion : brigadierSuggestions.getList()) {
             list.add(suggestion.getText());

--- a/api/src/main/java/net/md_5/bungee/api/event/TabCompleteResponseEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/TabCompleteResponseEvent.java
@@ -1,11 +1,17 @@
 package net.md_5.bungee.api.event;
 
+import com.mojang.brigadier.suggestion.Suggestion;
+import com.mojang.brigadier.suggestion.Suggestions;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import net.md_5.bungee.api.connection.Connection;
 import net.md_5.bungee.api.plugin.Cancellable;
+
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Event called when a backend server sends a response to a player asking to
@@ -25,14 +31,36 @@ public class TabCompleteResponseEvent extends TargetedEvent implements Cancellab
     private boolean cancelled;
 
     /**
-     * Mutable list of suggestions sent back to the player. If this list is
-     * empty, an empty list is sent back to the client.
+     * List of affected commands from the tab completion.
      */
-    private final List<String> suggestions;
+    private final List<String> commands;
 
-    public TabCompleteResponseEvent(Connection sender, Connection receiver, List<String> suggestions)
-    {
+    /**
+     *  Suggestions provided by minecrafts brigadier.
+     *  Note: this variable is not named suggestions caused by the deprecated method getSuggestions()
+     */
+    private final Suggestions brigadierSuggestions;
+
+    /**
+     * List of suggestions sent back to the player.
+     * If this list is empty, an empty list is sent back to the client.
+     * Changes at this list don't affect the suggested list.
+     *
+     * @return list from suggestions
+     * @deprecated
+     */
+    @Deprecated
+    public List<String> getSuggestions() {
+        List<String> list = new ArrayList<>();
+        for (Suggestion suggestion : brigadierSuggestions.getList()) {
+            list.add(suggestion.getText());
+        }
+        return list;
+    }
+
+    public TabCompleteResponseEvent(Connection sender, Connection receiver, List<String> commands, Suggestions suggestions) {
         super( sender, receiver );
-        this.suggestions = suggestions;
+        this.commands = commands;
+        this.brigadierSuggestions = suggestions;
     }
 }

--- a/api/src/main/java/net/md_5/bungee/util/SuggestionList.java
+++ b/api/src/main/java/net/md_5/bungee/util/SuggestionList.java
@@ -1,0 +1,309 @@
+package net.md_5.bungee.util;
+
+import com.mojang.brigadier.suggestion.Suggestion;
+import com.mojang.brigadier.suggestion.Suggestions;
+
+import java.util.*;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+public class SuggestionList implements List<String> {
+    private Suggestions suggestions;
+    public SuggestionList(Suggestions suggestions) {
+        Objects.requireNonNull(suggestions);
+        this.suggestions = suggestions;
+    }
+
+    private Suggestions getSuggestions() {
+        return this.suggestions;
+    }
+
+    @Override
+    public int size() {
+        return suggestions.getList().size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return suggestions.getList().isEmpty();
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        return indexOf(o) >= 0;
+    }
+
+    @Override
+    public Iterator<String> iterator() {
+        return new SuggestionListIterator(0);
+    }
+
+    @Override
+    public Object[] toArray() {
+        String[] obj = new String[size()];
+        for(int i = 0; i < size(); i++) {
+            obj[i] = suggestions.getList().get(i).getText();
+        }
+        return obj;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T[] toArray(T[] a) {
+        return (T[])toArray();
+    }
+
+    @Override
+    public boolean add(String s) {
+        Objects.requireNonNull(s);
+        return suggestions.getList().add(new Suggestion(suggestions.getRange(), s));
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        if(o instanceof Suggestion) {
+            return suggestions.getList().remove(o);
+        } else if(o instanceof String) {
+            for (Suggestion suggestion : suggestions.getList()) {
+                if(suggestion.getText().equals(o)) {
+                    return suggestions.getList().remove(suggestion);
+                }
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean containsAll(Collection<?> coll) {
+        Objects.requireNonNull(coll);
+        for (Suggestion suggestion : suggestions.getList()) {
+            for(Object c : coll) {
+                if(!contains(c)) return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends String> c) {
+        Objects.requireNonNull(c);
+        for(String string : c) {
+            if(!add(string)) return false;
+        }
+        return true;
+    }
+
+    @Override
+    public boolean addAll(int index, Collection<? extends String> c) {
+        Objects.requireNonNull(c);
+        return addAll(c);
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> c) {
+        Objects.requireNonNull(c);
+        for(Object o : c) {
+            if(!remove(o)) return false;
+        }
+        return true;
+    }
+
+    @Override
+    public boolean retainAll(Collection<?> c) {
+        Objects.requireNonNull(c);
+        for(Object o : c) {
+            if(!contains(o)) remove(o);
+        }
+        return true;
+    }
+
+    @Override
+    public boolean removeIf(Predicate<? super String> filter) {
+        Objects.requireNonNull(filter);
+        for (Suggestion suggestion : suggestions.getList()) {
+            if(filter.test(suggestion.getText()))
+                suggestions.getList().remove(suggestion);
+        }
+        return false;
+    }
+
+    @Override
+    public void sort(Comparator<? super String> c) {
+        // Do nothing. There is no need to sort the Suggestion list. The client will sort the list for his own.
+    }
+
+    @Override
+    public void clear() {
+        suggestions.getList().clear();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if(o instanceof SuggestionList) {
+            return suggestions.equals(((SuggestionList) o).getSuggestions());
+        } else if(o instanceof Suggestions) {
+            return suggestions.equals(o);
+        }
+        return false;
+    }
+
+    @Override
+    public String get(int index) {
+        return suggestions.getList().get(index).getText();
+    }
+
+    @Override
+    public String set(int index, String element) {
+        Objects.requireNonNull(element);
+        Suggestion suggestion = suggestions.getList().get(index);
+        suggestions.getList().set(index, new Suggestion(suggestion.getRange(), element));
+        return element;
+    }
+
+    @Override
+    public void add(int index, String element) {
+        add(element);
+    }
+
+    @Override
+    public String remove(int index) {
+        Suggestion suggestion = suggestions.getList().get(index);
+        suggestions.getList().remove(suggestion);
+        return suggestion.getText();
+    }
+
+    @Override
+    public int indexOf(Object o) {
+        if (o == null) {
+            return -1;
+        }
+        for(int i = 0; i < size(); i++) {
+            if (o.equals(suggestions.getList().get(i)))
+                return i;
+        }
+        return -1;
+    }
+
+    @Override
+    public int lastIndexOf(Object o) {
+        if (o == null)
+            return -1;
+        for(int i = size()-1; i >= 0; i--) {
+            if (o.equals(suggestions.getList().get(i)))
+                return i;
+        }
+        return -1;
+    }
+
+    @Override
+    public ListIterator<String> listIterator() {
+        return listIterator(0);
+    }
+
+    @Override
+    public ListIterator<String> listIterator(int index) {
+        return new SuggestionListIterator(index);
+    }
+
+    @Override
+    public List<String> subList(int fromIndex, int toIndex) {
+        if (fromIndex < 0)
+            throw new IndexOutOfBoundsException("fromIndex = " + fromIndex);
+        if (toIndex > size())
+            throw new IndexOutOfBoundsException("toIndex = " + toIndex);
+        if (fromIndex > toIndex)
+            throw new IllegalArgumentException("fromIndex(" + fromIndex +
+                    ") > toIndex(" + toIndex + ")");
+        List<String> list = new ArrayList<>(size());
+        for(Suggestion suggestion : suggestions.getList())
+            list.add(suggestion.getText());
+        return list;
+    }
+
+    @Override
+    public void forEach(Consumer<? super String> action) {
+        Objects.requireNonNull(action);
+        for (Suggestion suggestion : suggestions.getList()) {
+            action.accept(suggestion.getText());
+        }
+    }
+
+    @Override
+    public Spliterator<String> spliterator() {
+        ArrayList<String> list = new ArrayList<>();
+        for (Suggestion suggestion : suggestions.getList())
+            list.add(suggestion.getText());
+        return list.spliterator();
+    }
+
+    @Override
+    public Stream<String> stream() {
+        return suggestions.getList().stream().map(Suggestion::getText);
+    }
+
+    @Override
+    public Stream<String> parallelStream() {
+        return suggestions.getList().parallelStream().map(Suggestion::getText);
+    }
+
+    final class SuggestionListIterator implements ListIterator<String> {
+        int currIndex;
+
+        SuggestionListIterator(int index) {
+            this.currIndex = index;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return size() > currIndex;
+        }
+
+        @Override
+        public String next() {
+            currIndex++;
+            return get(currIndex);
+        }
+
+        @Override
+        public boolean hasPrevious() {
+            return currIndex < 0;
+        }
+
+        @Override
+        public String previous() {
+            currIndex--;
+            return get(currIndex);
+        }
+
+        @Override
+        public int nextIndex() {
+            return currIndex + 1;
+        }
+
+        @Override
+        public int previousIndex() {
+            return currIndex - 1;
+        }
+
+        @Override
+        public void remove() {
+            suggestions.getList().remove(currIndex);
+        }
+
+        @Override
+        public void forEachRemaining(Consumer<? super String> action) {
+
+        }
+
+        @Override
+        public void set(String s) {
+            SuggestionList.this.set(currIndex, s);
+        }
+
+        @Override
+        public void add(String s) {
+            SuggestionList.this.add(currIndex, s);
+        }
+    }
+}

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/TabCompleteResponse.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/TabCompleteResponse.java
@@ -6,6 +6,8 @@ import com.mojang.brigadier.suggestion.Suggestion;
 import com.mojang.brigadier.suggestion.Suggestions;
 import net.md_5.bungee.protocol.DefinedPacket;
 import io.netty.buffer.ByteBuf;
+
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import lombok.Data;
@@ -56,12 +58,14 @@ public class TabCompleteResponse extends DefinedPacket
 
             int cnt = readVarInt( buf );
             List<Suggestion> matches = new LinkedList<>();
+            commands = new ArrayList<>(cnt);
             for ( int i = 0; i < cnt; i++ )
             {
                 String match = readString( buf );
                 String tooltip = buf.readBoolean() ? readString( buf ) : null;
 
                 matches.add( new Suggestion( range, match, new LiteralMessage( tooltip ) ) );
+                commands.add(match);
             }
 
             suggestions = new Suggestions( range, matches );

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/TabCompleteResponse.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/TabCompleteResponse.java
@@ -36,6 +36,14 @@ public class TabCompleteResponse extends DefinedPacket
         this.commands = commands;
     }
 
+    public List<String> getCommands() {
+        return commands;
+    }
+
+    public Suggestions getSuggestions() {
+        return suggestions;
+    }
+
     @Override
     public void read(ByteBuf buf, ProtocolConstants.Direction direction, int protocolVersion)
     {
@@ -78,8 +86,8 @@ public class TabCompleteResponse extends DefinedPacket
             for ( Suggestion suggestion : suggestions.getList() )
             {
                 writeString( suggestion.getText(), buf );
-                buf.writeBoolean( suggestion.getTooltip() != null );
-                if ( suggestion.getTooltip() != null )
+                buf.writeBoolean( suggestion.getTooltip() != null && suggestion.getTooltip().getString() != null);
+                if ( suggestion.getTooltip() != null && suggestion.getTooltip().getString() != null)
                 {
                     writeString( suggestion.getTooltip().getString(), buf );
                 }

--- a/proxy/src/main/java/net/md_5/bungee/conf/Configuration.java
+++ b/proxy/src/main/java/net/md_5/bungee/conf/Configuration.java
@@ -62,6 +62,7 @@ public class Configuration implements ProxyConfig
     private boolean preventProxyConnections;
     private boolean forgeSupport;
     private boolean injectCommands;
+    private boolean brigadierSuggestions;
 
     public void load()
     {
@@ -94,6 +95,7 @@ public class Configuration implements ProxyConfig
         preventProxyConnections = adapter.getBoolean( "prevent_proxy_connections", preventProxyConnections );
         forgeSupport = adapter.getBoolean( "forge_support", forgeSupport );
         injectCommands = adapter.getBoolean( "inject_commands", injectCommands );
+        brigadierSuggestions = adapter.getBoolean("brigadier_suggestions", brigadierSuggestions);
         if ( injectCommands )
         {
             System.setProperty( "net.md-5.bungee.protocol.register_commands", "true" );

--- a/proxy/src/main/java/net/md_5/bungee/conf/Configuration.java
+++ b/proxy/src/main/java/net/md_5/bungee/conf/Configuration.java
@@ -63,6 +63,7 @@ public class Configuration implements ProxyConfig
     private boolean forgeSupport;
     private boolean injectCommands;
     private boolean brigadierSuggestions;
+    private boolean brigadierResponse;
 
     public void load()
     {
@@ -96,6 +97,7 @@ public class Configuration implements ProxyConfig
         forgeSupport = adapter.getBoolean( "forge_support", forgeSupport );
         injectCommands = adapter.getBoolean( "inject_commands", injectCommands );
         brigadierSuggestions = adapter.getBoolean("brigadier_suggestions", brigadierSuggestions);
+        brigadierSuggestions = adapter.getBoolean("brigadier_response", brigadierSuggestions);
         if ( injectCommands )
         {
             System.setProperty( "net.md-5.bungee.protocol.register_commands", "true" );

--- a/proxy/src/main/java/net/md_5/bungee/conf/Configuration.java
+++ b/proxy/src/main/java/net/md_5/bungee/conf/Configuration.java
@@ -62,8 +62,6 @@ public class Configuration implements ProxyConfig
     private boolean preventProxyConnections;
     private boolean forgeSupport;
     private boolean injectCommands;
-    private boolean brigadierSuggestions;
-    private boolean brigadierResponse;
 
     public void load()
     {
@@ -96,8 +94,6 @@ public class Configuration implements ProxyConfig
         preventProxyConnections = adapter.getBoolean( "prevent_proxy_connections", preventProxyConnections );
         forgeSupport = adapter.getBoolean( "forge_support", forgeSupport );
         injectCommands = adapter.getBoolean( "inject_commands", injectCommands );
-        brigadierSuggestions = adapter.getBoolean("brigadier_suggestions", brigadierSuggestions);
-        brigadierSuggestions = adapter.getBoolean("brigadier_response", brigadierSuggestions);
         if ( injectCommands )
         {
             System.setProperty( "net.md-5.bungee.protocol.register_commands", "true" );

--- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
@@ -6,6 +6,7 @@ import com.google.common.io.ByteStreams;
 import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.builder.RequiredArgumentBuilder;
+import com.mojang.brigadier.suggestion.Suggestion;
 import com.mojang.brigadier.suggestion.SuggestionProvider;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 import java.io.DataInput;
@@ -13,6 +14,8 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
 import java.util.Map;
+import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
 import net.md_5.bungee.BungeeCord;
 import net.md_5.bungee.ServerConnection;
@@ -497,13 +500,8 @@ public class DownstreamBridge extends PacketHandler
     @Override
     public void handle(TabCompleteResponse tabCompleteResponse) throws Exception
     {
-        if ( tabCompleteResponse.getCommands() == null )
-        {
-            // Passthrough on 1.13 style command responses - unclear of a sane way to process them at the moment, contributions welcome 
-            return;
-        }
-
-        TabCompleteResponseEvent tabCompleteResponseEvent = new TabCompleteResponseEvent( server, con, tabCompleteResponse.getCommands() );
+        TabCompleteResponseEvent tabCompleteResponseEvent = new TabCompleteResponseEvent( server, con,
+                tabCompleteResponse.getCommands(), tabCompleteResponse.getSuggestions());
 
         if ( !bungee.getPluginManager().callEvent( tabCompleteResponseEvent ).isCancelled() )
         {

--- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
@@ -500,11 +500,23 @@ public class DownstreamBridge extends PacketHandler
     @Override
     public void handle(TabCompleteResponse tabCompleteResponse) throws Exception
     {
+        boolean brigadier = BungeeCord.getInstance().config.isBrigadierSuggestions() &&
+                con.getPendingConnection().getVersion() >= ProtocolConstants.MINECRAFT_1_13;
         TabCompleteResponseEvent tabCompleteResponseEvent = new TabCompleteResponseEvent( server, con,
-                tabCompleteResponse.getCommands(), tabCompleteResponse.getSuggestions());
+                tabCompleteResponse.getCommands(), tabCompleteResponse.getSuggestions(), brigadier );
 
         if ( !bungee.getPluginManager().callEvent( tabCompleteResponseEvent ).isCancelled() )
         {
+            if( !brigadier && con.getPendingConnection().getVersion() >= ProtocolConstants.MINECRAFT_1_13 )
+            {
+                // Remove all TabCompletions using brigadier suggestions
+                tabCompleteResponse.getSuggestions().getList().clear();
+                // add all TabCompletions from the commands list to the brigadier suggestions.
+                for (String complete : tabCompleteResponse.getCommands())
+                    tabCompleteResponse.getSuggestions().getList().add(
+                            new Suggestion(tabCompleteResponse.getSuggestions().getRange(), complete, null)
+                    );
+            }
             con.unsafe().sendPacket( tabCompleteResponse );
         }
 

--- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
@@ -500,7 +500,7 @@ public class DownstreamBridge extends PacketHandler
     @Override
     public void handle(TabCompleteResponse tabCompleteResponse) throws Exception
     {
-        boolean brigadier = BungeeCord.getInstance().config.isBrigadierSuggestions() &&
+        boolean brigadier = BungeeCord.getInstance().config.isBrigadierResponse() &&
                 con.getPendingConnection().getVersion() >= ProtocolConstants.MINECRAFT_1_13;
         TabCompleteResponseEvent tabCompleteResponseEvent = new TabCompleteResponseEvent( server, con,
                 tabCompleteResponse.getCommands(), tabCompleteResponse.getSuggestions(), brigadier );

--- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
@@ -500,23 +500,12 @@ public class DownstreamBridge extends PacketHandler
     @Override
     public void handle(TabCompleteResponse tabCompleteResponse) throws Exception
     {
-        boolean brigadier = BungeeCord.getInstance().config.isBrigadierResponse() &&
-                con.getPendingConnection().getVersion() >= ProtocolConstants.MINECRAFT_1_13;
         TabCompleteResponseEvent tabCompleteResponseEvent = new TabCompleteResponseEvent( server, con,
-                tabCompleteResponse.getCommands(), tabCompleteResponse.getSuggestions(), brigadier );
+                tabCompleteResponse.getCommands(), tabCompleteResponse.getSuggestions(),
+                con.getPendingConnection().getVersion() >= ProtocolConstants.MINECRAFT_1_13 );
 
         if ( !bungee.getPluginManager().callEvent( tabCompleteResponseEvent ).isCancelled() )
         {
-            if( !brigadier && con.getPendingConnection().getVersion() >= ProtocolConstants.MINECRAFT_1_13 )
-            {
-                // Remove all TabCompletions using brigadier suggestions
-                tabCompleteResponse.getSuggestions().getList().clear();
-                // add all TabCompletions from the commands list to the brigadier suggestions.
-                for (String complete : tabCompleteResponse.getCommands())
-                    tabCompleteResponse.getSuggestions().getList().add(
-                            new Suggestion(tabCompleteResponse.getSuggestions().getRange(), complete, null)
-                    );
-            }
             con.unsafe().sendPacket( tabCompleteResponse );
         }
 

--- a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
@@ -172,8 +172,7 @@ public class UpstreamBridge extends PacketHandler
         }
 
         List<String> results = tabCompleteEvent.getSuggestions();
-        if ( !results.isEmpty() && (
-                con.getPendingConnection().getVersion() < ProtocolConstants.MINECRAFT_1_13 ) )
+        if ( !results.isEmpty() && ( con.getPendingConnection().getVersion() < ProtocolConstants.MINECRAFT_1_13 ) )
         {
             // Minecraft versions without brigadier or disabled Brigadier support.
             con.unsafe().sendPacket( new TabCompleteResponse( results ) );


### PR DESCRIPTION
Ticket: #2586 
Maybe there is a better way for implementing brigadier support.
I added a config variable for the support from minecraft's brigadier: 

`brigadier_suggestions` affects only TabCompleteEvent:
- true
  - only send changes from the brigadier suggestions
- false
  - merge suggestions from the List<String> and the brigadier suggestions.

`brigadier_response` affects only TabCompleteResponseEvent:
- true
  - changes made at the suggestions list in the TabCompleteResponseEvent will be ignored.
  - send only brigadier suggestions
- false
  - changes made at the brigadier suggestions will be ignored.
  - send only the suggestion list (like versions < Minecraft 1.13)