### PR TITLE
Plugin cant resolve more than 1 intent

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/event/AsyncEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/AsyncEvent.java
@@ -78,16 +78,19 @@ public class AsyncEvent<T> extends Event
         AtomicInteger intentCount = intents.get( plugin );
         Preconditions.checkState( intentCount != null && intentCount.get() > 0, "Plugin %s has not registered intents for event %s", plugin, this );
 
-        intentCount.decrementAndGet();
-        if ( fired.get() )
+        if ( intentCount.decrementAndGet() == 0 )
         {
-            if ( latch.decrementAndGet() == 0 )
+            intents.remove( plugin );
+            if ( fired.get() )
             {
-                done.done( (T) this, null );
+                if ( latch.decrementAndGet() == 0 )
+                {
+                    done.done( (T) this, null );
+                }
+            } else
+            {
+                latch.decrementAndGet();
             }
-        } else
-        {
-            latch.decrementAndGet();
         }
     }
 }


### PR DESCRIPTION
In January there was a change that a plugin could register more than 1 intent for a AsyncEvent, but the same plugin would not complete the intents stepwise.