### PR TITLE
Adding ClientConnectEvent

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/event/ClientConnectEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/ClientConnectEvent.java
@@ -1,0 +1,32 @@
+package net.md_5.bungee.api.event;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import net.md_5.bungee.api.config.ListenerInfo;
+import net.md_5.bungee.api.plugin.Cancellable;
+import net.md_5.bungee.api.plugin.Event;
+
+/**
+ * Event called to represent initialization of connection.
+ */
+@Data
+@ToString(callSuper = false)
+@EqualsAndHashCode(callSuper = false)
+public class ClientConnectEvent extends Event implements Cancellable
+{
+
+    /**
+     * Cancelled state.
+     */
+    private boolean cancelled;
+    /**
+     * Remote Adderss of user.
+     */
+    private final ListenerInfo listenerInfo;
+
+    public ClientConnectEvent(ListenerInfo listenerInfo)
+    {
+        this.listenerInfo = listenerInfo;
+    }
+}

--- a/api/src/main/java/net/md_5/bungee/api/event/ClientConnectEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/ClientConnectEvent.java
@@ -1,5 +1,6 @@
 package net.md_5.bungee.api.event;
 
+import java.net.SocketAddress;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -23,10 +24,15 @@ public class ClientConnectEvent extends Event implements Cancellable
     /**
      * Remote Adderss of user.
      */
+    private final SocketAddress socketAddress;
+    /**
+     * ListenerInfo from this connection.
+     */
     private final ListenerInfo listenerInfo;
 
-    public ClientConnectEvent(ListenerInfo listenerInfo)
+    public ClientConnectEvent(SocketAddress socketAddress, ListenerInfo listenerInfo)
     {
+        this.socketAddress = socketAddress;
         this.listenerInfo = listenerInfo;
     }
 }

--- a/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java
+++ b/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java
@@ -36,6 +36,7 @@ import net.md_5.bungee.UserConnection;
 import net.md_5.bungee.Util;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.config.ListenerInfo;
+import net.md_5.bungee.api.event.ClientConnectEvent;
 import net.md_5.bungee.connection.InitialHandler;
 import net.md_5.bungee.protocol.KickStringWriter;
 import net.md_5.bungee.protocol.LegacyDecoder;
@@ -63,6 +64,13 @@ public class PipelineUtils
             }
 
             ListenerInfo listener = ch.attr( LISTENER ).get();
+
+            ClientConnectEvent clientConnectEvent = new ClientConnectEvent( listener );
+            if ( BungeeCord.getInstance().getPluginManager().callEvent( clientConnectEvent ).isCancelled() )
+            {
+                ch.close();
+                return;
+            }
 
             BASE.initChannel( ch );
             ch.pipeline().addBefore( FRAME_DECODER, LEGACY_DECODER, new LegacyDecoder() );

--- a/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java
+++ b/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java
@@ -65,7 +65,7 @@ public class PipelineUtils
 
             ListenerInfo listener = ch.attr( LISTENER ).get();
 
-            ClientConnectEvent clientConnectEvent = new ClientConnectEvent( listener );
+            ClientConnectEvent clientConnectEvent = new ClientConnectEvent( ch.remoteAddress(), listener );
             if ( BungeeCord.getInstance().getPluginManager().callEvent( clientConnectEvent ).isCancelled() )
             {
                 ch.close();


### PR DESCRIPTION
This is inspired by WaterfallMC ([ConnectionInitEvent.patch](https://github.com/PaperMC/Waterfall/blob/master/BungeeCord-Patches/0055-ConnectionInitEvent.patch))

Why should you accept this idea?
* you can create a filter which could block very early specific IPs (for geo blocking or ban systems)
* effective way to do some blocks or checks
* probably useful for stats (but not that neccessary)

(i hope the coding styles is correct)
(I can live with it if this merge request get's rejected.)