### PR TITLE
Make ChatColor codes accessible

### DIFF
--- a/chat/src/main/java/net/md_5/bungee/api/ChatColor.java
+++ b/chat/src/main/java/net/md_5/bungee/api/ChatColor.java
@@ -116,6 +116,7 @@ public enum ChatColor
     /**
      * The code appended to {@link #COLOR_CHAR} to make usable colour.
      */
+    @Getter
     private final char code;
     /**
      * This colour's colour char prefixed by the {@link #COLOR_CHAR}.


### PR DESCRIPTION
Currently, there is no way to access `ChatColor` legacy codes.