### PR TITLE
Improved ping_cannot_connect ping info packet

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -207,7 +207,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
         return pos == -1 ? str : str.substring( 0, pos );
     }
 
-    private ServerPing getPingInfo( String motd, int protocol )
+    private ServerPing getPingInfo(String motd, int protocol)
     {
         return new ServerPing(
                 new ServerPing.Protocol( bungee.getName() + " " + bungee.getGameVersion(), protocol ),

--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -207,6 +207,14 @@ public class InitialHandler extends PacketHandler implements PendingConnection
         return pos == -1 ? str : str.substring( 0, pos );
     }
 
+    private ServerPing getPingInfo( String motd, int protocol )
+    {
+        new ServerPing(
+                new ServerPing.Protocol( bungee.getName() + " " + bungee.getGameVersion(), protocol ),
+                new ServerPing.Players( listener.getMaxPlayers(), bungee.getOnlineCount(), null ),
+                motd, BungeeCord.getInstance().config.getFaviconObject() );
+    }
+
     @Override
     public void handle(StatusRequest statusRequest) throws Exception
     {
@@ -214,6 +222,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
 
         ServerInfo forced = AbstractReconnectHandler.getForcedHost( this );
         final String motd = ( forced != null ) ? forced.getMotd() : listener.getMotd();
+        final int protocol = ( ProtocolConstants.SUPPORTED_VERSION_IDS.contains( handshake.getProtocolVersion() ) ) ? handshake.getProtocolVersion() : bungee.getProtocolVersion();
 
         Callback<ServerPing> pingBack = new Callback<ServerPing>()
         {
@@ -222,8 +231,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
             {
                 if ( error != null )
                 {
-                    result = new ServerPing();
-                    result.setDescription( bungee.getTranslation( "ping_cannot_connect" ) );
+                    result = getPingInfo( bungee.getTranslation( "ping_cannot_connect" ), protocol );
                     bungee.getLogger().log( Level.WARNING, "Error pinging remote server", error );
                 }
 
@@ -250,12 +258,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
             ( (BungeeServerInfo) forced ).ping( pingBack, handshake.getProtocolVersion() );
         } else
         {
-            int protocol = ( ProtocolConstants.SUPPORTED_VERSION_IDS.contains( handshake.getProtocolVersion() ) ) ? handshake.getProtocolVersion() : bungee.getProtocolVersion();
-            pingBack.done( new ServerPing(
-                    new ServerPing.Protocol( bungee.getName() + " " + bungee.getGameVersion(), protocol ),
-                    new ServerPing.Players( listener.getMaxPlayers(), bungee.getOnlineCount(), null ),
-                    motd, BungeeCord.getInstance().config.getFaviconObject() ),
-                    null );
+            pingBack.done( getPingInfo( motd, protocol ), null );
         }
 
         thisState = State.PING;

--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -209,7 +209,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
 
     private ServerPing getPingInfo( String motd, int protocol )
     {
-        new ServerPing(
+        return new ServerPing(
                 new ServerPing.Protocol( bungee.getName() + " " + bungee.getGameVersion(), protocol ),
                 new ServerPing.Players( listener.getMaxPlayers(), bungee.getOnlineCount(), null ),
                 motd, BungeeCord.getInstance().config.getFaviconObject() );


### PR DESCRIPTION
This PR makes failed pings from the client to the proxy show additional ping data from the proxy/: protocol info, player info (online/max) and the favicon of the proxy.

Previously the only info that was shown was in the MOTD as "ping_cannot_connect".