### PR TITLE
[1.14] Now using Entity IDs, not Object IDs.

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/entitymap/EntityMap.java
+++ b/proxy/src/main/java/net/md_5/bungee/entitymap/EntityMap.java
@@ -253,12 +253,12 @@ public abstract class EntityMap
                         throw Throwables.propagate( ex );
                     }
                     break;
-                case 16:
+                case 15:
                     DefinedPacket.readVarInt( packet );
                     DefinedPacket.readVarInt( packet );
                     DefinedPacket.readVarInt( packet );
                     break;
-                case 17:
+                case 16:
                     if ( index == metaIndex )
                     {
                         int position = packet.readerIndex();
@@ -267,7 +267,7 @@ public abstract class EntityMap
                     }
                     DefinedPacket.readVarInt( packet );
                     break;
-                case 18:
+                case 17:
                     DefinedPacket.readVarInt( packet );
                     break;
                 default:

--- a/proxy/src/main/java/net/md_5/bungee/entitymap/EntityMap.java
+++ b/proxy/src/main/java/net/md_5/bungee/entitymap/EntityMap.java
@@ -253,12 +253,12 @@ public abstract class EntityMap
                         throw Throwables.propagate( ex );
                     }
                     break;
-                case 15:
+                case 16:
                     DefinedPacket.readVarInt( packet );
                     DefinedPacket.readVarInt( packet );
                     DefinedPacket.readVarInt( packet );
                     break;
-                case 16:
+                case 17:
                     if ( index == metaIndex )
                     {
                         int position = packet.readerIndex();
@@ -267,7 +267,7 @@ public abstract class EntityMap
                     }
                     DefinedPacket.readVarInt( packet );
                     break;
-                case 17:
+                case 18:
                     DefinedPacket.readVarInt( packet );
                     break;
                 default:

--- a/proxy/src/main/java/net/md_5/bungee/entitymap/EntityMap_1_14.java
+++ b/proxy/src/main/java/net/md_5/bungee/entitymap/EntityMap_1_14.java
@@ -94,11 +94,11 @@ class EntityMap_1_14 extends EntityMap
             case 0x00 /* Spawn Object : PacketPlayOutSpawnEntity */:
                 DefinedPacket.readVarInt( packet );
                 DefinedPacket.readUUID( packet );
-                int type = packet.readUnsignedByte();
+                int type = DefinedPacket.readVarInt( packet );
 
-                if ( type == 60 || type == 90 || type == 91 )
+                if ( type == 2 || type == 93 || type == 68 ) // arrow, fishing_bobber or spectral_arrow
                 {
-                    if ( type == 60 || type == 91 )
+                    if ( type == 2 || type == 68 ) // arrow or spectral_arrow
                     {
                         oldId = oldId + 1;
                         newId = newId + 1;


### PR DESCRIPTION
~~Corrected new entity metadata type values for 1.14-pre5.~~
Spawn Object packet now uses Entity IDs, not Object IDs, and is sent as a VarInt rather than Byte.
Changed expected type values for tipped arrow, fishing hook and spectral arrow.