### PR TITLE
ServerConnector: return instead of throwing CancelSendSignal

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
+++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
@@ -21,7 +21,6 @@ import net.md_5.bungee.api.score.Score;
 import net.md_5.bungee.api.score.Scoreboard;
 import net.md_5.bungee.api.score.Team;
 import net.md_5.bungee.chat.ComponentSerializer;
-import net.md_5.bungee.connection.CancelSendSignal;
 import net.md_5.bungee.connection.DownstreamBridge;
 import net.md_5.bungee.connection.LoginResult;
 import net.md_5.bungee.forge.ForgeConstants;
@@ -159,8 +158,6 @@ public class ServerConnector extends PacketHandler
         {
             user.getForgeClientHandler().resetHandshake();
         }
-
-        throw CancelSendSignal.INSTANCE;
     }
 
     @Override
@@ -291,8 +288,6 @@ public class ServerConnector extends PacketHandler
         bungee.getPluginManager().callEvent( new ServerSwitchEvent( user ) );
 
         thisState = State.FINISHED;
-
-        throw CancelSendSignal.INSTANCE;
     }
 
     @Override
@@ -316,7 +311,7 @@ public class ServerConnector extends PacketHandler
         {
             obsolete = true;
             user.connect( event.getCancelServer(), ServerConnectEvent.Reason.KICK_REDIRECT );
-            throw CancelSendSignal.INSTANCE;
+            return;
         }
 
         String message = bungee.getTranslation( "connect_kick", target.getName(), event.getKickReason() );
@@ -327,8 +322,6 @@ public class ServerConnector extends PacketHandler
         {
             user.sendMessage( message );
         }
-
-        throw CancelSendSignal.INSTANCE;
     }
 
     @Override
@@ -370,7 +363,7 @@ public class ServerConnector extends PacketHandler
                 this.handshakeHandler.handle( pluginMessage );
 
                 // We send the message as part of the handler, so don't send it here.
-                throw CancelSendSignal.INSTANCE;
+                return;
             }
         }
 


### PR DESCRIPTION
As ServerConnector's handle(PacketWrapper) method does only check whether packet.packet is null, its not neccessary to cancel its execution by throwing CancelSendSignal.

I'm sure throwing, catching and updating a boolean field is more expensive than calling a method and checking a field for null again.