### PR TITLE
Update Guava

### DIFF
--- a/api/src/main/java/net/md_5/bungee/command/PlayerCommand.java
+++ b/api/src/main/java/net/md_5/bungee/command/PlayerCommand.java
@@ -38,6 +38,12 @@ public abstract class PlayerCommand extends Command implements TabExecutor
             {
                 return player.getName().toLowerCase( Locale.ROOT ).startsWith( lastArg );
             }
+
+            @Override
+            public boolean test(ProxiedPlayer input)
+            {
+                return apply( input );
+            }
         } ), new Function<ProxiedPlayer, String>()
         {
             @Override

--- a/module/cmd-server/src/main/java/net/md_5/bungee/module/cmd/server/CommandServer.java
+++ b/module/cmd-server/src/main/java/net/md_5/bungee/module/cmd/server/CommandServer.java
@@ -92,6 +92,12 @@ public class CommandServer extends Command implements TabExecutor
             {
                 return input.getName().toLowerCase( Locale.ROOT ).startsWith( lower ) && input.canAccess( sender );
             }
+
+            @Override
+            public boolean test(ServerInfo input)
+            {
+                return apply( input );
+            }
         } ), new Function<ServerInfo, String>()
         {
             @Override

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>20.0</version>
+            <version>21.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/PluginMessage.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/PluginMessage.java
@@ -55,6 +55,12 @@ public class PluginMessage extends DefinedPacket
         {
             return ( input.getTag().equals( "REGISTER" ) || input.getTag().equals( "minecraft:register" ) || input.getTag().equals( "MC|Brand" ) || input.getTag().equals( "minecraft:brand" ) ) && input.getData().length < Byte.MAX_VALUE;
         }
+
+        @Override
+        public boolean test(PluginMessage input)
+        {
+            return apply( input );
+        }
     };
     //
     private String tag;

--- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
@@ -730,6 +730,12 @@ public class BungeeCord extends ProxyServer
             {
                 return ( input == null ) ? false : input.getName().toLowerCase( Locale.ROOT ).startsWith( partialName.toLowerCase( Locale.ROOT ) );
             }
+
+            @Override
+            public boolean test(ProxiedPlayer input)
+            {
+                return apply( input );
+            }
         } ) );
     }
 


### PR DESCRIPTION
Update guava version to match spigots version. The guava predicates that are in the code base have been updated with the require `test` function that comes from them now implementing javas predicates.