### PR TITLE
Do not add empty completions

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
@@ -191,6 +191,10 @@ public class PluginManager
             {
                 for ( String s : ( (TabExecutor) command ).onTabComplete( sender, args ) )
                 {
+                    if ( s.isEmpty() )
+                    {
+                        continue;
+                    }
                     tabResults.add( s );
                 }
             }


### PR DESCRIPTION
This commit fixes https://github.com/aikar/commands/issues/243 .
Some people will ask why not opening a PR in ACF to fix it there? Because in general, BungeeCord shouldn't be adding empty completions!