### PR TITLE
Added .flush() before close

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/netty/ChannelWrapper.java
+++ b/proxy/src/main/java/net/md_5/bungee/netty/ChannelWrapper.java
@@ -106,6 +106,7 @@ public class ChannelWrapper
             // Minecraft client can take some time to switch protocols.
             // Sending the wrong disconnect packet whilst a protocol switch is in progress will crash it.
             // Delay 250ms to ensure that the protocol switch (if any) has definitely taken place.
+            ch.flush();
             ch.eventLoop().schedule( new Runnable()
             {
 


### PR DESCRIPTION
This fixes "connection overload" caused by high rate of connections, for some reason they fully close after a couple of seconds without the flush method.

Btw i would like to have some feedback about the flush method. I dont know too much about netty. I just noticed this exploit got fixed by adding this when playing with BungeeCord code and testing.

If you are being attacked and you have a plugin like serverlistplus it will stop responding breaking the switch between servers and the console will show this: (Probably because the plugin is poorly made)
https://imgur.com/oQRR0zD

But without any plugins it will just stop responding. (Not being able to switch modes, joining, some players crashing, etc...)