### PR TITLE
Fix TextComponent with a single extra component

### DIFF
--- a/chat/src/main/java/net/md_5/bungee/api/chat/TextComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/TextComponent.java
@@ -173,27 +173,12 @@ public final class TextComponent extends BaseComponent
      */
     public TextComponent(BaseComponent... extras)
     {
+        this();
         if ( extras.length == 0 )
         {
             return;
         }
-        if ( extras.length == 1 && extras[0] instanceof TextComponent )
-        {
-            copyFormatting( extras[0], ComponentBuilder.FormatRetention.ALL, true );
-            setText( ( (TextComponent) extras[0] ).getText() );
-            List<BaseComponent> headExtra = extras[0].getExtra();
-            if ( headExtra != null )
-            {
-                for ( BaseComponent extra : headExtra )
-                {
-                    addExtra( extra.duplicate() );
-                }
-            }
-        } else
-        {
-            setText( "" );
-            setExtra( new ArrayList<BaseComponent>( Arrays.asList( extras ) ) );
-        }
+        setExtra( new ArrayList<BaseComponent>( Arrays.asList( extras ) ) );
     }
 
     /**

--- a/chat/src/main/java/net/md_5/bungee/api/chat/TextComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/TextComponent.java
@@ -179,6 +179,7 @@ public final class TextComponent extends BaseComponent
         }
         if ( extras.length == 1 && extras[0] instanceof TextComponent )
         {
+            copyFormatting( extras[0], ComponentBuilder.FormatRetention.ALL, true );
             setText( ( (TextComponent) extras[0] ).getText() );
             List<BaseComponent> headExtra = extras[0].getExtra();
             if ( headExtra != null )


### PR DESCRIPTION
The constructor TextComponent(BaseComponent... extras) doesn't retain the formatting and events when called with a single extra component. The fix is to call copyFormatting() explicitly.

Commit https://github.com/SpigotMC/BungeeCord/commit/d2ceccd646f33cedca614a9a58bfd84a44b28322 changed the behavior of this constructor to special case a single extra TextComponent. The PR https://github.com/SpigotMC/BungeeCord/pull/2725 doesn't state a reason for this change. @Mystiflow 

An alternative to this PR could be to just remove the special case.