### PR TITLE
Set default `sendMessage(bc)` position to `SYSTEM`

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
@@ -433,13 +433,13 @@ public final class UserConnection implements ProxiedPlayer
     @Override
     public void sendMessage(BaseComponent... message)
     {
-        sendMessage( ChatMessageType.CHAT, message );
+        sendMessage( ChatMessageType.SYSTEM, message );
     }
 
     @Override
     public void sendMessage(BaseComponent message)
     {
-        sendMessage( ChatMessageType.CHAT, message );
+        sendMessage( ChatMessageType.SYSTEM, message );
     }
 
     private void sendMessage(ChatMessageType position, String message)


### PR DESCRIPTION
Most messages sent by plugins using `CommandSender.sendMessage(BaseComponent msg)` are not meant to be "chat" messages. This fixes the issue of narrator reading back BungeeCord messages sent by plugin even when narrator is set to read back only "chat" messages.

While I write plugins for BungeeCord, I always have to check if the `CommandSender` is a player or any other sender before I send the message to prevent the narrator from picking up my messages as "chat" messages.

```java
public void execute(CommandSender sender, String[] args) {
    BaseComponent send = new TextComponent();
    // ...
    if (sender instanceof ProxiedPlayer)
        ((ProxiedPlayer) sender).sendMessage(ChatMessageType.SYSTEM, send);
    else
        sender.sendMessage(send);
}
```
