### PR TITLE
Improved Chat Component API

### DIFF
--- a/chat/src/main/java/net/md_5/bungee/api/chat/BaseComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/BaseComponent.java
@@ -505,4 +505,29 @@ public abstract class BaseComponent
             }
         }
     }
+
+    void addFormat(StringBuilder builder)
+    {
+        builder.append( getColor() );
+        if ( isBold() )
+        {
+            builder.append( ChatColor.BOLD );
+        }
+        if ( isItalic() )
+        {
+            builder.append( ChatColor.ITALIC );
+        }
+        if ( isUnderlined() )
+        {
+            builder.append( ChatColor.UNDERLINE );
+        }
+        if ( isStrikethrough() )
+        {
+            builder.append( ChatColor.STRIKETHROUGH );
+        }
+        if ( isObfuscated() )
+        {
+            builder.append( ChatColor.MAGIC );
+        }
+    }
 }

--- a/chat/src/main/java/net/md_5/bungee/api/chat/ComponentBuilder.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/ComponentBuilder.java
@@ -40,6 +40,15 @@ public final class ComponentBuilder
     private final List<BaseComponent> parts = new ArrayList<BaseComponent>();
     private BaseComponent dummy;
 
+    private ComponentBuilder(BaseComponent[] parts)
+    {
+        for ( BaseComponent baseComponent : parts )
+        {
+            this.parts.add( baseComponent.duplicate() );
+        }
+        resetCursor();
+    }
+
     /**
      * Creates a ComponentBuilder from the other given ComponentBuilder to clone
      * it.
@@ -48,11 +57,7 @@ public final class ComponentBuilder
      */
     public ComponentBuilder(ComponentBuilder original)
     {
-        for ( BaseComponent baseComponent : original.parts )
-        {
-            parts.add( baseComponent.duplicate() );
-        }
-        resetCursor();
+        this( original.parts.toArray( new BaseComponent[ original.parts.size() ] ) );
     }
 
     /**
@@ -62,7 +67,7 @@ public final class ComponentBuilder
      */
     public ComponentBuilder(String text)
     {
-        append( new TextComponent( text ) );
+        this( new TextComponent( text ) );
     }
 
     /**
@@ -72,8 +77,12 @@ public final class ComponentBuilder
      */
     public ComponentBuilder(BaseComponent component)
     {
-        parts.add( component.duplicate() );
-        resetCursor();
+
+        this( new BaseComponent[]
+                {
+                        component
+                }
+        );
     }
 
     private BaseComponent getDummy()

--- a/chat/src/main/java/net/md_5/bungee/api/chat/ComponentBuilder.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/ComponentBuilder.java
@@ -146,7 +146,7 @@ public final class ComponentBuilder
      */
     public ComponentBuilder append(BaseComponent component, FormatRetention retention)
     {
-        BaseComponent previous = parts.get( parts.size() - 1 );
+        BaseComponent previous = ( parts.isEmpty() ) ? null : parts.get( parts.size() - 1 );
         if ( previous == null )
         {
             previous = dummy;

--- a/chat/src/main/java/net/md_5/bungee/api/chat/ComponentBuilder.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/ComponentBuilder.java
@@ -38,6 +38,7 @@ public final class ComponentBuilder
     private int cursor = -1;
     @Getter
     private final List<BaseComponent> parts = new ArrayList<BaseComponent>();
+    private BaseComponent dummy;
 
     /**
      * Creates a ComponentBuilder from the other given ComponentBuilder to clone
@@ -73,6 +74,22 @@ public final class ComponentBuilder
     {
         parts.add( component.duplicate() );
         resetCursor();
+    }
+
+    private BaseComponent getDummy()
+    {
+        if ( dummy == null )
+        {
+            dummy = new BaseComponent()
+            {
+                @Override
+                public BaseComponent duplicate()
+                {
+                    return this;
+                }
+            };
+        }
+        return dummy;
     }
 
     /**
@@ -129,8 +146,12 @@ public final class ComponentBuilder
      */
     public ComponentBuilder append(BaseComponent component, FormatRetention retention)
     {
-        resetCursor();
-        BaseComponent previous = getCurrentComponent();
+        BaseComponent previous = parts.get( parts.size() - 1 );
+        if ( previous == null )
+        {
+            previous = dummy;
+            dummy = null;
+        }
         if ( previous != null )
         {
             component.copyFormatting( previous, retention, false );
@@ -210,8 +231,7 @@ public final class ComponentBuilder
      */
     public ComponentBuilder append(String text, FormatRetention retention)
     {
-        TextComponent component = new TextComponent( text );
-        return append( component, retention );
+        return append( new TextComponent( text ), retention );
     }
 
     /**
@@ -280,7 +300,7 @@ public final class ComponentBuilder
      */
     public BaseComponent getCurrentComponent()
     {
-        return ( cursor == -1 ) ? null : parts.get( cursor );
+        return ( cursor == -1 ) ? getDummy() : parts.get( cursor );
     }
 
     /**
@@ -291,9 +311,7 @@ public final class ComponentBuilder
      */
     public ComponentBuilder color(ChatColor color)
     {
-        BaseComponent current = getCurrentComponent();
-        Preconditions.checkNotNull( current, "No component to modify" );
-        current.setColor( color );
+        getCurrentComponent().setColor( color );
         return this;
     }
 
@@ -305,9 +323,7 @@ public final class ComponentBuilder
      */
     public ComponentBuilder bold(boolean bold)
     {
-        BaseComponent current = getCurrentComponent();
-        Preconditions.checkNotNull( current, "No component to modify" );
-        current.setBold( bold );
+        getCurrentComponent().setBold( bold );
         return this;
     }
 
@@ -319,9 +335,7 @@ public final class ComponentBuilder
      */
     public ComponentBuilder italic(boolean italic)
     {
-        BaseComponent current = getCurrentComponent();
-        Preconditions.checkNotNull( current, "No component to modify" );
-        current.setItalic( italic );
+        getCurrentComponent().setItalic( italic );
         return this;
     }
 
@@ -333,9 +347,7 @@ public final class ComponentBuilder
      */
     public ComponentBuilder underlined(boolean underlined)
     {
-        BaseComponent current = getCurrentComponent();
-        Preconditions.checkNotNull( current, "No component to modify" );
-        current.setUnderlined( underlined );
+        getCurrentComponent().setUnderlined( underlined );
         return this;
     }
 
@@ -347,9 +359,7 @@ public final class ComponentBuilder
      */
     public ComponentBuilder strikethrough(boolean strikethrough)
     {
-        BaseComponent current = getCurrentComponent();
-        Preconditions.checkNotNull( current, "No component to modify" );
-        current.setStrikethrough( strikethrough );
+        getCurrentComponent().setStrikethrough( strikethrough );
         return this;
     }
 
@@ -361,9 +371,7 @@ public final class ComponentBuilder
      */
     public ComponentBuilder obfuscated(boolean obfuscated)
     {
-        BaseComponent current = getCurrentComponent();
-        Preconditions.checkNotNull( current, "No component to modify" );
-        current.setObfuscated( obfuscated );
+        getCurrentComponent().setObfuscated( obfuscated );
         return this;
     }
 
@@ -375,9 +383,7 @@ public final class ComponentBuilder
      */
     public ComponentBuilder insertion(String insertion)
     {
-        BaseComponent current = getCurrentComponent();
-        Preconditions.checkNotNull( current, "No component to modify" );
-        current.setInsertion( insertion );
+        getCurrentComponent().setInsertion( insertion );
         return this;
     }
 
@@ -389,9 +395,7 @@ public final class ComponentBuilder
      */
     public ComponentBuilder event(ClickEvent clickEvent)
     {
-        BaseComponent current = getCurrentComponent();
-        Preconditions.checkNotNull( current, "No component to modify" );
-        current.setClickEvent( clickEvent );
+        getCurrentComponent().setClickEvent( clickEvent );
         return this;
     }
 
@@ -403,9 +407,7 @@ public final class ComponentBuilder
      */
     public ComponentBuilder event(HoverEvent hoverEvent)
     {
-        BaseComponent current = getCurrentComponent();
-        Preconditions.checkNotNull( current, "No component to modify" );
-        current.setHoverEvent( hoverEvent );
+        getCurrentComponent().setHoverEvent( hoverEvent );
         return this;
     }
 
@@ -427,9 +429,7 @@ public final class ComponentBuilder
      */
     public ComponentBuilder retain(FormatRetention retention)
     {
-        BaseComponent current = getCurrentComponent();
-        Preconditions.checkNotNull( current, "No component to modify" );
-        current.retain( retention );
+        getCurrentComponent().retain( retention );
         return this;
     }
 
@@ -445,7 +445,7 @@ public final class ComponentBuilder
         int i = 0;
         for ( BaseComponent part : parts )
         {
-            cloned[ i ] = parts.get( i++ ).duplicate();
+            cloned[ i++ ] = part.duplicate();
         }
         return cloned;
     }

--- a/chat/src/main/java/net/md_5/bungee/api/chat/ComponentBuilder.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/ComponentBuilder.java
@@ -29,6 +29,13 @@ import net.md_5.bungee.api.ChatColor;
 public final class ComponentBuilder
 {
 
+    /**
+     * The position for the current part to modify.
+     * Modified cursors will automatically reset to the last part after appending new components.
+     * Default value at -1 to assert that the builder has no parts.
+     */
+    @Getter
+    private int cursor = -1;
     @Getter
     private final List<BaseComponent> parts = new ArrayList<BaseComponent>();
 
@@ -44,6 +51,7 @@ public final class ComponentBuilder
         {
             parts.add( baseComponent.duplicate() );
         }
+        resetCursor();
     }
 
     /**
@@ -64,6 +72,37 @@ public final class ComponentBuilder
     public ComponentBuilder(BaseComponent component)
     {
         parts.add( component.duplicate() );
+        resetCursor();
+    }
+
+    /**
+     * Resets the cursor to index of the last element.
+     *
+     * @return this ComponentBuilder for chaining
+     */
+    public ComponentBuilder resetCursor()
+    {
+        cursor = parts.size() - 1;
+        return this;
+    }
+
+    /**
+     * Sets the position of the current component to be modified
+     *
+     * @param pos the cursor position synonymous to an element position for a list
+     * @throws IndexOutOfBoundsException if the index is out of range
+     *         ({@code index < 0 || index >= size()})
+     * @return this ComponentBuilder for chaining
+     */
+    public ComponentBuilder setCursor(int pos) throws IndexOutOfBoundsException
+    {
+        if ( ( this.cursor != pos ) && ( pos < 0 || pos >= parts.size() ) )
+        {
+            throw new IndexOutOfBoundsException( "Cursor out of bounds (expected between 0 + " + ( parts.size() - 1 ) + ")" );
+        }
+
+        this.cursor = pos;
+        return this;
     }
 
     /**
@@ -90,12 +129,14 @@ public final class ComponentBuilder
      */
     public ComponentBuilder append(BaseComponent component, FormatRetention retention)
     {
+        resetCursor();
         BaseComponent previous = getCurrentComponent();
         if ( previous != null )
         {
             component.copyFormatting( previous, retention, false );
         }
         parts.add( component );
+        resetCursor();
         return this;
     }
 
@@ -205,13 +246,41 @@ public final class ComponentBuilder
     }
 
     /**
-     * Gets the active component this builder is working on.
+     * Remove the component part at the position of given index.
+     *
+     * @param pos the index to remove at
+     * @throws IndexOutOfBoundsException if the index is out of range
+     *         ({@code index < 0 || index >= size()})
+     */
+    public void removeComponent(int pos) throws IndexOutOfBoundsException
+    {
+        if ( parts.remove( pos ) != null )
+        {
+            resetCursor();
+        }
+    }
+
+    /**
+     * Gets the component part at the position of given index.
+     *
+     * @param pos the index to find
+     * @return the component
+     * @throws IndexOutOfBoundsException if the index is out of range
+     *         ({@code index < 0 || index >= size()})
+     */
+    public BaseComponent getComponent(int pos) throws IndexOutOfBoundsException
+    {
+        return parts.get( pos );
+    }
+
+    /**
+     * Gets the component at the position of the cursor.
      *
      * @return the active component or null if builder is empty
      */
     public BaseComponent getCurrentComponent()
     {
-        return ( parts.isEmpty() ) ? null : parts.get( parts.size() - 1 );
+        return ( cursor == -1 ) ? null : parts.get( cursor );
     }
 
     /**
@@ -366,7 +435,7 @@ public final class ComponentBuilder
 
     /**
      * Returns the components needed to display the message created by this
-     * builder.
+     * builder.git
      *
      * @return the created components
      */

--- a/chat/src/main/java/net/md_5/bungee/api/chat/KeybindComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/KeybindComponent.java
@@ -5,7 +5,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
-import net.md_5.bungee.api.ChatColor;
 
 @Getter
 @Setter
@@ -60,29 +59,8 @@ public final class KeybindComponent extends BaseComponent
     @Override
     protected void toLegacyText(StringBuilder builder)
     {
-        builder.append( getColor() );
-        if ( isBold() )
-        {
-            builder.append( ChatColor.BOLD );
-        }
-        if ( isItalic() )
-        {
-            builder.append( ChatColor.ITALIC );
-        }
-        if ( isUnderlined() )
-        {
-            builder.append( ChatColor.UNDERLINE );
-        }
-        if ( isStrikethrough() )
-        {
-            builder.append( ChatColor.STRIKETHROUGH );
-        }
-        if ( isObfuscated() )
-        {
-            builder.append( ChatColor.MAGIC );
-        }
+        addFormat( builder );
         builder.append( getKeybind() );
-
         super.toLegacyText( builder );
     }
 }

--- a/chat/src/main/java/net/md_5/bungee/api/chat/ScoreComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/ScoreComponent.java
@@ -85,8 +85,16 @@ public final class ScoreComponent extends BaseComponent
     }
 
     @Override
+    protected void toPlainText(StringBuilder builder)
+    {
+        builder.append( this.value );
+        super.toPlainText( builder );
+    }
+
+    @Override
     protected void toLegacyText(StringBuilder builder)
     {
+        addFormat( builder );
         builder.append( this.value );
         super.toLegacyText( builder );
     }

--- a/chat/src/main/java/net/md_5/bungee/api/chat/SelectorComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/SelectorComponent.java
@@ -51,8 +51,16 @@ public final class SelectorComponent extends BaseComponent
     }
 
     @Override
+    protected void toPlainText(StringBuilder builder)
+    {
+        builder.append( this.selector );
+        super.toPlainText( builder );
+    }
+
+    @Override
     protected void toLegacyText(StringBuilder builder)
     {
+        addFormat( builder );
         builder.append( this.selector );
         super.toLegacyText( builder );
     }

--- a/chat/src/main/java/net/md_5/bungee/api/chat/TextComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/TextComponent.java
@@ -197,27 +197,7 @@ public final class TextComponent extends BaseComponent
     @Override
     protected void toLegacyText(StringBuilder builder)
     {
-        builder.append( getColor() );
-        if ( isBold() )
-        {
-            builder.append( ChatColor.BOLD );
-        }
-        if ( isItalic() )
-        {
-            builder.append( ChatColor.ITALIC );
-        }
-        if ( isUnderlined() )
-        {
-            builder.append( ChatColor.UNDERLINE );
-        }
-        if ( isStrikethrough() )
-        {
-            builder.append( ChatColor.STRIKETHROUGH );
-        }
-        if ( isObfuscated() )
-        {
-            builder.append( ChatColor.MAGIC );
-        }
+        addFormat( builder );
         builder.append( text );
         super.toLegacyText( builder );
     }

--- a/chat/src/main/java/net/md_5/bungee/api/chat/TextComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/TextComponent.java
@@ -2,6 +2,7 @@ package net.md_5.bungee.api.chat;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import lombok.AllArgsConstructor;
@@ -172,21 +173,26 @@ public final class TextComponent extends BaseComponent
      */
     public TextComponent(BaseComponent... extras)
     {
-        this( wrapComponent( extras ) );
-    }
-
-    private static TextComponent wrapComponent(BaseComponent... extras)
-    {
+        if ( extras.length == 0 )
+        {
+            return;
+        }
         if ( extras.length == 1 && extras[0] instanceof TextComponent )
         {
-            return (TextComponent) extras[0];
-        }
-        TextComponent component = new TextComponent( "" );
-        if ( extras.length != 0 )
+            setText( ( (TextComponent) extras[0] ).getText() );
+            List<BaseComponent> headExtra = extras[0].getExtra();
+            if ( headExtra != null )
+            {
+                for ( BaseComponent extra : headExtra )
+                {
+                    addExtra( extra.duplicate() );
+                }
+            }
+        } else
         {
-            component.setExtra( new ArrayList<BaseComponent>( Arrays.asList( extras ) ) );
+            setText( "" );
+            setExtra( new ArrayList<BaseComponent>( Arrays.asList( extras ) ) );
         }
-        return component;
     }
 
     /**

--- a/chat/src/main/java/net/md_5/bungee/api/chat/TextComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/TextComponent.java
@@ -172,8 +172,21 @@ public final class TextComponent extends BaseComponent
      */
     public TextComponent(BaseComponent... extras)
     {
-        setText( "" );
-        setExtra( new ArrayList<BaseComponent>( Arrays.asList( extras ) ) );
+        this( wrapComponent( extras ) );
+    }
+
+    private static TextComponent wrapComponent(BaseComponent... extras)
+    {
+        if ( extras.length == 1 && extras[0] instanceof TextComponent )
+        {
+            return (TextComponent) extras[0];
+        }
+        TextComponent component = new TextComponent( "" );
+        if ( extras.length != 0 )
+        {
+            component.setExtra( new ArrayList<BaseComponent>( Arrays.asList( extras ) ) );
+        }
+        return component;
     }
 
     /**

--- a/chat/src/main/java/net/md_5/bungee/api/chat/TranslatableComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/TranslatableComponent.java
@@ -9,7 +9,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
-import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.chat.TranslationRegistry;
 
 @Getter
@@ -139,44 +138,19 @@ public final class TranslatableComponent extends BaseComponent
     @Override
     protected void toPlainText(StringBuilder builder)
     {
-        String trans = TranslationRegistry.INSTANCE.translate( translate );
-
-        Matcher matcher = format.matcher( trans );
-        int position = 0;
-        int i = 0;
-        while ( matcher.find( position ) )
-        {
-            int pos = matcher.start();
-            if ( pos != position )
-            {
-                builder.append( trans.substring( position, pos ) );
-            }
-            position = matcher.end();
-
-            String formatCode = matcher.group( 2 );
-            switch ( formatCode.charAt( 0 ) )
-            {
-                case 's':
-                case 'd':
-                    String withIndex = matcher.group( 1 );
-                    with.get( withIndex != null ? Integer.parseInt( withIndex ) - 1 : i++ ).toPlainText( builder );
-                    break;
-                case '%':
-                    builder.append( '%' );
-                    break;
-            }
-        }
-        if ( trans.length() != position )
-        {
-            builder.append( trans.substring( position, trans.length() ) );
-        }
-
+        convert( builder, false );
         super.toPlainText( builder );
     }
 
     @Override
     protected void toLegacyText(StringBuilder builder)
     {
+        convert( builder, true );
+        super.toLegacyText( builder );
+    }
+
+    private void convert(StringBuilder builder, boolean applyFormat)
+    {
         String trans = TranslationRegistry.INSTANCE.translate( translate );
 
         Matcher matcher = format.matcher( trans );
@@ -187,7 +161,10 @@ public final class TranslatableComponent extends BaseComponent
             int pos = matcher.start();
             if ( pos != position )
             {
-                addFormat( builder );
+                if ( applyFormat )
+                {
+                    addFormat( builder );
+                }
                 builder.append( trans.substring( position, pos ) );
             }
             position = matcher.end();
@@ -198,44 +175,32 @@ public final class TranslatableComponent extends BaseComponent
                 case 's':
                 case 'd':
                     String withIndex = matcher.group( 1 );
-                    with.get( withIndex != null ? Integer.parseInt( withIndex ) - 1 : i++ ).toLegacyText( builder );
+
+                    BaseComponent withComponent = with.get( withIndex != null ? Integer.parseInt( withIndex ) - 1 : i++ );
+                    if ( applyFormat )
+                    {
+                        withComponent.toLegacyText( builder );
+                    } else
+                    {
+                        withComponent.toPlainText( builder );
+                    }
                     break;
                 case '%':
-                    addFormat( builder );
+                    if ( applyFormat )
+                    {
+                        addFormat( builder );
+                    }
                     builder.append( '%' );
                     break;
             }
         }
         if ( trans.length() != position )
         {
-            addFormat( builder );
+            if ( applyFormat )
+            {
+                addFormat( builder );
+            }
             builder.append( trans.substring( position, trans.length() ) );
-        }
-        super.toLegacyText( builder );
-    }
-
-    private void addFormat(StringBuilder builder)
-    {
-        builder.append( getColor() );
-        if ( isBold() )
-        {
-            builder.append( ChatColor.BOLD );
-        }
-        if ( isItalic() )
-        {
-            builder.append( ChatColor.ITALIC );
-        }
-        if ( isUnderlined() )
-        {
-            builder.append( ChatColor.UNDERLINE );
-        }
-        if ( isStrikethrough() )
-        {
-            builder.append( ChatColor.STRIKETHROUGH );
-        }
-        if ( isObfuscated() )
-        {
-            builder.append( ChatColor.MAGIC );
         }
     }
 }

--- a/chat/src/main/java/net/md_5/bungee/chat/TranslatableComponentSerializer.java
+++ b/chat/src/main/java/net/md_5/bungee/chat/TranslatableComponentSerializer.java
@@ -24,7 +24,7 @@ public class TranslatableComponentSerializer extends BaseComponentSerializer imp
         component.setTranslate( object.get( "translate" ).getAsString() );
         if ( object.has( "with" ) )
         {
-            component.setWith( Arrays.asList( (BaseComponent[]) context.deserialize( object.get( "with" ), BaseComponent[].class ) ) );
+            component.setWith( Arrays.asList( context.<BaseComponent>deserialize( object.get( "with" ), BaseComponent[].class ) ) );
         }
         return component;
     }

--- a/chat/src/test/java/net/md_5/bungee/api/chat/ComponentsTest.java
+++ b/chat/src/test/java/net/md_5/bungee/api/chat/ComponentsTest.java
@@ -12,6 +12,63 @@ public class ComponentsTest
 {
 
     @Test
+    public void testEmptyComponentBuilder()
+    {
+        ComponentBuilder builder = new ComponentBuilder();
+
+        BaseComponent[] parts = builder.create();
+        Assert.assertEquals( parts.length, 0 );
+
+        for ( int i = 0; i < 3; i++ )
+        {
+            builder.append( "part:" + i );
+            parts = builder.create();
+            Assert.assertEquals( parts.length, i + 1 );
+        }
+    }
+
+    @Test
+    public void testDummyRetaining()
+    {
+        ComponentBuilder builder = new ComponentBuilder();
+        Assert.assertNotNull( builder.getCurrentComponent() );
+        builder.color( ChatColor.GREEN );
+        builder.append( "test ", ComponentBuilder.FormatRetention.ALL );
+        Assert.assertEquals( builder.getCurrentComponent().getColor(), ChatColor.GREEN );
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void testComponentGettingExceptions()
+    {
+        ComponentBuilder builder = new ComponentBuilder();
+        builder.getComponent( -1 );
+        builder.getComponent( 0 );
+        builder.getComponent( 1 );
+        BaseComponent component = new TextComponent( "Hello" );
+        builder.append( component );
+        Assert.assertEquals( builder.getComponent( 0 ), component );
+        builder.getComponent( 1 );
+    }
+
+    @Test
+    public void testComponentParting()
+    {
+        ComponentBuilder builder = new ComponentBuilder();
+        TextComponent apple = new TextComponent( "apple" );
+        builder.append( apple );
+        Assert.assertEquals( builder.getCurrentComponent(), apple );
+        Assert.assertEquals( builder.getComponent( 0 ), apple );
+
+        TextComponent mango = new TextComponent( "mango" );
+        TextComponent orange = new TextComponent( "orange" );
+        builder.append( mango );
+        builder.append( orange );
+        builder.removeComponent( 1 ); // Removing mango
+        Assert.assertEquals( builder.getComponent( 0 ), apple );
+        Assert.assertEquals( builder.getComponent( 1 ), orange );
+    }
+
+    @Test
     public void testToLegacyFromLegacy()
     {
         String text = "§a§lHello §f§kworld§7!";

--- a/chat/src/test/java/net/md_5/bungee/api/chat/ComponentsTest.java
+++ b/chat/src/test/java/net/md_5/bungee/api/chat/ComponentsTest.java
@@ -18,6 +18,41 @@ public class ComponentsTest
         Assert.assertEquals( text, TextComponent.toLegacyText( TextComponent.fromLegacyText( text ) ) );
     }
 
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void testComponentBuilderCursorInvalidPos()
+    {
+        ComponentBuilder builder = new ComponentBuilder();
+        builder.append( new TextComponent( "Apple, ") );
+        builder.append( new TextComponent( "Orange, ") );
+        builder.setCursor( -1 );
+        builder.setCursor( 2 );
+    }
+
+    @Test
+    public void testComponentBuilderCursor()
+    {
+        TextComponent t1, t2, t3;
+        ComponentBuilder builder = new ComponentBuilder();
+        Assert.assertEquals( builder.getCursor(), -1 );
+        builder.append( t1 = new TextComponent( "Apple, ") );
+        Assert.assertEquals( builder.getCursor(), 0 );
+        builder.append( t2 = new TextComponent( "Orange, ") );
+        builder.append( t3 = new TextComponent( "Mango, ") );
+        Assert.assertEquals( builder.getCursor(), 2 );
+
+        builder.setCursor( 0 );
+        Assert.assertEquals( builder.getCurrentComponent(), t1 );
+
+        // Test that appending new components updates the position to the new list size
+        // after having previously set it to 0 (first component)
+        builder.append( new TextComponent( "and Grapefruit"));
+        Assert.assertEquals( builder.getCursor(), 3 );
+
+        builder.setCursor( 0 );
+        builder.resetCursor();
+        Assert.assertEquals( builder.getCursor(), 3 );
+    }
+
     @Test
     public void testLegacyComponentBuilderAppend()
     {

--- a/chat/src/test/java/net/md_5/bungee/api/chat/ComponentsTest.java
+++ b/chat/src/test/java/net/md_5/bungee/api/chat/ComponentsTest.java
@@ -12,15 +12,19 @@ public class ComponentsTest
 {
 
     @Test
+    public void testToLegacyFromLegacy()
+    {
+        String text = "§a§lHello §f§kworld§7!";
+        Assert.assertEquals( text, TextComponent.toLegacyText( TextComponent.fromLegacyText( text ) ) );
+    }
+
+    @Test
     public void testLegacyComponentBuilderAppend()
     {
         String text = "§a§lHello §r§kworld§7!";
         BaseComponent[] components = TextComponent.fromLegacyText( text );
-        BaseComponent[] builderComponents = new ComponentBuilder( "" ).append( components ).create();
+        BaseComponent[] builderComponents = new ComponentBuilder().append( components ).create();
         List<BaseComponent> list = new ArrayList<BaseComponent>( Arrays.asList( builderComponents ) );
-        // Remove the first element (empty text component). This needs to be done because toLegacyText always
-        // appends &f regardless if the color is non null or not and would otherwise mess with our unit test.
-        list.remove( 0 );
         Assert.assertEquals(
                 TextComponent.toLegacyText( components ),
                 TextComponent.toLegacyText( list.toArray( new BaseComponent[ list.size() ] ) )
@@ -28,7 +32,7 @@ public class ComponentsTest
     }
 
     @Test
-    public void testComponentFormatRetention()
+    public void testFormatRetentionCopyFormatting()
     {
         TextComponent first = new TextComponent( "Hello" );
         first.setBold( true );
@@ -47,7 +51,7 @@ public class ComponentsTest
     @Test
     public void testBuilderClone()
     {
-        ComponentBuilder builder = new ComponentBuilder( "Hel" ).color( ChatColor.RED ).append( "lo" ).color( ChatColor.DARK_RED );
+        ComponentBuilder builder = new ComponentBuilder( "Hello " ).color( ChatColor.RED ).append( "world" ).color( ChatColor.DARK_RED );
         ComponentBuilder cloned = new ComponentBuilder( builder );
 
         Assert.assertEquals( TextComponent.toLegacyText( builder.create() ), TextComponent.toLegacyText( cloned.create() ) );

--- a/module/cmd-server/src/main/java/net/md_5/bungee/module/cmd/server/CommandServer.java
+++ b/module/cmd-server/src/main/java/net/md_5/bungee/module/cmd/server/CommandServer.java
@@ -40,7 +40,7 @@ public class CommandServer extends Command implements TabExecutor
                 sender.sendMessage( ProxyServer.getInstance().getTranslation( "current_server", ( (ProxiedPlayer) sender ).getServer().getInfo().getName() ) );
             }
 
-            ComponentBuilder serverList = new ComponentBuilder( "" ).appendLegacy( ProxyServer.getInstance().getTranslation( "server_list" ) );
+            ComponentBuilder serverList = new ComponentBuilder().appendLegacy( ProxyServer.getInstance().getTranslation( "server_list" ) );
             boolean first = true;
             for ( ServerInfo server : servers.values() )
             {


### PR DESCRIPTION
See description of every commit for further detail.

- Shared code for various BaseComponent toLegacyText and toPlainText methods moved to the superclass to cut back on duplicate code and make it more accessible
- Various unit tests inserted to accommodate new changes
--
**ComponentBuilder:**
- No arg constructor. Allows for creating without an initial component (e.g. "" TextComponent)
- Better control of parts (get at index, remove at index, get the most recent part -getCurrentComponent)
- Cursor API. For example; when there are two components in a builder, setting the cursor to 0 and then using ```setColor(ChatColor.BLUE)``` will set the color of the first component instead of the second by default. Or to change the previous part ```setCursor(getCursor() - 1).setColor(ChatColor.BLUE)```
--