### PR TITLE
Get in use of sweet java 8 features

### DIFF
--- a/api/src/main/java/net/md_5/bungee/command/PlayerCommand.java
+++ b/api/src/main/java/net/md_5/bungee/command/PlayerCommand.java
@@ -1,12 +1,9 @@
 package net.md_5.bungee.command;
 
-import com.google.common.base.Function;
-import com.google.common.base.Predicate;
-import com.google.common.collect.Iterables;
 import java.util.Locale;
+import java.util.stream.Collectors;
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.ProxyServer;
-import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.plugin.Command;
 import net.md_5.bungee.api.plugin.TabExecutor;
 
@@ -31,20 +28,9 @@ public abstract class PlayerCommand extends Command implements TabExecutor
     public Iterable<String> onTabComplete(CommandSender sender, String[] args)
     {
         final String lastArg = ( args.length > 0 ) ? args[args.length - 1].toLowerCase( Locale.ROOT ) : "";
-        return Iterables.transform( Iterables.filter( ProxyServer.getInstance().getPlayers(), new Predicate<ProxiedPlayer>()
-        {
-            @Override
-            public boolean apply(ProxiedPlayer player)
-            {
-                return player.getName().toLowerCase( Locale.ROOT ).startsWith( lastArg );
-            }
-        } ), new Function<ProxiedPlayer, String>()
-        {
-            @Override
-            public String apply(ProxiedPlayer player)
-            {
-                return player.getName();
-            }
-        } );
+        return ProxyServer.getInstance().getPlayers().stream()
+            .map( player -> player.getName().toLowerCase( Locale.ROOT ) )
+            .filter( name -> name.startsWith( lastArg ) )
+            .collect( Collectors.toList() );
     }
 }

--- a/module/cmd-server/src/main/java/net/md_5/bungee/module/cmd/server/CommandServer.java
+++ b/module/cmd-server/src/main/java/net/md_5/bungee/module/cmd/server/CommandServer.java
@@ -1,11 +1,9 @@
 package net.md_5.bungee.module.cmd.server;
 
-import com.google.common.base.Function;
-import com.google.common.base.Predicate;
-import com.google.common.collect.Iterables;
 import java.util.Collections;
 import java.util.Locale;
 import java.util.Map;
+import java.util.stream.Collectors;
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.chat.ClickEvent;
@@ -83,22 +81,14 @@ public class CommandServer extends Command implements TabExecutor
     @Override
     public Iterable<String> onTabComplete(final CommandSender sender, final String[] args)
     {
-        return ( args.length > 1 ) ? Collections.EMPTY_LIST : Iterables.transform( Iterables.filter( ProxyServer.getInstance().getServers().values(), new Predicate<ServerInfo>()
+        if ( args.length != 1 )
         {
-            private final String lower = ( args.length == 0 ) ? "" : args[0].toLowerCase( Locale.ROOT );
-
-            @Override
-            public boolean apply(ServerInfo input)
-            {
-                return input.getName().toLowerCase( Locale.ROOT ).startsWith( lower ) && input.canAccess( sender );
-            }
-        } ), new Function<ServerInfo, String>()
-        {
-            @Override
-            public String apply(ServerInfo input)
-            {
-                return input.getName();
-            }
-        } );
+            return Collections.emptyList();
+        }
+        String lower = args[0].toLowerCase( Locale.ROOT );
+        return ProxyServer.getInstance().getServers().values().stream()
+            .filter( info -> info.getName().toLowerCase( Locale.ROOT ).startsWith( lower ) && info.canAccess( sender ) )
+            .map( ServerInfo::getName )
+            .collect( Collectors.toList() );
     }
 }

--- a/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java
@@ -6,7 +6,7 @@ import gnu.trove.map.TIntObjectMap;
 import gnu.trove.map.TObjectIntMap;
 import gnu.trove.map.hash.TIntObjectHashMap;
 import gnu.trove.map.hash.TObjectIntHashMap;
-import java.lang.reflect.Constructor;
+import java.util.function.Supplier;
 import lombok.Data;
 import lombok.Getter;
 import net.md_5.bungee.protocol.packet.BossBar;
@@ -52,6 +52,7 @@ public enum Protocol
         {
             TO_SERVER.registerPacket(
                     Handshake.class,
+                    Handshake::new,
                     map( ProtocolConstants.MINECRAFT_1_8, 0x00 )
             );
         }
@@ -63,6 +64,7 @@ public enum Protocol
         {
             TO_CLIENT.registerPacket(
                     KeepAlive.class,
+                    KeepAlive::new,
                     map( ProtocolConstants.MINECRAFT_1_8, 0x00 ),
                     map( ProtocolConstants.MINECRAFT_1_9, 0x1F ),
                     map( ProtocolConstants.MINECRAFT_1_13, 0x21 ),
@@ -71,6 +73,7 @@ public enum Protocol
             );
             TO_CLIENT.registerPacket(
                     Login.class,
+                    Login::new,
                     map( ProtocolConstants.MINECRAFT_1_8, 0x01 ),
                     map( ProtocolConstants.MINECRAFT_1_9, 0x23 ),
                     map( ProtocolConstants.MINECRAFT_1_13, 0x25 ),
@@ -78,6 +81,7 @@ public enum Protocol
             );
             TO_CLIENT.registerPacket(
                     Chat.class,
+                    Chat::new,
                     map( ProtocolConstants.MINECRAFT_1_8, 0x02 ),
                     map( ProtocolConstants.MINECRAFT_1_9, 0x0F ),
                     map( ProtocolConstants.MINECRAFT_1_13, 0x0E ),
@@ -85,6 +89,7 @@ public enum Protocol
             );
             TO_CLIENT.registerPacket(
                     Respawn.class,
+                    Respawn::new,
                     map( ProtocolConstants.MINECRAFT_1_8, 0x07 ),
                     map( ProtocolConstants.MINECRAFT_1_9, 0x33 ),
                     map( ProtocolConstants.MINECRAFT_1_12, 0x34 ),
@@ -95,11 +100,13 @@ public enum Protocol
             );
             TO_CLIENT.registerPacket(
                     BossBar.class,
+                    BossBar::new,
                     map( ProtocolConstants.MINECRAFT_1_9, 0x0C ),
                     map( ProtocolConstants.MINECRAFT_1_15, 0x0D )
             );
             TO_CLIENT.registerPacket(
                     PlayerListItem.class, // PlayerInfo
+                    PlayerListItem::new,
                     map( ProtocolConstants.MINECRAFT_1_8, 0x38 ),
                     map( ProtocolConstants.MINECRAFT_1_9, 0x2D ),
                     map( ProtocolConstants.MINECRAFT_1_12_1, 0x2E ),
@@ -109,6 +116,7 @@ public enum Protocol
             );
             TO_CLIENT.registerPacket(
                     TabCompleteResponse.class,
+                    TabCompleteResponse::new,
                     map( ProtocolConstants.MINECRAFT_1_8, 0x3A ),
                     map( ProtocolConstants.MINECRAFT_1_9, 0x0E ),
                     map( ProtocolConstants.MINECRAFT_1_13, 0x10 ),
@@ -116,6 +124,7 @@ public enum Protocol
             );
             TO_CLIENT.registerPacket(
                     ScoreboardObjective.class,
+                    ScoreboardObjective::new,
                     map( ProtocolConstants.MINECRAFT_1_8, 0x3B ),
                     map( ProtocolConstants.MINECRAFT_1_9, 0x3F ),
                     map( ProtocolConstants.MINECRAFT_1_12, 0x41 ),
@@ -126,6 +135,7 @@ public enum Protocol
             );
             TO_CLIENT.registerPacket(
                     ScoreboardScore.class,
+                    ScoreboardScore::new,
                     map( ProtocolConstants.MINECRAFT_1_8, 0x3C ),
                     map( ProtocolConstants.MINECRAFT_1_9, 0x42 ),
                     map( ProtocolConstants.MINECRAFT_1_12, 0x44 ),
@@ -136,6 +146,7 @@ public enum Protocol
             );
             TO_CLIENT.registerPacket(
                     ScoreboardDisplay.class,
+                    ScoreboardDisplay::new,
                     map( ProtocolConstants.MINECRAFT_1_8, 0x3D ),
                     map( ProtocolConstants.MINECRAFT_1_9, 0x38 ),
                     map( ProtocolConstants.MINECRAFT_1_12, 0x3A ),
@@ -146,6 +157,7 @@ public enum Protocol
             );
             TO_CLIENT.registerPacket(
                     Team.class,
+                    Team::new,
                     map( ProtocolConstants.MINECRAFT_1_8, 0x3E ),
                     map( ProtocolConstants.MINECRAFT_1_9, 0x41 ),
                     map( ProtocolConstants.MINECRAFT_1_12, 0x43 ),
@@ -156,6 +168,7 @@ public enum Protocol
             );
             TO_CLIENT.registerPacket(
                     PluginMessage.class,
+                    PluginMessage::new,
                     map( ProtocolConstants.MINECRAFT_1_8, 0x3F ),
                     map( ProtocolConstants.MINECRAFT_1_9, 0x18 ),
                     map( ProtocolConstants.MINECRAFT_1_13, 0x19 ),
@@ -164,6 +177,7 @@ public enum Protocol
             );
             TO_CLIENT.registerPacket(
                     Kick.class,
+                    Kick::new,
                     map( ProtocolConstants.MINECRAFT_1_8, 0x40 ),
                     map( ProtocolConstants.MINECRAFT_1_9, 0x1A ),
                     map( ProtocolConstants.MINECRAFT_1_13, 0x1B ),
@@ -172,6 +186,7 @@ public enum Protocol
             );
             TO_CLIENT.registerPacket(
                     Title.class,
+                    Title::new,
                     map( ProtocolConstants.MINECRAFT_1_8, 0x45 ),
                     map( ProtocolConstants.MINECRAFT_1_12, 0x47 ),
                     map( ProtocolConstants.MINECRAFT_1_12_1, 0x48 ),
@@ -181,6 +196,7 @@ public enum Protocol
             );
             TO_CLIENT.registerPacket(
                     PlayerListHeaderFooter.class,
+                    PlayerListHeaderFooter::new,
                     map( ProtocolConstants.MINECRAFT_1_8, 0x47 ),
                     map( ProtocolConstants.MINECRAFT_1_9, 0x48 ),
                     map( ProtocolConstants.MINECRAFT_1_9_4, 0x47 ),
@@ -192,6 +208,7 @@ public enum Protocol
             );
             TO_CLIENT.registerPacket(
                     EntityStatus.class,
+                    EntityStatus::new,
                     map( ProtocolConstants.MINECRAFT_1_8, 0x1A ),
                     map( ProtocolConstants.MINECRAFT_1_9, 0x1B ),
                     map( ProtocolConstants.MINECRAFT_1_13, 0x1C ),
@@ -200,21 +217,25 @@ public enum Protocol
             );
             TO_CLIENT.registerPacket(
                     Commands.class,
+                    Commands::new,
                     map( ProtocolConstants.MINECRAFT_1_13, 0x11 ),
                     map( ProtocolConstants.MINECRAFT_1_15, 0x12 )
             );
             TO_CLIENT.registerPacket(
                     GameState.class,
+                    GameState::new,
                     map( ProtocolConstants.MINECRAFT_1_15, 0x1F )
             );
             TO_CLIENT.registerPacket(
                     ViewDistance.class,
+                    ViewDistance::new,
                     map( ProtocolConstants.MINECRAFT_1_14, 0x41 ),
                     map( ProtocolConstants.MINECRAFT_1_15, 0x42 )
             );
 
             TO_SERVER.registerPacket(
                     KeepAlive.class,
+                    KeepAlive::new,
                     map( ProtocolConstants.MINECRAFT_1_8, 0x00 ),
                     map( ProtocolConstants.MINECRAFT_1_9, 0x0B ),
                     map( ProtocolConstants.MINECRAFT_1_12, 0x0C ),
@@ -224,6 +245,7 @@ public enum Protocol
             );
             TO_SERVER.registerPacket(
                     Chat.class,
+                    Chat::new,
                     map( ProtocolConstants.MINECRAFT_1_8, 0x01 ),
                     map( ProtocolConstants.MINECRAFT_1_9, 0x02 ),
                     map( ProtocolConstants.MINECRAFT_1_12, 0x03 ),
@@ -232,6 +254,7 @@ public enum Protocol
             );
             TO_SERVER.registerPacket(
                     TabCompleteRequest.class,
+                    TabCompleteRequest::new,
                     map( ProtocolConstants.MINECRAFT_1_8, 0x14 ),
                     map( ProtocolConstants.MINECRAFT_1_9, 0x01 ),
                     map( ProtocolConstants.MINECRAFT_1_12, 0x02 ),
@@ -241,6 +264,7 @@ public enum Protocol
             );
             TO_SERVER.registerPacket(
                     ClientSettings.class,
+                    ClientSettings::new,
                     map( ProtocolConstants.MINECRAFT_1_8, 0x15 ),
                     map( ProtocolConstants.MINECRAFT_1_9, 0x04 ),
                     map( ProtocolConstants.MINECRAFT_1_12, 0x05 ),
@@ -249,6 +273,7 @@ public enum Protocol
             );
             TO_SERVER.registerPacket(
                     PluginMessage.class,
+                    PluginMessage::new,
                     map( ProtocolConstants.MINECRAFT_1_8, 0x17 ),
                     map( ProtocolConstants.MINECRAFT_1_9, 0x09 ),
                     map( ProtocolConstants.MINECRAFT_1_12, 0x0A ),
@@ -265,19 +290,23 @@ public enum Protocol
         {
             TO_CLIENT.registerPacket(
                     StatusResponse.class,
+                    StatusResponse::new,
                     map( ProtocolConstants.MINECRAFT_1_8, 0x00 )
             );
             TO_CLIENT.registerPacket(
                     PingPacket.class,
+                    PingPacket::new,
                     map( ProtocolConstants.MINECRAFT_1_8, 0x01 )
             );
 
             TO_SERVER.registerPacket(
                     StatusRequest.class,
+                    StatusRequest::new,
                     map( ProtocolConstants.MINECRAFT_1_8, 0x00 )
             );
             TO_SERVER.registerPacket(
                     PingPacket.class,
+                    PingPacket::new,
                     map( ProtocolConstants.MINECRAFT_1_8, 0x01 )
             );
         }
@@ -289,35 +318,43 @@ public enum Protocol
         {
             TO_CLIENT.registerPacket(
                     Kick.class,
+                    Kick::new,
                     map( ProtocolConstants.MINECRAFT_1_8, 0x00 )
             );
             TO_CLIENT.registerPacket(
                     EncryptionRequest.class,
+                    EncryptionRequest::new,
                     map( ProtocolConstants.MINECRAFT_1_8, 0x01 )
             );
             TO_CLIENT.registerPacket(
                     LoginSuccess.class,
+                    LoginSuccess::new,
                     map( ProtocolConstants.MINECRAFT_1_8, 0x02 )
             );
             TO_CLIENT.registerPacket(
                     SetCompression.class,
+                    SetCompression::new,
                     map( ProtocolConstants.MINECRAFT_1_8, 0x03 )
             );
             TO_CLIENT.registerPacket(
                     LoginPayloadRequest.class,
+                    LoginPayloadRequest::new,
                     map( ProtocolConstants.MINECRAFT_1_13, 0x04 )
             );
 
             TO_SERVER.registerPacket(
                     LoginRequest.class,
+                    LoginRequest::new,
                     map( ProtocolConstants.MINECRAFT_1_8, 0x00 )
             );
             TO_SERVER.registerPacket(
                     EncryptionResponse.class,
+                    EncryptionResponse::new,
                     map( ProtocolConstants.MINECRAFT_1_8, 0x01 )
             );
             TO_SERVER.registerPacket(
                     LoginPayloadResponse.class,
+                    LoginPayloadResponse::new,
                     map( ProtocolConstants.MINECRAFT_1_13, 0x02 )
             );
         }
@@ -368,7 +405,7 @@ public enum Protocol
 
         private final int protocolVersion;
         private final TObjectIntMap<Class<? extends DefinedPacket>> packetMap = new TObjectIntHashMap<>( MAX_PACKET_ID );
-        private final Constructor<? extends DefinedPacket>[] packetConstructors = new Constructor[ MAX_PACKET_ID ];
+        private final Supplier<? extends DefinedPacket>[] packetConstructors = new Supplier[ MAX_PACKET_ID ];
     }
 
     @Data
@@ -427,52 +464,38 @@ public enum Protocol
                 throw new BadPacketException( "Packet with id " + id + " outside of range " );
             }
 
-            Constructor<? extends DefinedPacket> constructor = protocolData.packetConstructors[id];
-            try
-            {
-                return ( constructor == null ) ? null : constructor.newInstance();
-            } catch ( ReflectiveOperationException ex )
-            {
-                throw new BadPacketException( "Could not construct packet with id " + id, ex );
-            }
+            Supplier<? extends DefinedPacket> constructor = protocolData.packetConstructors[id];
+            return ( constructor == null ) ? null : constructor.get();
         }
 
-        private void registerPacket(Class<? extends DefinedPacket> packetClass, ProtocolMapping... mappings)
+        private <T extends DefinedPacket> void registerPacket(Class<T> packetClass, Supplier<T> constructor, ProtocolMapping... mappings)
         {
-            try
+            int mappingIndex = 0;
+            ProtocolMapping mapping = mappings[mappingIndex];
+            for ( int protocol : ProtocolConstants.SUPPORTED_VERSION_IDS )
             {
-                Constructor<? extends DefinedPacket> constructor = packetClass.getDeclaredConstructor();
-
-                int mappingIndex = 0;
-                ProtocolMapping mapping = mappings[mappingIndex];
-                for ( int protocol : ProtocolConstants.SUPPORTED_VERSION_IDS )
+                if ( protocol < mapping.protocolVersion )
                 {
-                    if ( protocol < mapping.protocolVersion )
-                    {
-                        // This is a new packet, skip it till we reach the next protocol
-                        continue;
-                    }
-
-                    if ( mapping.protocolVersion < protocol && mappingIndex + 1 < mappings.length )
-                    {
-                        // Mapping is non current, but the next one may be ok
-                        ProtocolMapping nextMapping = mappings[mappingIndex + 1];
-                        if ( nextMapping.protocolVersion == protocol )
-                        {
-                            Preconditions.checkState( nextMapping.packetID != mapping.packetID, "Duplicate packet mapping (%s, %s)", mapping.protocolVersion, nextMapping.protocolVersion );
-
-                            mapping = nextMapping;
-                            mappingIndex++;
-                        }
-                    }
-
-                    ProtocolData data = protocols.get( protocol );
-                    data.packetMap.put( packetClass, mapping.packetID );
-                    data.packetConstructors[mapping.packetID] = constructor;
+                    // This is a new packet, skip it till we reach the next protocol
+                    continue;
                 }
-            } catch ( NoSuchMethodException ex )
-            {
-                throw new BadPacketException( "No NoArgsConstructor for packet class " + packetClass );
+
+                if ( mapping.protocolVersion < protocol && mappingIndex + 1 < mappings.length )
+                {
+                    // Mapping is non current, but the next one may be ok
+                    ProtocolMapping nextMapping = mappings[mappingIndex + 1];
+                    if ( nextMapping.protocolVersion == protocol )
+                    {
+                        Preconditions.checkState( nextMapping.packetID != mapping.packetID, "Duplicate packet mapping (%s, %s)", mapping.protocolVersion, nextMapping.protocolVersion );
+
+                        mapping = nextMapping;
+                        mappingIndex++;
+                    }
+                }
+
+                ProtocolData data = protocols.get( protocol );
+                data.packetMap.put( packetClass, mapping.packetID );
+                data.packetConstructors[mapping.packetID] = constructor;
             }
         }
 

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/PluginMessage.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/PluginMessage.java
@@ -1,13 +1,13 @@
 package net.md_5.bungee.protocol.packet;
 
-import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Predicate;
 import io.netty.buffer.ByteBuf;
 import java.io.ByteArrayInputStream;
 import java.io.DataInput;
 import java.io.DataInputStream;
 import java.util.Locale;
+import java.util.function.Function;
+import java.util.function.Predicate;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -51,7 +51,7 @@ public class PluginMessage extends DefinedPacket
     public static final Predicate<PluginMessage> SHOULD_RELAY = new Predicate<PluginMessage>()
     {
         @Override
-        public boolean apply(PluginMessage input)
+        public boolean test(PluginMessage input)
         {
             return ( input.getTag().equals( "REGISTER" ) || input.getTag().equals( "minecraft:register" ) || input.getTag().equals( "MC|Brand" ) || input.getTag().equals( "minecraft:brand" ) ) && input.getData().length < Byte.MAX_VALUE;
         }

--- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
@@ -2,10 +2,7 @@ package net.md_5.bungee;
 
 import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Predicate;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -45,6 +42,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import jline.console.ConsoleReader;
 import lombok.Getter;
 import lombok.Setter;
@@ -661,7 +659,7 @@ public class BungeeCord extends ProxyServer
     {
         if ( protocolVersion >= ProtocolConstants.MINECRAFT_1_13 )
         {
-            return new PluginMessage( "minecraft:register", Util.format( Iterables.transform( pluginChannels, PluginMessage.MODERNISE ), "\00" ).getBytes( Charsets.UTF_8 ), false );
+            return new PluginMessage( "minecraft:register", Util.format( pluginChannels.stream().map( PluginMessage.MODERNISE ).collect( Collectors.toList() ), "\00" ).getBytes( Charsets.UTF_8 ), false );
         }
 
         return new PluginMessage( "REGISTER", Util.format( pluginChannels, "\00" ).getBytes( Charsets.UTF_8 ), false );
@@ -766,15 +764,9 @@ public class BungeeCord extends ProxyServer
             return Collections.singleton( exactMatch );
         }
 
-        return Sets.newHashSet( Iterables.filter( getPlayers(), new Predicate<ProxiedPlayer>()
-        {
-
-            @Override
-            public boolean apply(ProxiedPlayer input)
-            {
-                return ( input == null ) ? false : input.getName().toLowerCase( Locale.ROOT ).startsWith( partialName.toLowerCase( Locale.ROOT ) );
-            }
-        } ) );
+        return getPlayers().stream()
+            .filter( player -> player != null && player.getName().toLowerCase( Locale.ROOT ).startsWith( partialName.toLowerCase( Locale.ROOT ) ) )
+            .collect( Collectors.toSet() );
     }
 
     @Override

--- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
@@ -1,8 +1,6 @@
 package net.md_5.bungee.connection;
 
-import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
 import com.google.common.io.ByteArrayDataOutput;
 import com.google.common.io.ByteStreams;
 import com.mojang.brigadier.arguments.StringArgumentType;
@@ -21,6 +19,7 @@ import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import net.md_5.bungee.ServerConnection;
 import net.md_5.bungee.ServerConnection.KeepAliveData;
@@ -518,14 +517,7 @@ public class DownstreamBridge extends PacketHandler
         List<String> commands = tabCompleteResponse.getCommands();
         if ( commands == null )
         {
-            commands = Lists.transform( tabCompleteResponse.getSuggestions().getList(), new Function<Suggestion, String>()
-            {
-                @Override
-                public String apply(Suggestion input)
-                {
-                    return input.getText();
-                }
-            } );
+            commands = tabCompleteResponse.getSuggestions().getList().stream().map( Suggestion::getText ).collect( Collectors.toList() );
         }
 
         TabCompleteResponseEvent tabCompleteResponseEvent = new TabCompleteResponseEvent( server, con, new ArrayList<>( commands ) );
@@ -542,14 +534,8 @@ public class DownstreamBridge extends PacketHandler
                 {
                     // Brigadier style
                     final StringRange range = tabCompleteResponse.getSuggestions().getRange();
-                    tabCompleteResponse.setSuggestions( new Suggestions( range, Lists.transform( tabCompleteResponseEvent.getSuggestions(), new Function<String, Suggestion>()
-                    {
-                        @Override
-                        public Suggestion apply(String input)
-                        {
-                            return new Suggestion( range, input );
-                        }
-                    } ) ) );
+                    tabCompleteResponse.setSuggestions( new Suggestions( range, tabCompleteResponseEvent.getSuggestions()
+                        .stream().map( text -> new Suggestion( range, text ) ).collect( Collectors.toList() ) ) );
                 }
             }
 

--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -154,7 +154,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
     public void handle(PluginMessage pluginMessage) throws Exception
     {
         // TODO: Unregister?
-        if ( PluginMessage.SHOULD_RELAY.apply( pluginMessage ) )
+        if ( PluginMessage.SHOULD_RELAY.test( pluginMessage ) )
         {
             relayMessages.add( pluginMessage );
         }

--- a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
@@ -246,7 +246,7 @@ public class UpstreamBridge extends PacketHandler
         }
 
         // TODO: Unregister as well?
-        if ( PluginMessage.SHOULD_RELAY.apply( pluginMessage ) )
+        if ( PluginMessage.SHOULD_RELAY.test( pluginMessage ) )
         {
             con.getPendingConnection().getRelayMessages().add( pluginMessage );
         }

--- a/proxy/src/main/java/net/md_5/bungee/util/ChatComponentTransformer.java
+++ b/proxy/src/main/java/net/md_5/bungee/util/ChatComponentTransformer.java
@@ -1,7 +1,7 @@
 package net.md_5.bungee.util;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
+import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
 import lombok.AccessLevel;
@@ -63,7 +63,7 @@ public final class ChatComponentTransformer
         {
             if ( root.getExtra() != null && !root.getExtra().isEmpty() )
             {
-                List<BaseComponent> list = Lists.newArrayList( transform( player, root.getExtra().toArray( new BaseComponent[ root.getExtra().size() ] ) ) );
+                List<BaseComponent> list = Arrays.asList( transform( player, root.getExtra().toArray( new BaseComponent[root.getExtra().size()] ) ) );
                 root.setExtra( list );
             }
 


### PR DESCRIPTION
- Replace guava Predicate's and Function's to java ones
- Replace guava's filtering and mapping to java 8's stream api
- Make use of java 8's supplier to speed up packet construction

Sadly can't replace callbacks with futures cuz that would break api :(