### PR TITLE
Fix TranslatableComponent.deserialize()

### DIFF
--- a/chat/src/main/java/net/md_5/bungee/chat/TranslatableComponentSerializer.java
+++ b/chat/src/main/java/net/md_5/bungee/chat/TranslatableComponentSerializer.java
@@ -24,7 +24,7 @@ public class TranslatableComponentSerializer extends BaseComponentSerializer imp
         component.setTranslate( object.get( "translate" ).getAsString() );
         if ( object.has( "with" ) )
         {
-            component.setWith( Arrays.asList( context.<BaseComponent>deserialize( object.get( "with" ), BaseComponent[].class ) ) );
+            component.setWith( Arrays.asList( context.<BaseComponent[]>deserialize( object.get( "with" ), BaseComponent[].class ) ) );
         }
         return component;
     }

--- a/chat/src/test/java/net/md_5/bungee/api/chat/TranslatableComponentTest.java
+++ b/chat/src/test/java/net/md_5/bungee/api/chat/TranslatableComponentTest.java
@@ -1,5 +1,6 @@
 package net.md_5.bungee.api.chat;
 
+import net.md_5.bungee.chat.ComponentSerializer;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -12,5 +13,16 @@ public class TranslatableComponentTest
         TranslatableComponent testComponent = new TranslatableComponent( "Test string with %s placeholders: %s", 2, "aoeu" );
         Assert.assertEquals( "Test string with 2 placeholders: aoeu", testComponent.toPlainText() );
         Assert.assertEquals( "§fTest string with §f2§f placeholders: §faoeu", testComponent.toLegacyText() );
+    }
+
+    @Test
+    public void testJsonSerialisation()
+    {
+        TranslatableComponent testComponent = new TranslatableComponent( "Test string with %s placeholder", "a" );
+        String jsonString = ComponentSerializer.toString( testComponent );
+        BaseComponent[] baseComponents = ComponentSerializer.parse( jsonString );
+
+        Assert.assertEquals( "Test string with a placeholder", TextComponent.toPlainText( baseComponents ) );
+        Assert.assertEquals( "§fTest string with §fa§f placeholder", TextComponent.toLegacyText( baseComponents ) );
     }
 }


### PR DESCRIPTION
TranslatableComponent.deserialize() is using the generic type BaseComponent instead of BaseComponent[], causing this exception to be thrown:

```
java.lang.ClassCastException: class [Lnet.md_5.bungee.api.chat.BaseComponent; cannot be cast to class net.md_5.bungee.api.chat.BaseComponent ([Lnet.md_5.bungee.api.chat.BaseComponent; and net.md_5.bungee.api.chat.BaseComponent are in unnamed module of loader 'app')
	at net.md_5.bungee.chat.TranslatableComponentSerializer.deserialize(TranslatableComponentSerializer.java:28)
	at net.md_5.bungee.chat.TranslatableComponentSerializer.deserialize(TranslatableComponentSerializer.java:15)
	at com.google.gson.internal.bind.TreeTypeAdapter.read(TreeTypeAdapter.java:69)
	at com.google.gson.Gson.fromJson(Gson.java:887)
	at com.google.gson.Gson.fromJson(Gson.java:952)
	at com.google.gson.internal.bind.TreeTypeAdapter$GsonContextImpl.deserialize(TreeTypeAdapter.java:162)
	at net.md_5.bungee.chat.ComponentSerializer.deserialize(ComponentSerializer.java:77)
	at net.md_5.bungee.chat.ComponentSerializer.deserialize(ComponentSerializer.java:20)
	at com.google.gson.internal.bind.TreeTypeAdapter.read(TreeTypeAdapter.java:69)
	at com.google.gson.Gson.fromJson(Gson.java:887)
	at com.google.gson.Gson.fromJson(Gson.java:952)
	at com.google.gson.Gson.fromJson(Gson.java:925)
	at net.md_5.bungee.chat.ComponentSerializer.parse(ComponentSerializer.java:46)
...

```

I added a test for this, too.