### PR TITLE
Add 1.15 support

### DIFF
--- a/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java
@@ -6,7 +6,6 @@ import gnu.trove.map.TIntObjectMap;
 import gnu.trove.map.TObjectIntMap;
 import gnu.trove.map.hash.TIntObjectHashMap;
 import gnu.trove.map.hash.TObjectIntHashMap;
-import java.lang.reflect.Constructor;
 import lombok.Data;
 import lombok.Getter;
 import net.md_5.bungee.protocol.packet.BossBar;
@@ -41,264 +40,282 @@ import net.md_5.bungee.protocol.packet.Team;
 import net.md_5.bungee.protocol.packet.Title;
 import net.md_5.bungee.protocol.packet.ViewDistance;
 
+import java.lang.reflect.Constructor;
+
 public enum Protocol
 {
 
     // Undef
     HANDSHAKE
-    {
+            {
 
-        {
-            TO_SERVER.registerPacket(
-                    Handshake.class,
-                    map( ProtocolConstants.MINECRAFT_1_8, 0x00 )
-            );
-        }
-    },
+                {
+                    TO_SERVER.registerPacket(
+                            Handshake.class,
+                            map( ProtocolConstants.MINECRAFT_1_8, 0x00 )
+                    );
+                }
+            },
     // 0
     GAME
-    {
+            {
 
-        {
-            TO_CLIENT.registerPacket(
-                    KeepAlive.class,
-                    map( ProtocolConstants.MINECRAFT_1_8, 0x00 ),
-                    map( ProtocolConstants.MINECRAFT_1_9, 0x1F ),
-                    map( ProtocolConstants.MINECRAFT_1_13, 0x21 ),
-                    map( ProtocolConstants.MINECRAFT_1_14, 0x20 )
-            );
-            TO_CLIENT.registerPacket(
-                    Login.class,
-                    map( ProtocolConstants.MINECRAFT_1_8, 0x01 ),
-                    map( ProtocolConstants.MINECRAFT_1_9, 0x23 ),
-                    map( ProtocolConstants.MINECRAFT_1_13, 0x25 )
-            );
-            TO_CLIENT.registerPacket(
-                    Chat.class,
-                    map( ProtocolConstants.MINECRAFT_1_8, 0x02 ),
-                    map( ProtocolConstants.MINECRAFT_1_9, 0x0F ),
-                    map( ProtocolConstants.MINECRAFT_1_13, 0x0E )
-            );
-            TO_CLIENT.registerPacket(
-                    Respawn.class,
-                    map( ProtocolConstants.MINECRAFT_1_8, 0x07 ),
-                    map( ProtocolConstants.MINECRAFT_1_9, 0x33 ),
-                    map( ProtocolConstants.MINECRAFT_1_12, 0x34 ),
-                    map( ProtocolConstants.MINECRAFT_1_12_1, 0x35 ),
-                    map( ProtocolConstants.MINECRAFT_1_13, 0x38 ),
-                    map( ProtocolConstants.MINECRAFT_1_14, 0x3A )
-            );
-            TO_CLIENT.registerPacket(
-                    BossBar.class,
-                    map( ProtocolConstants.MINECRAFT_1_9, 0x0C )
-            );
-            TO_CLIENT.registerPacket(
-                    PlayerListItem.class, // PlayerInfo
-                    map( ProtocolConstants.MINECRAFT_1_8, 0x38 ),
-                    map( ProtocolConstants.MINECRAFT_1_9, 0x2D ),
-                    map( ProtocolConstants.MINECRAFT_1_12_1, 0x2E ),
-                    map( ProtocolConstants.MINECRAFT_1_13, 0x30 ),
-                    map( ProtocolConstants.MINECRAFT_1_14, 0x33 )
-            );
-            TO_CLIENT.registerPacket(
-                    TabCompleteResponse.class,
-                    map( ProtocolConstants.MINECRAFT_1_8, 0x3A ),
-                    map( ProtocolConstants.MINECRAFT_1_9, 0x0E ),
-                    map( ProtocolConstants.MINECRAFT_1_13, 0x10 )
-            );
-            TO_CLIENT.registerPacket(
-                    ScoreboardObjective.class,
-                    map( ProtocolConstants.MINECRAFT_1_8, 0x3B ),
-                    map( ProtocolConstants.MINECRAFT_1_9, 0x3F ),
-                    map( ProtocolConstants.MINECRAFT_1_12, 0x41 ),
-                    map( ProtocolConstants.MINECRAFT_1_12_1, 0x42 ),
-                    map( ProtocolConstants.MINECRAFT_1_13, 0x45 ),
-                    map( ProtocolConstants.MINECRAFT_1_14, 0x49 )
-            );
-            TO_CLIENT.registerPacket(
-                    ScoreboardScore.class,
-                    map( ProtocolConstants.MINECRAFT_1_8, 0x3C ),
-                    map( ProtocolConstants.MINECRAFT_1_9, 0x42 ),
-                    map( ProtocolConstants.MINECRAFT_1_12, 0x44 ),
-                    map( ProtocolConstants.MINECRAFT_1_12_1, 0x45 ),
-                    map( ProtocolConstants.MINECRAFT_1_13, 0x48 ),
-                    map( ProtocolConstants.MINECRAFT_1_14, 0x4C )
-            );
-            TO_CLIENT.registerPacket(
-                    ScoreboardDisplay.class,
-                    map( ProtocolConstants.MINECRAFT_1_8, 0x3D ),
-                    map( ProtocolConstants.MINECRAFT_1_9, 0x38 ),
-                    map( ProtocolConstants.MINECRAFT_1_12, 0x3A ),
-                    map( ProtocolConstants.MINECRAFT_1_12_1, 0x3B ),
-                    map( ProtocolConstants.MINECRAFT_1_13, 0x3E ),
-                    map( ProtocolConstants.MINECRAFT_1_14, 0x42 )
-            );
-            TO_CLIENT.registerPacket(
-                    Team.class,
-                    map( ProtocolConstants.MINECRAFT_1_8, 0x3E ),
-                    map( ProtocolConstants.MINECRAFT_1_9, 0x41 ),
-                    map( ProtocolConstants.MINECRAFT_1_12, 0x43 ),
-                    map( ProtocolConstants.MINECRAFT_1_12_1, 0x44 ),
-                    map( ProtocolConstants.MINECRAFT_1_13, 0x47 ),
-                    map( ProtocolConstants.MINECRAFT_1_14, 0x4B )
-            );
-            TO_CLIENT.registerPacket(
-                    PluginMessage.class,
-                    map( ProtocolConstants.MINECRAFT_1_8, 0x3F ),
-                    map( ProtocolConstants.MINECRAFT_1_9, 0x18 ),
-                    map( ProtocolConstants.MINECRAFT_1_13, 0x19 ),
-                    map( ProtocolConstants.MINECRAFT_1_14, 0x18 )
-            );
-            TO_CLIENT.registerPacket(
-                    Kick.class,
-                    map( ProtocolConstants.MINECRAFT_1_8, 0x40 ),
-                    map( ProtocolConstants.MINECRAFT_1_9, 0x1A ),
-                    map( ProtocolConstants.MINECRAFT_1_13, 0x1B ),
-                    map( ProtocolConstants.MINECRAFT_1_14, 0x1A )
-            );
-            TO_CLIENT.registerPacket(
-                    Title.class,
-                    map( ProtocolConstants.MINECRAFT_1_8, 0x45 ),
-                    map( ProtocolConstants.MINECRAFT_1_12, 0x47 ),
-                    map( ProtocolConstants.MINECRAFT_1_12_1, 0x48 ),
-                    map( ProtocolConstants.MINECRAFT_1_13, 0x4B ),
-                    map( ProtocolConstants.MINECRAFT_1_14, 0x4F )
-            );
-            TO_CLIENT.registerPacket(
-                    PlayerListHeaderFooter.class,
-                    map( ProtocolConstants.MINECRAFT_1_8, 0x47 ),
-                    map( ProtocolConstants.MINECRAFT_1_9, 0x48 ),
-                    map( ProtocolConstants.MINECRAFT_1_9_4, 0x47 ),
-                    map( ProtocolConstants.MINECRAFT_1_12, 0x49 ),
-                    map( ProtocolConstants.MINECRAFT_1_12_1, 0x4A ),
-                    map( ProtocolConstants.MINECRAFT_1_13, 0x4E ),
-                    map( ProtocolConstants.MINECRAFT_1_14, 0x53 )
-            );
-            TO_CLIENT.registerPacket(
-                    EntityStatus.class,
-                    map( ProtocolConstants.MINECRAFT_1_8, 0x1A ),
-                    map( ProtocolConstants.MINECRAFT_1_9, 0x1B ),
-                    map( ProtocolConstants.MINECRAFT_1_13, 0x1C ),
-                    map( ProtocolConstants.MINECRAFT_1_14, 0x1B )
-            );
-            TO_CLIENT.registerPacket(
-                    Commands.class,
-                    map( ProtocolConstants.MINECRAFT_1_13, 0x11 )
-            );
-            TO_CLIENT.registerPacket(
-                    ViewDistance.class,
-                    map( ProtocolConstants.MINECRAFT_1_14, 0x41 )
-            );
+                {
+                    TO_CLIENT.registerPacket(
+                            KeepAlive.class,
+                            map( ProtocolConstants.MINECRAFT_1_8, 0x00 ),
+                            map( ProtocolConstants.MINECRAFT_1_9, 0x1F ),
+                            map( ProtocolConstants.MINECRAFT_1_13, 0x21 ),
+                            map( ProtocolConstants.MINECRAFT_1_14, 0x20 ),
+                            map( ProtocolConstants.MINECRAFT_1_15, 0x21 )
+                    );
+                    TO_CLIENT.registerPacket(
+                            Login.class,
+                            map( ProtocolConstants.MINECRAFT_1_8, 0x01 ),
+                            map( ProtocolConstants.MINECRAFT_1_9, 0x23 ),
+                            map( ProtocolConstants.MINECRAFT_1_13, 0x25 ),
+                            map( ProtocolConstants.MINECRAFT_1_15, 0x26 )
+                    );
+                    TO_CLIENT.registerPacket(
+                            Chat.class,
+                            map( ProtocolConstants.MINECRAFT_1_8, 0x02 ),
+                            map( ProtocolConstants.MINECRAFT_1_9, 0x0F ),
+                            map( ProtocolConstants.MINECRAFT_1_13, 0x0E ),
+                            map( ProtocolConstants.MINECRAFT_1_15, 0x0F )
+                    );
+                    TO_CLIENT.registerPacket(
+                            Respawn.class,
+                            map( ProtocolConstants.MINECRAFT_1_8, 0x07 ),
+                            map( ProtocolConstants.MINECRAFT_1_9, 0x33 ),
+                            map( ProtocolConstants.MINECRAFT_1_12, 0x34 ),
+                            map( ProtocolConstants.MINECRAFT_1_12_1, 0x35 ),
+                            map( ProtocolConstants.MINECRAFT_1_13, 0x38 ),
+                            map( ProtocolConstants.MINECRAFT_1_14, 0x3A ),
+                            map( ProtocolConstants.MINECRAFT_1_15, 0x3B )
+                    );
+                    TO_CLIENT.registerPacket(
+                            BossBar.class,
+                            map( ProtocolConstants.MINECRAFT_1_9, 0x0C ),
+                            map( ProtocolConstants.MINECRAFT_1_15, 0x0D )
+                    );
+                    TO_CLIENT.registerPacket(
+                            PlayerListItem.class, // PlayerInfo
+                            map( ProtocolConstants.MINECRAFT_1_8, 0x38 ),
+                            map( ProtocolConstants.MINECRAFT_1_9, 0x2D ),
+                            map( ProtocolConstants.MINECRAFT_1_12_1, 0x2E ),
+                            map( ProtocolConstants.MINECRAFT_1_13, 0x30 ),
+                            map( ProtocolConstants.MINECRAFT_1_14, 0x33 ),
+                            map( ProtocolConstants.MINECRAFT_1_15, 0x34 )
+                    );
+                    TO_CLIENT.registerPacket(
+                            TabCompleteResponse.class,
+                            map( ProtocolConstants.MINECRAFT_1_8, 0x3A ),
+                            map( ProtocolConstants.MINECRAFT_1_9, 0x0E ),
+                            map( ProtocolConstants.MINECRAFT_1_13, 0x10 ),
+                            map( ProtocolConstants.MINECRAFT_1_15, 0x11 )
+                    );
+                    TO_CLIENT.registerPacket(
+                            ScoreboardObjective.class,
+                            map( ProtocolConstants.MINECRAFT_1_8, 0x3B ),
+                            map( ProtocolConstants.MINECRAFT_1_9, 0x3F ),
+                            map( ProtocolConstants.MINECRAFT_1_12, 0x41 ),
+                            map( ProtocolConstants.MINECRAFT_1_12_1, 0x42 ),
+                            map( ProtocolConstants.MINECRAFT_1_13, 0x45 ),
+                            map( ProtocolConstants.MINECRAFT_1_14, 0x49 ),
+                            map( ProtocolConstants.MINECRAFT_1_15, 0x4A )
+                    );
+                    TO_CLIENT.registerPacket(
+                            ScoreboardScore.class,
+                            map( ProtocolConstants.MINECRAFT_1_8, 0x3C ),
+                            map( ProtocolConstants.MINECRAFT_1_9, 0x42 ),
+                            map( ProtocolConstants.MINECRAFT_1_12, 0x44 ),
+                            map( ProtocolConstants.MINECRAFT_1_12_1, 0x45 ),
+                            map( ProtocolConstants.MINECRAFT_1_13, 0x48 ),
+                            map( ProtocolConstants.MINECRAFT_1_14, 0x4C ),
+                            map( ProtocolConstants.MINECRAFT_1_15, 0x4D )
+                    );
+                    TO_CLIENT.registerPacket(
+                            ScoreboardDisplay.class,
+                            map( ProtocolConstants.MINECRAFT_1_8, 0x3D ),
+                            map( ProtocolConstants.MINECRAFT_1_9, 0x38 ),
+                            map( ProtocolConstants.MINECRAFT_1_12, 0x3A ),
+                            map( ProtocolConstants.MINECRAFT_1_12_1, 0x3B ),
+                            map( ProtocolConstants.MINECRAFT_1_13, 0x3E ),
+                            map( ProtocolConstants.MINECRAFT_1_14, 0x42 ),
+                            map( ProtocolConstants.MINECRAFT_1_15, 0x43 )
+                    );
+                    TO_CLIENT.registerPacket(
+                            Team.class,
+                            map( ProtocolConstants.MINECRAFT_1_8, 0x3E ),
+                            map( ProtocolConstants.MINECRAFT_1_9, 0x41 ),
+                            map( ProtocolConstants.MINECRAFT_1_12, 0x43 ),
+                            map( ProtocolConstants.MINECRAFT_1_12_1, 0x44 ),
+                            map( ProtocolConstants.MINECRAFT_1_13, 0x47 ),
+                            map( ProtocolConstants.MINECRAFT_1_14, 0x4B ),
+                            map( ProtocolConstants.MINECRAFT_1_15, 0x4C )
+                    );
+                    TO_CLIENT.registerPacket(
+                            PluginMessage.class,
+                            map( ProtocolConstants.MINECRAFT_1_8, 0x3F ),
+                            map( ProtocolConstants.MINECRAFT_1_9, 0x18 ),
+                            map( ProtocolConstants.MINECRAFT_1_13, 0x19 ),
+                            map( ProtocolConstants.MINECRAFT_1_14, 0x18 ),
+                            map( ProtocolConstants.MINECRAFT_1_15, 0x19 )
+                    );
+                    TO_CLIENT.registerPacket(
+                            Kick.class,
+                            map( ProtocolConstants.MINECRAFT_1_8, 0x40 ),
+                            map( ProtocolConstants.MINECRAFT_1_9, 0x1A ),
+                            map( ProtocolConstants.MINECRAFT_1_13, 0x1B ),
+                            map( ProtocolConstants.MINECRAFT_1_14, 0x1A ),
+                            map( ProtocolConstants.MINECRAFT_1_15, 0x1B )
+                    );
+                    TO_CLIENT.registerPacket(
+                            Title.class,
+                            map( ProtocolConstants.MINECRAFT_1_8, 0x45 ),
+                            map( ProtocolConstants.MINECRAFT_1_12, 0x47 ),
+                            map( ProtocolConstants.MINECRAFT_1_12_1, 0x48 ),
+                            map( ProtocolConstants.MINECRAFT_1_13, 0x4B ),
+                            map( ProtocolConstants.MINECRAFT_1_14, 0x4F ),
+                            map( ProtocolConstants.MINECRAFT_1_15, 0x50 )
+                    );
+                    TO_CLIENT.registerPacket(
+                            PlayerListHeaderFooter.class,
+                            map( ProtocolConstants.MINECRAFT_1_8, 0x47 ),
+                            map( ProtocolConstants.MINECRAFT_1_9, 0x48 ),
+                            map( ProtocolConstants.MINECRAFT_1_9_4, 0x47 ),
+                            map( ProtocolConstants.MINECRAFT_1_12, 0x49 ),
+                            map( ProtocolConstants.MINECRAFT_1_12_1, 0x4A ),
+                            map( ProtocolConstants.MINECRAFT_1_13, 0x4E ),
+                            map( ProtocolConstants.MINECRAFT_1_14, 0x53 )
+                    );
+                    TO_CLIENT.registerPacket(
+                            EntityStatus.class,
+                            map( ProtocolConstants.MINECRAFT_1_8, 0x1A ),
+                            map( ProtocolConstants.MINECRAFT_1_9, 0x1B ),
+                            map( ProtocolConstants.MINECRAFT_1_13, 0x1C ),
+                            map( ProtocolConstants.MINECRAFT_1_14, 0x1B ),
+                            map( ProtocolConstants.MINECRAFT_1_15, 0x1C )
+                    );
+                    TO_CLIENT.registerPacket(
+                            Commands.class,
+                            map( ProtocolConstants.MINECRAFT_1_13, 0x11 )
+                    );
+                    TO_CLIENT.registerPacket(
+                            ViewDistance.class,
+                            map( ProtocolConstants.MINECRAFT_1_14, 0x41 ),
+                            map( ProtocolConstants.MINECRAFT_1_15, 0x42 )
+                    );
 
-            TO_SERVER.registerPacket(
-                    KeepAlive.class,
-                    map( ProtocolConstants.MINECRAFT_1_8, 0x00 ),
-                    map( ProtocolConstants.MINECRAFT_1_9, 0x0B ),
-                    map( ProtocolConstants.MINECRAFT_1_12, 0x0C ),
-                    map( ProtocolConstants.MINECRAFT_1_12_1, 0x0B ),
-                    map( ProtocolConstants.MINECRAFT_1_13, 0x0E ),
-                    map( ProtocolConstants.MINECRAFT_1_14, 0x0F )
-            );
-            TO_SERVER.registerPacket(
-                    Chat.class,
-                    map( ProtocolConstants.MINECRAFT_1_8, 0x01 ),
-                    map( ProtocolConstants.MINECRAFT_1_9, 0x02 ),
-                    map( ProtocolConstants.MINECRAFT_1_12, 0x03 ),
-                    map( ProtocolConstants.MINECRAFT_1_12_1, 0x02 ),
-                    map( ProtocolConstants.MINECRAFT_1_14, 0x03 )
-            );
-            TO_SERVER.registerPacket(
-                    TabCompleteRequest.class,
-                    map( ProtocolConstants.MINECRAFT_1_8, 0x14 ),
-                    map( ProtocolConstants.MINECRAFT_1_9, 0x01 ),
-                    map( ProtocolConstants.MINECRAFT_1_12, 0x02 ),
-                    map( ProtocolConstants.MINECRAFT_1_12_1, 0x01 ),
-                    map( ProtocolConstants.MINECRAFT_1_13, 0x05 ),
-                    map( ProtocolConstants.MINECRAFT_1_14, 0x06 )
-            );
-            TO_SERVER.registerPacket(
-                    ClientSettings.class,
-                    map( ProtocolConstants.MINECRAFT_1_8, 0x15 ),
-                    map( ProtocolConstants.MINECRAFT_1_9, 0x04 ),
-                    map( ProtocolConstants.MINECRAFT_1_12, 0x05 ),
-                    map( ProtocolConstants.MINECRAFT_1_12_1, 0x04 ),
-                    map( ProtocolConstants.MINECRAFT_1_14, 0x05 )
-            );
-            TO_SERVER.registerPacket(
-                    PluginMessage.class,
-                    map( ProtocolConstants.MINECRAFT_1_8, 0x17 ),
-                    map( ProtocolConstants.MINECRAFT_1_9, 0x09 ),
-                    map( ProtocolConstants.MINECRAFT_1_12, 0x0A ),
-                    map( ProtocolConstants.MINECRAFT_1_12_1, 0x09 ),
-                    map( ProtocolConstants.MINECRAFT_1_13, 0x0A ),
-                    map( ProtocolConstants.MINECRAFT_1_14, 0x0B )
-            );
-        }
-    },
+                    TO_SERVER.registerPacket(
+                            KeepAlive.class,
+                            map( ProtocolConstants.MINECRAFT_1_8, 0x00 ),
+                            map( ProtocolConstants.MINECRAFT_1_9, 0x0B ),
+                            map( ProtocolConstants.MINECRAFT_1_12, 0x0C ),
+                            map( ProtocolConstants.MINECRAFT_1_12_1, 0x0B ),
+                            map( ProtocolConstants.MINECRAFT_1_13, 0x0E ),
+                            map( ProtocolConstants.MINECRAFT_1_14, 0x0F )
+                    );
+                    TO_SERVER.registerPacket(
+                            Chat.class,
+                            map( ProtocolConstants.MINECRAFT_1_8, 0x01 ),
+                            map( ProtocolConstants.MINECRAFT_1_9, 0x02 ),
+                            map( ProtocolConstants.MINECRAFT_1_12, 0x03 ),
+                            map( ProtocolConstants.MINECRAFT_1_12_1, 0x02 ),
+                            map( ProtocolConstants.MINECRAFT_1_14, 0x03 )
+                    );
+                    TO_SERVER.registerPacket(
+                            TabCompleteRequest.class,
+                            map( ProtocolConstants.MINECRAFT_1_8, 0x14 ),
+                            map( ProtocolConstants.MINECRAFT_1_9, 0x01 ),
+                            map( ProtocolConstants.MINECRAFT_1_12, 0x02 ),
+                            map( ProtocolConstants.MINECRAFT_1_12_1, 0x01 ),
+                            map( ProtocolConstants.MINECRAFT_1_13, 0x05 ),
+                            map( ProtocolConstants.MINECRAFT_1_14, 0x06 )
+                    );
+                    TO_SERVER.registerPacket(
+                            ClientSettings.class,
+                            map( ProtocolConstants.MINECRAFT_1_8, 0x15 ),
+                            map( ProtocolConstants.MINECRAFT_1_9, 0x04 ),
+                            map( ProtocolConstants.MINECRAFT_1_12, 0x05 ),
+                            map( ProtocolConstants.MINECRAFT_1_12_1, 0x04 ),
+                            map( ProtocolConstants.MINECRAFT_1_14, 0x05 )
+                    );
+                    TO_SERVER.registerPacket(
+                            PluginMessage.class,
+                            map( ProtocolConstants.MINECRAFT_1_8, 0x17 ),
+                            map( ProtocolConstants.MINECRAFT_1_9, 0x09 ),
+                            map( ProtocolConstants.MINECRAFT_1_12, 0x0A ),
+                            map( ProtocolConstants.MINECRAFT_1_12_1, 0x09 ),
+                            map( ProtocolConstants.MINECRAFT_1_13, 0x0A ),
+                            map( ProtocolConstants.MINECRAFT_1_14, 0x0B )
+                    );
+                }
+            },
     // 1
     STATUS
-    {
+            {
 
-        {
-            TO_CLIENT.registerPacket(
-                    StatusResponse.class,
-                    map( ProtocolConstants.MINECRAFT_1_8, 0x00 )
-            );
-            TO_CLIENT.registerPacket(
-                    PingPacket.class,
-                    map( ProtocolConstants.MINECRAFT_1_8, 0x01 )
-            );
+                {
+                    TO_CLIENT.registerPacket(
+                            StatusResponse.class,
+                            map( ProtocolConstants.MINECRAFT_1_8, 0x00 )
+                    );
+                    TO_CLIENT.registerPacket(
+                            PingPacket.class,
+                            map( ProtocolConstants.MINECRAFT_1_8, 0x01 )
+                    );
 
-            TO_SERVER.registerPacket(
-                    StatusRequest.class,
-                    map( ProtocolConstants.MINECRAFT_1_8, 0x00 )
-            );
-            TO_SERVER.registerPacket(
-                    PingPacket.class,
-                    map( ProtocolConstants.MINECRAFT_1_8, 0x01 )
-            );
-        }
-    },
+                    TO_SERVER.registerPacket(
+                            StatusRequest.class,
+                            map( ProtocolConstants.MINECRAFT_1_8, 0x00 )
+                    );
+                    TO_SERVER.registerPacket(
+                            PingPacket.class,
+                            map( ProtocolConstants.MINECRAFT_1_8, 0x01 )
+                    );
+                }
+            },
     //2
     LOGIN
-    {
+            {
 
-        {
-            TO_CLIENT.registerPacket(
-                    Kick.class,
-                    map( ProtocolConstants.MINECRAFT_1_8, 0x00 )
-            );
-            TO_CLIENT.registerPacket(
-                    EncryptionRequest.class,
-                    map( ProtocolConstants.MINECRAFT_1_8, 0x01 )
-            );
-            TO_CLIENT.registerPacket(
-                    LoginSuccess.class,
-                    map( ProtocolConstants.MINECRAFT_1_8, 0x02 )
-            );
-            TO_CLIENT.registerPacket(
-                    SetCompression.class,
-                    map( ProtocolConstants.MINECRAFT_1_8, 0x03 )
-            );
-            TO_CLIENT.registerPacket(
-                    LoginPayloadRequest.class,
-                    map( ProtocolConstants.MINECRAFT_1_13, 0x04 )
-            );
+                {
+                    TO_CLIENT.registerPacket(
+                            Kick.class,
+                            map( ProtocolConstants.MINECRAFT_1_8, 0x00 )
+                    );
+                    TO_CLIENT.registerPacket(
+                            EncryptionRequest.class,
+                            map( ProtocolConstants.MINECRAFT_1_8, 0x01 )
+                    );
+                    TO_CLIENT.registerPacket(
+                            LoginSuccess.class,
+                            map( ProtocolConstants.MINECRAFT_1_8, 0x02 )
+                    );
+                    TO_CLIENT.registerPacket(
+                            SetCompression.class,
+                            map( ProtocolConstants.MINECRAFT_1_8, 0x03 )
+                    );
+                    TO_CLIENT.registerPacket(
+                            LoginPayloadRequest.class,
+                            map( ProtocolConstants.MINECRAFT_1_13, 0x04 )
+                    );
 
-            TO_SERVER.registerPacket(
-                    LoginRequest.class,
-                    map( ProtocolConstants.MINECRAFT_1_8, 0x00 )
-            );
-            TO_SERVER.registerPacket(
-                    EncryptionResponse.class,
-                    map( ProtocolConstants.MINECRAFT_1_8, 0x01 )
-            );
-            TO_SERVER.registerPacket(
-                    LoginPayloadResponse.class,
-                    map( ProtocolConstants.MINECRAFT_1_13, 0x02 )
-            );
-        }
-    };
+                    TO_SERVER.registerPacket(
+                            LoginRequest.class,
+                            map( ProtocolConstants.MINECRAFT_1_8, 0x00 )
+                    );
+                    TO_SERVER.registerPacket(
+                            EncryptionResponse.class,
+                            map( ProtocolConstants.MINECRAFT_1_8, 0x01 )
+                    );
+                    TO_SERVER.registerPacket(
+                            LoginPayloadResponse.class,
+                            map( ProtocolConstants.MINECRAFT_1_13, 0x02 )
+                    );
+                }
+            };
     /*========================================================================*/
     public static final int MAX_PACKET_ID = 0xFF;
     /*========================================================================*/
@@ -345,7 +362,7 @@ public enum Protocol
 
         private final int protocolVersion;
         private final TObjectIntMap<Class<? extends DefinedPacket>> packetMap = new TObjectIntHashMap<>( MAX_PACKET_ID );
-        private final Constructor<? extends DefinedPacket>[] packetConstructors = new Constructor[ MAX_PACKET_ID ];
+        private final Constructor<? extends DefinedPacket>[] packetConstructors = new Constructor[MAX_PACKET_ID];
     }
 
     @Data
@@ -385,7 +402,7 @@ public enum Protocol
         private ProtocolData getProtocolData(int version)
         {
             ProtocolData protocol = protocols.get( version );
-            if ( protocol == null && ( protocolPhase != Protocol.GAME ) )
+            if ( protocol == null && (protocolPhase != Protocol.GAME) )
             {
                 protocol = Iterables.getFirst( protocols.valueCollection(), null );
             }
@@ -407,7 +424,7 @@ public enum Protocol
             Constructor<? extends DefinedPacket> constructor = protocolData.packetConstructors[id];
             try
             {
-                return ( constructor == null ) ? null : constructor.newInstance();
+                return (constructor == null) ? null : constructor.newInstance();
             } catch ( ReflectiveOperationException ex )
             {
                 throw new BadPacketException( "Could not construct packet with id " + id, ex );

--- a/protocol/src/main/java/net/md_5/bungee/protocol/ProtocolConstants.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/ProtocolConstants.java
@@ -3,8 +3,7 @@ package net.md_5.bungee.protocol;
 import java.util.Arrays;
 import java.util.List;
 
-public class ProtocolConstants
-{
+public class ProtocolConstants {
 
     public static final int MINECRAFT_1_8 = 47;
     public static final int MINECRAFT_1_9 = 107;
@@ -25,6 +24,7 @@ public class ProtocolConstants
     public static final int MINECRAFT_1_14_2 = 485;
     public static final int MINECRAFT_1_14_3 = 490;
     public static final int MINECRAFT_1_14_4 = 498;
+    public static final int MINECRAFT_1_15 = 573;
     public static final List<String> SUPPORTED_VERSIONS = Arrays.asList(
             "1.8.x",
             "1.9.x",
@@ -32,7 +32,8 @@ public class ProtocolConstants
             "1.11.x",
             "1.12.x",
             "1.13.x",
-            "1.14.x"
+            "1.14.x",
+            "1.15.x"
     );
     public static final List<Integer> SUPPORTED_VERSION_IDS = Arrays.asList(
             ProtocolConstants.MINECRAFT_1_8,
@@ -53,11 +54,11 @@ public class ProtocolConstants
             ProtocolConstants.MINECRAFT_1_14_1,
             ProtocolConstants.MINECRAFT_1_14_2,
             ProtocolConstants.MINECRAFT_1_14_3,
-            ProtocolConstants.MINECRAFT_1_14_4
+            ProtocolConstants.MINECRAFT_1_14_4,
+            ProtocolConstants.MINECRAFT_1_15
     );
 
-    public enum Direction
-    {
+    public enum Direction {
 
         TO_CLIENT, TO_SERVER;
     }

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/Login.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/Login.java
@@ -19,11 +19,13 @@ public class Login extends DefinedPacket
     private int entityId;
     private short gameMode;
     private int dimension;
+    private long hashedSeed;
     private short difficulty;
     private short maxPlayers;
     private String levelType;
     private int viewDistance;
     private boolean reducedDebugInfo;
+    private boolean enableRespawnScreen;
 
     @Override
     public void read(ByteBuf buf, ProtocolConstants.Direction direction, int protocolVersion)
@@ -40,6 +42,9 @@ public class Login extends DefinedPacket
         if ( protocolVersion < ProtocolConstants.MINECRAFT_1_14 )
         {
             difficulty = buf.readUnsignedByte();
+        } else if ( protocolVersion >= ProtocolConstants.MINECRAFT_1_15 )
+        {
+            hashedSeed = buf.readLong();
         }
         maxPlayers = buf.readUnsignedByte();
         levelType = readString( buf );
@@ -50,6 +55,10 @@ public class Login extends DefinedPacket
         if ( protocolVersion >= 29 )
         {
             reducedDebugInfo = buf.readBoolean();
+        }
+        if ( protocolVersion >= ProtocolConstants.MINECRAFT_1_15 )
+        {
+            enableRespawnScreen = buf.readBoolean();
         }
     }
 
@@ -68,6 +77,9 @@ public class Login extends DefinedPacket
         if ( protocolVersion < ProtocolConstants.MINECRAFT_1_14 )
         {
             buf.writeByte( difficulty );
+        } else if ( protocolVersion >= ProtocolConstants.MINECRAFT_1_15 )
+        {
+            buf.writeLong( hashedSeed );
         }
         buf.writeByte( maxPlayers );
         writeString( levelType, buf );
@@ -78,6 +90,10 @@ public class Login extends DefinedPacket
         if ( protocolVersion >= 29 )
         {
             buf.writeBoolean( reducedDebugInfo );
+        }
+        if ( protocolVersion >= ProtocolConstants.MINECRAFT_1_15 )
+        {
+            buf.writeBoolean( enableRespawnScreen );
         }
     }
 

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/Respawn.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/Respawn.java
@@ -19,6 +19,7 @@ public class Respawn extends DefinedPacket
     private int dimension;
     private short difficulty;
     private short gameMode;
+    private long hashedSeed;
     private String levelType;
 
     @Override
@@ -28,6 +29,9 @@ public class Respawn extends DefinedPacket
         if ( protocolVersion < ProtocolConstants.MINECRAFT_1_14 )
         {
             difficulty = buf.readUnsignedByte();
+        } else if ( protocolVersion >= ProtocolConstants.MINECRAFT_1_15 )
+        {
+            hashedSeed = buf.readLong();
         }
         gameMode = buf.readUnsignedByte();
         levelType = readString( buf );
@@ -40,6 +44,9 @@ public class Respawn extends DefinedPacket
         if ( protocolVersion < ProtocolConstants.MINECRAFT_1_14 )
         {
             buf.writeByte( difficulty );
+        } else if ( protocolVersion >= ProtocolConstants.MINECRAFT_1_15 )
+        {
+            buf.writeLong( hashedSeed );
         }
         buf.writeByte( gameMode );
         writeString( levelType, buf );

--- a/proxy/src/main/java/net/md_5/bungee/PacketConstants.java
+++ b/proxy/src/main/java/net/md_5/bungee/PacketConstants.java
@@ -7,8 +7,8 @@ import net.md_5.bungee.protocol.packet.Respawn;
 public class PacketConstants
 {
 
-    public static final Respawn DIM1_SWITCH = new Respawn( (byte) 1, (byte) 0, (byte) 0, "default" );
-    public static final Respawn DIM2_SWITCH = new Respawn( (byte) -1, (byte) 0, (byte) 0, "default" );
+    public static final Respawn DIM1_SWITCH = new Respawn( (byte) 1, (byte) 0, (byte) 0, -1, "default");
+    public static final Respawn DIM2_SWITCH = new Respawn( (byte) -1, (byte) 0, (byte) 0, -1, "default" );
     public static final ClientStatus CLIENT_LOGIN = new ClientStatus( (byte) 0 );
     public static final PluginMessage FORGE_MOD_REQUEST = new PluginMessage( "FML", new byte[]
     {

--- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
+++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
@@ -210,8 +210,8 @@ public class ServerConnector extends PacketHandler
             user.setServerEntityId( login.getEntityId() );
 
             // Set tab list size, TODO: what shall we do about packet mutability
-            Login modLogin = new Login( login.getEntityId(), login.getGameMode(), (byte) login.getDimension(), login.getDifficulty(),
-                    (byte) user.getPendingConnection().getListener().getTabListSize(), login.getLevelType(), login.getViewDistance(), login.isReducedDebugInfo() );
+            Login modLogin = new Login( login.getEntityId(), login.getGameMode(), (byte) login.getDimension(), login.getHashedSeed(), login.getDifficulty(),
+                    (byte) user.getPendingConnection().getListener().getTabListSize(), login.getLevelType(), login.getViewDistance(), login.isReducedDebugInfo(), login.isEnableRespawnScreen());
 
             user.unsafe().sendPacket( modLogin );
 
@@ -254,11 +254,11 @@ public class ServerConnector extends PacketHandler
             user.setDimensionChange( true );
             if ( login.getDimension() == user.getDimension() )
             {
-                user.unsafe().sendPacket( new Respawn( ( login.getDimension() >= 0 ? -1 : 0 ), login.getDifficulty(), login.getGameMode(), login.getLevelType() ) );
+                user.unsafe().sendPacket( new Respawn( ( login.getDimension() >= 0 ? -1 : 0 ), login.getDifficulty(), login.getGameMode(), login.getHashedSeed(), login.getLevelType() ) );
             }
 
             user.setServerEntityId( login.getEntityId() );
-            user.unsafe().sendPacket( new Respawn( login.getDimension(), login.getDifficulty(), login.getGameMode(), login.getLevelType() ) );
+            user.unsafe().sendPacket( new Respawn( login.getDimension(), login.getDifficulty(), login.getGameMode(), login.getHashedSeed(), login.getLevelType() ) );
             if ( user.getPendingConnection().getVersion() >= ProtocolConstants.MINECRAFT_1_14 )
             {
                 user.unsafe().sendPacket( new ViewDistance( login.getViewDistance() ) );

--- a/proxy/src/main/java/net/md_5/bungee/entitymap/EntityMap.java
+++ b/proxy/src/main/java/net/md_5/bungee/entitymap/EntityMap.java
@@ -5,11 +5,12 @@ import com.google.common.base.Throwables;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufInputStream;
-import java.io.IOException;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import net.md_5.bungee.protocol.DefinedPacket;
 import net.md_5.bungee.protocol.ProtocolConstants;
+
+import java.io.IOException;
 
 /**
  * Class to rewrite integers within packets.
@@ -57,6 +58,8 @@ public abstract class EntityMap
             case ProtocolConstants.MINECRAFT_1_14_3:
             case ProtocolConstants.MINECRAFT_1_14_4:
                 return EntityMap_1_14.INSTANCE;
+            case ProtocolConstants.MINECRAFT_1_15:
+                return EntityMap_1_15.INSTANCE;
         }
         throw new RuntimeException( "Version " + version + " has no entity map" );
     }
@@ -67,17 +70,17 @@ public abstract class EntityMap
         {
             if ( varint )
             {
-                clientboundVarInts[id] = true;
+                clientboundVarInts[ id ] = true;
             } else
             {
-                clientboundInts[id] = true;
+                clientboundInts[ id ] = true;
             }
         } else if ( varint )
         {
-            serverboundVarInts[id] = true;
+            serverboundVarInts[ id ] = true;
         } else
         {
-            serverboundInts[id] = true;
+            serverboundInts[ id ] = true;
         }
     }
 
@@ -140,7 +143,7 @@ public abstract class EntityMap
         int readerIndex = packet.readerIndex();
 
         short index;
-        while ( ( index = packet.readUnsignedByte() ) != 0xFF )
+        while ( (index = packet.readUnsignedByte()) != 0xFF )
         {
             int type = DefinedPacket.readVarInt( packet );
             if ( protocolVersion >= ProtocolConstants.MINECRAFT_1_13 )
@@ -284,13 +287,13 @@ public abstract class EntityMap
 
     private static void readSkipSlot(ByteBuf packet, int protocolVersion)
     {
-        if ( ( protocolVersion >= ProtocolConstants.MINECRAFT_1_13_2 ) ? packet.readBoolean() : packet.readShort() != -1 )
+        if ( (protocolVersion >= ProtocolConstants.MINECRAFT_1_13_2) ? packet.readBoolean() : packet.readShort() != -1 )
         {
             if ( protocolVersion >= ProtocolConstants.MINECRAFT_1_13_2 )
             {
                 DefinedPacket.readVarInt( packet );
             }
-            packet.skipBytes( ( protocolVersion >= ProtocolConstants.MINECRAFT_1_13 ) ? 1 : 3 ); // byte vs byte, short
+            packet.skipBytes( (protocolVersion >= ProtocolConstants.MINECRAFT_1_13) ? 1 : 3 ); // byte vs byte, short
 
             int position = packet.readerIndex();
             if ( packet.readByte() != 0 )
@@ -315,10 +318,10 @@ public abstract class EntityMap
         int packetId = DefinedPacket.readVarInt( packet );
         int packetIdLength = packet.readerIndex() - readerIndex;
 
-        if ( ints[packetId] )
+        if ( ints[ packetId ] )
         {
             rewriteInt( packet, oldId, newId, readerIndex + packetIdLength );
-        } else if ( varints[packetId] )
+        } else if ( varints[ packetId ] )
         {
             rewriteVarInt( packet, oldId, newId, readerIndex + packetIdLength );
         }

--- a/proxy/src/main/java/net/md_5/bungee/entitymap/EntityMap.java
+++ b/proxy/src/main/java/net/md_5/bungee/entitymap/EntityMap.java
@@ -5,12 +5,11 @@ import com.google.common.base.Throwables;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufInputStream;
+import java.io.IOException;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import net.md_5.bungee.protocol.DefinedPacket;
 import net.md_5.bungee.protocol.ProtocolConstants;
-
-import java.io.IOException;
 
 /**
  * Class to rewrite integers within packets.

--- a/proxy/src/main/java/net/md_5/bungee/entitymap/EntityMap_1_15.java
+++ b/proxy/src/main/java/net/md_5/bungee/entitymap/EntityMap_1_15.java
@@ -2,13 +2,12 @@ package net.md_5.bungee.entitymap;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.netty.buffer.ByteBuf;
+import java.util.UUID;
 import net.md_5.bungee.BungeeCord;
 import net.md_5.bungee.UserConnection;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.protocol.DefinedPacket;
 import net.md_5.bungee.protocol.ProtocolConstants;
-
-import java.util.UUID;
 
 class EntityMap_1_15 extends EntityMap
 {

--- a/proxy/src/main/java/net/md_5/bungee/entitymap/EntityMap_1_15.java
+++ b/proxy/src/main/java/net/md_5/bungee/entitymap/EntityMap_1_15.java
@@ -1,0 +1,187 @@
+package net.md_5.bungee.entitymap;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.netty.buffer.ByteBuf;
+import net.md_5.bungee.BungeeCord;
+import net.md_5.bungee.UserConnection;
+import net.md_5.bungee.api.connection.ProxiedPlayer;
+import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.protocol.ProtocolConstants;
+
+import java.util.UUID;
+
+class EntityMap_1_15 extends EntityMap
+{
+
+    static final EntityMap_1_15 INSTANCE = new EntityMap_1_15();
+
+    EntityMap_1_15()
+    {
+        addRewrite( 0x00, ProtocolConstants.Direction.TO_CLIENT, true ); // Spawn Object : PacketPlayOutSpawnEntity
+        addRewrite( 0x01, ProtocolConstants.Direction.TO_CLIENT, true ); // Spawn Experience Orb : PacketPlayOutSpawnEntityExperienceOrb
+        addRewrite( 0x03, ProtocolConstants.Direction.TO_CLIENT, true ); // Spawn Mob : PacketPlayOutSpawnEntityLiving
+        addRewrite( 0x04, ProtocolConstants.Direction.TO_CLIENT, true ); // Spawn Painting : PacketPlayOutSpawnEntityPainting
+        addRewrite( 0x05, ProtocolConstants.Direction.TO_CLIENT, true ); // Spawn Player : PacketPlayOutNamedEntitySpawn
+        addRewrite( 0x06, ProtocolConstants.Direction.TO_CLIENT, true ); // Animation : PacketPlayOutAnimation
+        addRewrite( 0x09, ProtocolConstants.Direction.TO_CLIENT, true ); // Block Break Animation : PacketPlayOutBlockBreakAnimation
+        addRewrite( 0x1C, ProtocolConstants.Direction.TO_CLIENT, false ); // Entity Status : PacketPlayOutEntityStatus
+        addRewrite( 0x29, ProtocolConstants.Direction.TO_CLIENT, true ); // Entity Relative Move : PacketPlayOutRelEntityMove
+        addRewrite( 0x2A, ProtocolConstants.Direction.TO_CLIENT, true ); // Entity Look and Relative Move : PacketPlayOutRelEntityMoveLook
+        addRewrite( 0x2B, ProtocolConstants.Direction.TO_CLIENT, true ); // Entity Look : PacketPlayOutEntityLook
+        addRewrite( 0x2C, ProtocolConstants.Direction.TO_CLIENT, true ); // Entity : PacketPlayOutEntity
+        addRewrite( 0x39, ProtocolConstants.Direction.TO_CLIENT, true ); // Remove Entity Effect : PacketPlayOutRemoveEntityEffect
+        addRewrite( 0x3C, ProtocolConstants.Direction.TO_CLIENT, true ); // Entity Head Look : PacketPlayOutEntityHeadRotation
+        addRewrite( 0x3F, ProtocolConstants.Direction.TO_CLIENT, true ); // Camera : PacketPlayOutCamera
+        addRewrite( 0x44, ProtocolConstants.Direction.TO_CLIENT, true ); // Entity Metadata : PacketPlayOutEntityMetadata
+        addRewrite( 0x45, ProtocolConstants.Direction.TO_CLIENT, false ); // Attach Entity : PacketPlayOutAttachEntity
+        addRewrite( 0x46, ProtocolConstants.Direction.TO_CLIENT, true ); // Entity Velocity : PacketPlayOutEntityVelocity
+        addRewrite( 0x47, ProtocolConstants.Direction.TO_CLIENT, true ); // Entity Equipment : PacketPlayOutEntityEquipment
+        addRewrite( 0x4B, ProtocolConstants.Direction.TO_CLIENT, true ); // Set Passengers : PacketPlayOutMount
+        addRewrite( 0x56, ProtocolConstants.Direction.TO_CLIENT, true ); // Collect Item : PacketPlayOutCollect
+        addRewrite( 0x57, ProtocolConstants.Direction.TO_CLIENT, true ); // Entity Teleport : PacketPlayOutEntityTeleport
+        addRewrite( 0x59, ProtocolConstants.Direction.TO_CLIENT, true ); // Entity Properties : PacketPlayOutUpdateAttributes
+        addRewrite( 0x5A, ProtocolConstants.Direction.TO_CLIENT, true ); // Entity Effect : PacketPlayOutEntityEffect
+
+        addRewrite( 0x0E, ProtocolConstants.Direction.TO_SERVER, true ); // Use Entity : PacketPlayInUseEntity
+        addRewrite( 0x1C, ProtocolConstants.Direction.TO_SERVER, true ); // Entity Action : PacketPlayInEntityAction
+    }
+
+    @Override
+    @SuppressFBWarnings("DLS_DEAD_LOCAL_STORE")
+    public void rewriteClientbound(ByteBuf packet, int oldId, int newId, int protocolVersion)
+    {
+        super.rewriteClientbound( packet, oldId, newId );
+
+        // Special cases
+        int readerIndex = packet.readerIndex();
+        int packetId = DefinedPacket.readVarInt( packet );
+        int packetIdLength = packet.readerIndex() - readerIndex;
+        int jumpIndex = packet.readerIndex();
+        switch ( packetId )
+        {
+            case 0x45 /* Attach Entity : PacketPlayOutAttachEntity */:
+                rewriteInt( packet, oldId, newId, readerIndex + packetIdLength + 4 );
+                break;
+            case 0x56 /* Collect Item : PacketPlayOutCollect */:
+                DefinedPacket.readVarInt( packet );
+                rewriteVarInt( packet, oldId, newId, packet.readerIndex() );
+                break;
+            case 0x4B /* Set Passengers : PacketPlayOutMount */:
+                DefinedPacket.readVarInt( packet );
+                jumpIndex = packet.readerIndex();
+                // Fall through on purpose to int array of IDs
+            case 0x38 /* Destroy Entities : PacketPlayOutEntityDestroy */:
+                int count = DefinedPacket.readVarInt( packet );
+                int[] ids = new int[ count ];
+                for ( int i = 0; i < count; i++ )
+                {
+                    ids[ i ] = DefinedPacket.readVarInt( packet );
+                }
+                packet.readerIndex( jumpIndex );
+                packet.writerIndex( jumpIndex );
+                DefinedPacket.writeVarInt( count, packet );
+                for ( int id : ids )
+                {
+                    if ( id == oldId )
+                    {
+                        id = newId;
+                    } else if ( id == newId )
+                    {
+                        id = oldId;
+                    }
+                    DefinedPacket.writeVarInt( id, packet );
+                }
+                break;
+            case 0x00 /* Spawn Object : PacketPlayOutSpawnEntity */:
+                DefinedPacket.readVarInt( packet );
+                DefinedPacket.readUUID( packet );
+                int type = DefinedPacket.readVarInt( packet );
+
+                if ( type == 2 || type == 101 || type == 71 ) // arrow, fishing_bobber or spectral_arrow
+                {
+                    if ( type == 2 || type == 71 ) // arrow or spectral_arrow
+                    {
+                        oldId = oldId + 1;
+                        newId = newId + 1;
+                    }
+
+                    packet.skipBytes( 26 ); // double, double, double, byte, byte
+                    int position = packet.readerIndex();
+                    int readId = packet.readInt();
+                    if ( readId == oldId )
+                    {
+                        packet.setInt( position, newId );
+                    } else if ( readId == newId )
+                    {
+                        packet.setInt( position, oldId );
+                    }
+                }
+                break;
+            case 0x05 /* Spawn Player : PacketPlayOutNamedEntitySpawn */:
+                DefinedPacket.readVarInt( packet ); // Entity ID
+                int idLength = packet.readerIndex() - readerIndex - packetIdLength;
+                UUID uuid = DefinedPacket.readUUID( packet );
+                ProxiedPlayer player;
+                if ( (player = BungeeCord.getInstance().getPlayerByOfflineUUID( uuid )) != null )
+                {
+                    int previous = packet.writerIndex();
+                    packet.readerIndex( readerIndex );
+                    packet.writerIndex( readerIndex + packetIdLength + idLength );
+                    DefinedPacket.writeUUID( player.getUniqueId(), packet );
+                    packet.writerIndex( previous );
+                }
+                break;
+            case 0x33 /* Combat Event : PacketPlayOutCombatEvent */:
+                int event = packet.readUnsignedByte();
+                if ( event == 1 /* End Combat*/ )
+                {
+                    DefinedPacket.readVarInt( packet );
+                    rewriteInt( packet, oldId, newId, packet.readerIndex() );
+                } else if ( event == 2 /* Entity Dead */ )
+                {
+                    int position = packet.readerIndex();
+                    rewriteVarInt( packet, oldId, newId, packet.readerIndex() );
+                    packet.readerIndex( position );
+                    DefinedPacket.readVarInt( packet );
+                    rewriteInt( packet, oldId, newId, packet.readerIndex() );
+                }
+                break;
+            case 0x44 /* EntityMetadata : PacketPlayOutEntityMetadata */:
+                DefinedPacket.readVarInt( packet ); // Entity ID
+                rewriteMetaVarInt( packet, oldId + 1, newId + 1, 7, protocolVersion ); // fishing hook
+                rewriteMetaVarInt( packet, oldId, newId, 8, protocolVersion ); // fireworks (et al)
+                break;
+            case 0x51 /* Entity Sound Effect : PacketPlayOutEntitySound */:
+                DefinedPacket.readVarInt( packet );
+                DefinedPacket.readVarInt( packet );
+                rewriteVarInt( packet, oldId, newId, packet.readerIndex() );
+                break;
+        }
+        packet.readerIndex( readerIndex );
+    }
+
+    @Override
+    public void rewriteServerbound(ByteBuf packet, int oldId, int newId)
+    {
+        super.rewriteServerbound( packet, oldId, newId );
+        // Special cases
+        int readerIndex = packet.readerIndex();
+        int packetId = DefinedPacket.readVarInt( packet );
+        int packetIdLength = packet.readerIndex() - readerIndex;
+
+        if ( packetId == 0x2B /* Spectate : PacketPlayInSpectate */ && !BungeeCord.getInstance().getConfig().isIpForward() )
+        {
+            UUID uuid = DefinedPacket.readUUID( packet );
+            ProxiedPlayer player;
+            if ( (player = BungeeCord.getInstance().getPlayer( uuid )) != null )
+            {
+                int previous = packet.writerIndex();
+                packet.readerIndex( readerIndex );
+                packet.writerIndex( readerIndex + packetIdLength );
+                DefinedPacket.writeUUID( ((UserConnection) player).getPendingConnection().getOfflineId(), packet );
+                packet.writerIndex( previous );
+            }
+        }
+        packet.readerIndex( readerIndex );
+    }
+}


### PR DESCRIPTION
This PR adds support for the Minecraft 1.15 protocol.
I added the new protocol version (573) and created a new EntityMap for 1.15 and changed all the modified packet ids according to https://wiki.vg/Pre-release_protocol.
Modifying the packet rewriting was not necessary.
I also added the new properties to the Login and Respawn packet.

I'm not entirely sure if everything works, this might need more testing.
