### PR TITLE
shorten BadPacketException message in MinecraftDecoder

### DIFF
--- a/protocol/src/main/java/net/md_5/bungee/protocol/MinecraftDecoder.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/MinecraftDecoder.java
@@ -41,7 +41,7 @@ public class MinecraftDecoder extends MessageToMessageDecoder<ByteBuf>
 
                 if ( in.isReadable() )
                 {
-                    throw new BadPacketException( "Did not read all bytes from packet " + packet.getClass() + " " + packetId + " Protocol " + protocol + " Direction " + prot.getDirection() );
+                    throw new BadPacketException( "Packet longer than expected: " + packet.getClass().getSimpleName() + " " + packetId + " Protocol " + protocol + " Direction " + prot.getDirection() );
                 }
             } else
             {

--- a/protocol/src/main/java/net/md_5/bungee/protocol/MinecraftDecoder.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/MinecraftDecoder.java
@@ -41,7 +41,7 @@ public class MinecraftDecoder extends MessageToMessageDecoder<ByteBuf>
 
                 if ( in.isReadable() )
                 {
-                    throw new BadPacketException( "Packet longer than expected: " + packet.getClass().getSimpleName() + " " + packetId + " Protocol " + protocol + " Direction " + prot.getDirection() );
+                    throw new BadPacketException( "Packet " + protocol + ":" + prot.getDirection() + "/" + packetId + " (" + packet.getClass().getSimpleName() + ") larger than expected, extra bytes: " + in.readableBytes() );
                 }
             } else
             {


### PR DESCRIPTION
simple class name should be enough, also rephrased the message