### PR TITLE
Protect the plugin manager from 3rd party modifications

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
@@ -40,7 +40,7 @@ import org.yaml.snakeyaml.introspector.PropertyUtils;
  * example event handling and plugin management.
  */
 @RequiredArgsConstructor
-public class PluginManager
+public final class PluginManager
 {
 
     /*========================================================================*/


### PR DESCRIPTION
If you remember, before some spigot devs tried to modify the PluginManager by adding their own stuff to the methods. We don't want this in BungeeCord also, do we?