### PR TITLE
Add CommandsDeclareEvent that exposes Brigadier API to plugins

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/event/CommandsDeclareEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/CommandsDeclareEvent.java
@@ -1,0 +1,157 @@
+package net.md_5.bungee.api.event;
+
+import com.mojang.brigadier.arguments.ArgumentType;
+import com.mojang.brigadier.arguments.IntegerArgumentType;
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.builder.ArgumentBuilder;
+import com.mojang.brigadier.builder.RequiredArgumentBuilder;
+import com.mojang.brigadier.suggestion.SuggestionProvider;
+import com.mojang.brigadier.tree.CommandNode;
+import com.mojang.brigadier.tree.RootCommandNode;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Setter;
+import lombok.ToString;
+import net.md_5.bungee.api.CommandSender;
+import net.md_5.bungee.api.connection.Connection;
+import net.md_5.bungee.api.plugin.Command;
+import net.md_5.bungee.api.plugin.Plugin;
+import net.md_5.bungee.api.plugin.PluginManager;
+import net.md_5.bungee.api.plugin.TabExecutor;
+
+/**
+ * Event called when a downstream server (on 1.13+) sends the command structure
+ * to a player, but before BungeeCord adds the dummy command nodes of
+ * registered commands.
+ * <p>
+ * BungeeCord will not overwrite the modifications made by the listeners.
+ *
+ * <h2>Usage example</h2>
+ * Here is a usage example of this event, to declare a command structure.
+ * This illustrates the commands /server and /send of Bungee.
+ * <pre>
+ * event.getRoot().addChild( LiteralArgumentBuilder.&lt;CommandSender&gt;literal( "server" )
+ *         .requires( sender -&gt; sender.hasPermission( "bungeecord.command.server" ) )
+ *         .executes( a -&gt; 0 )
+ *         .then( RequiredArgumentBuilder.argument( "serverName", StringArgumentType.greedyString() )
+ *                 .suggests( SuggestionRegistry.ASK_SERVER )
+ *         )
+ *         .build()
+ * );
+ * event.getRoot().addChild( LiteralArgumentBuilder.&lt;CommandSender&gt;literal( "send" )
+ *         .requires( sender -&gt; sender.hasPermission( "bungeecord.command.send" ) )
+ *         .then( RequiredArgumentBuilder.argument( "playerName", StringArgumentType.word() )
+ *                 .suggests( SuggestionRegistry.ASK_SERVER )
+ *                 .then( RequiredArgumentBuilder.argument( "serverName", StringArgumentType.greedyString() )
+ *                         .suggests( SuggestionRegistry.ASK_SERVER )
+ *                 )
+ *         )
+ *         .build()
+ * );
+ * </pre>
+ *
+ * <h2>Flag a {@link CommandNode} as executable or not</h2>
+ * The implementation of a {@link com.mojang.brigadier.Command Command} used in
+ * {@link ArgumentBuilder#executes(com.mojang.brigadier.Command)} will never be
+ * executed. This will only tell to the client if the current node is
+ * executable or not.
+ * <ul>
+ *     <li>
+ *         {@code builder.executes(null)} (default) to mark the node as not
+ *         executable.
+ *     </li>
+ *     <li>
+ *         {@code builder.executes(a -> 0)}, or any non null argument, to mark
+ *         the node as executable (the child arguments are displayed as
+ *         optional).
+ *     </li>
+ * </ul>
+ *
+ * <h2>{@link CommandNode}’s suggestions management</h2>
+ * The implementation of a SuggestionProvider used in
+ * {@link RequiredArgumentBuilder#suggests(SuggestionProvider)} will never be
+ * executed. This will only tell to the client how to deal with the
+ * auto-completion of the argument.
+ * <ul>
+ *     <li>
+ *         {@code builder.suggests(null)} (default) to disable auto-completion
+ *         for this argument.
+ *     </li>
+ *     <li>
+ *         {@code builder.suggests(SuggestionRegistry.ALL_RECIPES)} to suggest
+ *         Minecraft’s recipes.
+ *     </li>
+ *     <li>
+ *         {@code builder.suggests(SuggestionRegistry.AVAILABLE_SOUNDS)} to
+ *         suggest Minecraft’s default sound identifiers.
+ *     </li>
+ *     <li>
+ *         {@code builder.suggests(SuggestionRegistry.SUMMONABLE_ENTITIES)} to
+ *         suggest Minecraft’s default summonable entities identifiers.
+ *     </li>
+ *     <li>
+ *         {@code builder.suggests(SuggestionRegistry.ASK_SERVER)}, or any
+ *         other non null argument, to make the Minecraft client ask
+ *         auto-completion to the server. Any specified implementation of
+ *         {@link SuggestionProvider} will never be executed.
+ *     </li>
+ * </ul>
+ *
+ * <h2>Argument types</h2>
+ * When building a new argument command node using
+ * {@link RequiredArgumentBuilder#argument(String, ArgumentType)}, you have to
+ * specify an {@link ArgumentType}. You can use all subclasses of
+ * {@link ArgumentType} provided with brigadier (for instance,
+ * {@link StringArgumentType} or {@link IntegerArgumentType}), or call any
+ * {@code ArgumentRegistry.minecraft*()} methods to use a {@code minecraft:*}
+ * argument type.
+ *
+ * <h2>Limitations with brigadier API</h2>
+ * This event is only used for the client to show command syntax, suggest
+ * sub-commands and color the arguments in the chat box. The command execution
+ * needs to be implemented using {@link PluginManager#registerCommand(Plugin,
+ * Command)} and the server-side tab-completion using {@link TabCompleteEvent}
+ * or {@link TabExecutor}.
+ */
+@Data
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class CommandsDeclareEvent extends TargetedEvent
+{
+    /**
+     * Wether or not the command tree is modified by this event.
+     *
+     * If this value is set to true, BungeeCord will ensure that the
+     * modifications made in the command tree, will be sent to the player.
+     * If this is false, the modifications may not be taken into account.
+     *
+     * When calling {@link #getRoot()}, this value is automatically set
+     * to true.
+     */
+    @Setter(value = AccessLevel.NONE)
+    private boolean modified = false;
+
+    /**
+     * The root command node of the command structure that will be send to the
+     * player.
+     */
+    private final RootCommandNode<CommandSender> root;
+
+    public CommandsDeclareEvent(Connection sender, Connection receiver, RootCommandNode<CommandSender> root)
+    {
+        super( sender, receiver );
+        this.root = root;
+    }
+
+    /**
+     * The root command node of the command structure that will be send to the
+     * player.
+     * @return The root command node
+     */
+    public RootCommandNode<CommandSender> getRoot()
+    {
+        modified = true;
+        return root;
+    }
+}


### PR DESCRIPTION
Here is an implementation of a new event `CommandsDeclareEvent` that exposes the brigadier API to plugin developers, so they can declare custom command structure to 1.13+ Minecraft clients.
The event provides a reference to the `RootCommandNode`, the root of the command structure.
This follows the discussion and will close #2812.

Below are the modifications made in this PR.


### `Commands` packet handling (in `DownstreamBridge` class)
When the downstream server sends the command structure (usually when the player joins the server), it is processed by BungeeCord as explained below.

1. Bungee receives the command structure from the downstream server.
2. (**added by this PR**) Bungee calls the event `CommandsDeclareEvent` with a reference to the `RootCommandNode`, the downstream server and the upstream client.
3. Bungee adds a dummy command nodes for each commands found in the Bungee commands dispatcher, _only if the command structure does not already contains a command with the same name_.
4. (**added by this PR**) If the command structure is modified (in 2. and 3.), it is filtered to remove any nodes that the player does not have access to (using `ArgumentBuilder#requires(Predicate<ProxiedPlayer>)`). If the predicate throws an exception, it is logged to the console (like if a bungee task or event listener fail) and the predicate is considered to return true _(comment if you disagree)_.


### `Commands` packet decoding process
This PR slightly alter the decoding of the packet, the only change made is that all the brigadier argument types are not wrapped in a DummyType anymore, since we have access to their proper ArgumentType class.


### `Commands` packet encoding process
This PR make some changes in the encoding process of the packet `Commands`:
- Argument types are converted to avoid client disconnected due to unrecognized type:
  - `minecraft:nbt` and `minecraft:nbt_compound_tag` are equivalent parsers, but with different identifier depending of the MC version. They are converted from one to another if necessary.
  - `brigadier:long` is not supported in 1.13, so it is converted to `brigadier:int`.
  - `minecraft:time` is not supported in 1.13, so it is converted to `brigadier:string` (word).
  - `minecraft:nbt_tag` is not supported in 1.13, so it is converted to `minecraft:nbt`. They are not strictly equivalent, but they parse more or less the same thing
- Any `SuggestionProvider` that are not instance of `DummyProvider` are replaced with `SuggestionRegistry.ASK_SERVER`

### Limitations about brigadier API with `CommandsDeclareEvent`
See javadoc of the event class

### Plugin example/test
https://gist.github.com/marcbal/7db8ceddcf453d059d366ac7123e5f76