### PR TITLE
InitialHandler: Kick packet is not defined in handshake protocol

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -562,7 +562,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
     @Override
     public void disconnect(final BaseComponent... reason)
     {
-        if ( thisState != State.STATUS && thisState != State.PING )
+        if ( thisState != State.STATUS && thisState != State.PING && thisState != State.HANDSHAKE )
         {
             ch.delayedClose( new Kick( ComponentSerializer.toString( reason ) ) );
         } else


### PR DESCRIPTION
InitialHandler: Kick packet is not defined in handshake protocol, so close channel only