### PR TITLE
Plugin#getName, lombok version update

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/plugin/Plugin.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/Plugin.java
@@ -62,6 +62,17 @@ public class Plugin
     }
 
     /**
+     * Gets the plugin name
+     * Shortcut from {@link PluginDescription#getName()}
+     *
+     * @return plugin name
+     */
+    public String getName()
+    {
+        return description.getName();
+    }
+
+    /**
      * Get a resource from within this plugins jar or container. Care must be
      * taken to close the returned stream.
      *

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.4</version>
+            <version>1.18.6</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Latest lombok gives some new things, such as "var" and "val", and could be useful.
Plugin#getName is really useful for some people who don't want to type always `somePluginInstance.getDescription().getName()`