### PR TITLE
Handle posix signals SIGTERM, SIGINT, SIGHUP gracefully

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
@@ -400,7 +400,7 @@ public class BungeeCord extends ProxyServer
     }
 
     @Override
-    public synchronized void stop(final String reason)
+    public void stop(final String reason)
     {
         new Thread( "Shutdown Thread" )
         {

--- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
@@ -298,17 +298,17 @@ public class BungeeCord extends ProxyServer
         }, 0, TimeUnit.MINUTES.toMillis( 5 ) );
         metricsThread.scheduleAtFixedRate( new Metrics(), 0, TimeUnit.MINUTES.toMillis( Metrics.PING_INTERVAL ) );
 
-        Runtime.getRuntime().addShutdownHook( new Thread( new Runnable()
+        Runtime.getRuntime().addShutdownHook( new Thread()
         {
             @Override
             public void run()
             {
                 if ( isRunning )
                 {
-                    independantThreadStop( getTranslation( "restart" ) );
+                    independentThreadStop( getTranslation( "restart" ) );
                 }
             }
-        } ) );
+        } );
     }
 
     public void startListeners()
@@ -410,7 +410,7 @@ public class BungeeCord extends ProxyServer
             @Override
             public void run()
             {
-                independantThreadStop( reason );
+                independentThreadStop( reason );
                 System.exit( 0 );
             }
         }.start();
@@ -419,7 +419,7 @@ public class BungeeCord extends ProxyServer
     /* This must be run on a separate thread to avoid deadlock! */
     @SuppressFBWarnings("DM_EXIT")
     @SuppressWarnings("TooBroadCatch")
-    private void independantThreadStop(final String reason)
+    private void independentThreadStop(final String reason)
     {
         stopListeners();
         getLogger().info( "Closing pending connections" );


### PR DESCRIPTION
This is based on #2606 from @coderobe and the feedback provided by md-5 on that patch. If this is merged, that pull request can be closed. 

- Move working contents of `Bungeecord.stop()` to a separate function
named `independentThreadStop()` intended to be called from a separate thread.
- Added a new generic shutdown hook to call `independentThreadStop()` when
the JVM begins shutting down.

This has been tested locally by running `/end`, control+c at console, `/kill <pid>`, and `/kill -SIGHUP <pid>`

This is an important feature when running in containerization software such as Docker / Kubernetes, which stop the workload by using SIGTERM. Without this functionality, our locations file is often not saved, losing the most recent player movement. 

Suggest viewing the diff ignoring whitespace - very few lines have actually changed (mostly indentation)