### PR TITLE
Add Tab Complete to Find Command

### DIFF
--- a/module/cmd-find/src/main/java/net/md_5/bungee/module/cmd/find/CommandFind.java
+++ b/module/cmd-find/src/main/java/net/md_5/bungee/module/cmd/find/CommandFind.java
@@ -55,4 +55,3 @@ public class CommandFind extends PlayerCommand implements TabExecutor
         return matches;
     }
 }
-}

--- a/module/cmd-find/src/main/java/net/md_5/bungee/module/cmd/find/CommandFind.java
+++ b/module/cmd-find/src/main/java/net/md_5/bungee/module/cmd/find/CommandFind.java
@@ -6,7 +6,6 @@ import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.plugin.TabExecutor;
 import net.md_5.bungee.command.PlayerCommand;
-
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
@@ -39,17 +38,17 @@ public class CommandFind extends PlayerCommand implements TabExecutor
     }
     public Iterable<String> onTabComplete(CommandSender sender, String[] args)
     {
-        if (args.length != 1)
+        if ( args.length != 1 )
         {
             return ImmutableSet.of();
         }
         Set<String> matches = new HashSet<>();
-        String search = args[0].toLowerCase(Locale.ROOT);
-        for (ProxiedPlayer player : ProxyServer.getInstance().getPlayers())
+        String search = args[0].toLowerCase( Locale.ROOT );
+        for ( ProxiedPlayer player : ProxyServer.getInstance().getPlayers() )
         {
-            if (player.getName().toLowerCase(Locale.ROOT).startsWith(search))
+            if ( player.getName().toLowerCase( Locale.ROOT ).startsWith( search ) )
             {
-                matches.add(player.getName());
+                matches.add( player.getName() );
             }
         }
         return matches;

--- a/module/cmd-find/src/main/java/net/md_5/bungee/module/cmd/find/CommandFind.java
+++ b/module/cmd-find/src/main/java/net/md_5/bungee/module/cmd/find/CommandFind.java
@@ -1,14 +1,14 @@
 package net.md_5.bungee.module.cmd.find;
 
 import com.google.common.collect.ImmutableSet;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.plugin.TabExecutor;
 import net.md_5.bungee.command.PlayerCommand;
-import java.util.Locale;
-import java.util.HashSet;
-import java.util.Set;
 
 public class CommandFind extends PlayerCommand implements TabExecutor
 {

--- a/module/cmd-find/src/main/java/net/md_5/bungee/module/cmd/find/CommandFind.java
+++ b/module/cmd-find/src/main/java/net/md_5/bungee/module/cmd/find/CommandFind.java
@@ -1,11 +1,17 @@
 package net.md_5.bungee.module.cmd.find;
 
+import com.google.common.collect.ImmutableSet;
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
+import net.md_5.bungee.api.plugin.TabExecutor;
 import net.md_5.bungee.command.PlayerCommand;
 
-public class CommandFind extends PlayerCommand
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
+
+public class CommandFind extends PlayerCommand implements TabExecutor
 {
 
     public CommandFind()
@@ -31,4 +37,22 @@ public class CommandFind extends PlayerCommand
             }
         }
     }
+    public Iterable<String> onTabComplete(CommandSender sender, String[] args)
+    {
+        if (args.length != 1)
+        {
+            return ImmutableSet.of();
+        }
+        Set<String> matches = new HashSet<>();
+        String search = args[0].toLowerCase(Locale.ROOT);
+        for (ProxiedPlayer player : ProxyServer.getInstance().getPlayers())
+        {
+            if (player.getName().toLowerCase(Locale.ROOT).startsWith(search))
+            {
+                matches.add(player.getName());
+            }
+        }
+        return matches;
+    }
+}
 }

--- a/module/cmd-find/src/main/java/net/md_5/bungee/module/cmd/find/CommandFind.java
+++ b/module/cmd-find/src/main/java/net/md_5/bungee/module/cmd/find/CommandFind.java
@@ -6,8 +6,8 @@ import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.plugin.TabExecutor;
 import net.md_5.bungee.command.PlayerCommand;
-import java.util.HashSet;
 import java.util.Locale;
+import java.util.HashSet;
 import java.util.Set;
 
 public class CommandFind extends PlayerCommand implements TabExecutor


### PR DESCRIPTION
I went ahead and took the format from Tab Completing names in the [CommandServer.java](https://github.com/SpigotMC/BungeeCord/blob/master/module/cmd-send/src/main/java/net/md_5/bungee/module/cmd/send/CommandSend.java) class and added it into the Find Command. This way people can now tab-complete finding players. It checks all online players and puts them into the list of who is online. 