### PR TITLE
Support for plugin grouping

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/ProxyConfig.java
+++ b/api/src/main/java/net/md_5/bungee/api/ProxyConfig.java
@@ -55,6 +55,11 @@ public interface ProxyConfig
     Collection<String> getDisabledCommands();
 
     /**
+     * A collection of plugin group bundles.
+     */
+    Collection<String> getPluginGroups();
+
+    /**
      * The connection throttle delay.
      */
     @Deprecated

--- a/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
@@ -53,11 +53,13 @@ public class PluginManager
     private Map<String, PluginDescription> toLoad = new HashMap<>();
     private final Multimap<Plugin, Command> commandsByPlugin = ArrayListMultimap.create();
     private final Multimap<Plugin, Listener> listenersByPlugin = ArrayListMultimap.create();
+    private final List<String> enforcedPluginGroups;
 
     @SuppressWarnings("unchecked")
-    public PluginManager(ProxyServer proxy)
+    public PluginManager(ProxyServer proxy, List<String> enforcedPluginGroups)
     {
         this.proxy = proxy;
+        this.enforcedPluginGroups = enforcedPluginGroups;
 
         // Ignore unknown entries in the plugin descriptions
         Constructor yamlConstructor = new Constructor();
@@ -359,7 +361,7 @@ public class PluginManager
                 detectJarFile( file );
             } else if ( file.isDirectory() )
             {
-                if ( proxy.getConfig().getPluginGroups().contains( file.getName() ) )
+                if ( proxy.getConfig().getPluginGroups().contains( file.getName() ) || ( enforcedPluginGroups.contains( file.getName() ) ) )
                 {
                     proxy.getLogger().log( Level.INFO, "Attempting to load plugins from group " + file.getName() );
                     for ( File groupFile : file.listFiles() )

--- a/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
@@ -347,19 +347,20 @@ public class PluginManager
      * Load all plugins from the specified folder.
      *
      * @param folder the folder to search for plugins in
+     * @param searchGroups if subsequent directories should be searched for plugins to load
      */
-    public void detectPlugins(File folder)
+    public void detectPlugins(File folder, boolean searchGroups)
     {
         Preconditions.checkNotNull( folder, "folder" );
         Preconditions.checkArgument( folder.isDirectory(), "Must load from a directory" );
 
-        proxy.getLogger().log(Level.INFO, "Attempting to load plugins");
+        proxy.getLogger().log( Level.INFO, "Attempting to load plugins from " + folder.getName() );
         for ( File file : folder.listFiles() )
         {
             if ( file.getName().endsWith( ".jar" ) )
             {
                 detectJarFile( file );
-            } else if ( file.isDirectory() )
+            } else if ( searchGroups && file.isDirectory() )
             {
                 if ( proxy.getConfig().getPluginGroups().contains( file.getName() ) || ( enforcedPluginGroups.contains( file.getName() ) ) )
                 {

--- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
@@ -29,6 +29,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.MissingResourceException;
@@ -147,6 +148,7 @@ public class BungeeCord extends ProxyServer
     private final Collection<String> pluginChannels = new HashSet<>();
     @Getter
     private final File pluginsFolder = new File( "plugins" );
+    private List<String> enforcedPluginGroups;
     @Getter
     private final BungeeScheduler scheduler = new BungeeScheduler();
     @Getter
@@ -176,8 +178,13 @@ public class BungeeCord extends ProxyServer
         return (BungeeCord) ProxyServer.getInstance();
     }
 
-    @SuppressFBWarnings("DM_DEFAULT_ENCODING")
     public BungeeCord() throws IOException
+    {
+        this( new ArrayList<String>() );
+    }
+
+    @SuppressFBWarnings("DM_DEFAULT_ENCODING")
+    public BungeeCord( List<String> enforcedPluginGroups ) throws IOException
     {
         // Java uses ! to indicate a resource inside of a jar/zip/other container. Running Bungee from within a directory that has a ! will cause this to muck up.
         Preconditions.checkState( new File( "." ).getAbsolutePath().indexOf( '!' ) == -1, "Cannot use BungeeCord in directory with ! in path." );
@@ -212,7 +219,7 @@ public class BungeeCord extends ProxyServer
         System.setErr( new PrintStream( new LoggingOutputStream( logger, Level.SEVERE ), true ) );
         System.setOut( new PrintStream( new LoggingOutputStream( logger, Level.INFO ), true ) );
 
-        pluginManager = new PluginManager( this );
+        pluginManager = new PluginManager( this, enforcedPluginGroups );
         getPluginManager().registerCommand( null, new CommandReload() );
         getPluginManager().registerCommand( null, new CommandEnd() );
         getPluginManager().registerCommand( null, new CommandIP() );

--- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
@@ -266,12 +266,12 @@ public class BungeeCord extends ProxyServer
 
         File moduleDirectory = new File( "modules" );
         moduleManager.load( this, moduleDirectory );
-        pluginManager.detectPlugins( moduleDirectory );
+        pluginManager.detectPlugins( moduleDirectory, false );
 
         // No need to search for plugins if this is the first time the folder was init'ed
         if ( !pluginsFolder.mkdir() )
         {
-            pluginManager.detectPlugins( pluginsFolder );
+            pluginManager.detectPlugins( pluginsFolder, true );
         }
         pluginManager.loadPlugins();
 

--- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
@@ -255,15 +255,18 @@ public class BungeeCord extends ProxyServer
 
         eventLoops = PipelineUtils.newEventLoopGroup( 0, new ThreadFactoryBuilder().setNameFormat( "Netty IO Thread #%1$d" ).build() );
 
+        config.load();
+
         File moduleDirectory = new File( "modules" );
         moduleManager.load( this, moduleDirectory );
         pluginManager.detectPlugins( moduleDirectory );
 
-        pluginsFolder.mkdir();
-        pluginManager.detectPlugins( pluginsFolder );
-
+        // No need to search for plugins if this is the first time the folder was init'ed
+        if ( !pluginsFolder.mkdir() )
+        {
+            pluginManager.detectPlugins( pluginsFolder );
+        }
         pluginManager.loadPlugins();
-        config.load();
 
         if ( config.isForgeSupport() )
         {

--- a/proxy/src/main/java/net/md_5/bungee/BungeeCordLauncher.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeCordLauncher.java
@@ -2,12 +2,15 @@ package net.md_5.bungee;
 
 import java.security.Security;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
+import joptsimple.OptionSpec;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.chat.ComponentBuilder;
@@ -26,6 +29,7 @@ public class BungeeCordLauncher
         parser.acceptsAll( Arrays.asList( "help" ), "Show the help" );
         parser.acceptsAll( Arrays.asList( "v", "version" ), "Print version and exit" );
         parser.acceptsAll( Arrays.asList( "noconsole" ), "Disable console input" );
+        OptionSpec pluginGroupSpec = parser.accepts( "plugingroups", "Force a plugin group(s) to load" ).withRequiredArg().withValuesSeparatedBy(',');
 
         OptionSet options = parser.parse( args );
 
@@ -56,7 +60,8 @@ public class BungeeCordLauncher
             }
         }
 
-        BungeeCord bungee = new BungeeCord();
+        List<String> enforcedPluginGroups = options.has( pluginGroupSpec ) ? new ArrayList<String>( options.valuesOf( pluginGroupSpec ) ) : new ArrayList<String>();
+        BungeeCord bungee = new BungeeCord( enforcedPluginGroups );
         ProxyServer.setInstance( bungee );
         bungee.getLogger().info( "Enabled BungeeCord version " + bungee.getVersion() );
         bungee.start();

--- a/proxy/src/main/java/net/md_5/bungee/conf/Configuration.java
+++ b/proxy/src/main/java/net/md_5/bungee/conf/Configuration.java
@@ -4,6 +4,7 @@ import com.google.common.base.Preconditions;
 import gnu.trove.map.TMap;
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
@@ -54,6 +55,7 @@ public class Configuration implements ProxyConfig
     private boolean logPings = true;
     private int playerLimit = -1;
     private Collection<String> disabledCommands;
+    private Collection<String> pluginGroups;
     private int throttle = 4000;
     private int throttleLimit = 3;
     private boolean ipForward;
@@ -94,6 +96,8 @@ public class Configuration implements ProxyConfig
         forgeSupport = adapter.getBoolean( "forge_support", forgeSupport );
 
         disabledCommands = new CaseInsensitiveSet( (Collection<String>) adapter.getList( "disabled_commands", Arrays.asList( "disabledcommandhere" ) ) );
+
+        pluginGroups = (Collection<String>) adapter.getList("plugin-groups", new ArrayList<>());
 
         Preconditions.checkArgument( listeners != null && !listeners.isEmpty(), "No listeners defined." );
 


### PR DESCRIPTION
This PR adds the functionality for BungeeCord to load plugins from within a folder in the plugins directory. It uses the config.yml to specify which "plugin groups" will be loaded, additionally command line arguments can be used to load plugin groups.

This makes it so the proxy isn't bound to loading all the plugins at the same time without having to remove or add plugins from the plugin folder and instead different folder groups can be made.

*Here's one possible use case:* one group can be made for testing some plugins that depend on eachother and if any fail the tests, it can be simple as just removing the group from the config temporarily while the cause is fixed.

Other changes this PR makes:
- Logs when plugins are about to be loaded, previously no log
- Separated a block within ```detectPlugins``` into method called ```detectJarFile```
- Ignore looking for plugins when the plugin folder was made for the first time by bungee