### PR TITLE
Don't throw an exception when the next state is invalid

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -343,6 +343,8 @@ public class InitialHandler extends PacketHandler implements PendingConnection
                     return;
                 }
                 break;
+            default:
+                ch.close();
         }
     }
 

--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -343,8 +343,6 @@ public class InitialHandler extends PacketHandler implements PendingConnection
                     return;
                 }
                 break;
-            default:
-                throw new QuietException( "Cannot request protocol " + handshake.getRequestedProtocol() );
         }
     }
 


### PR DESCRIPTION
This would fix one of the most popular crashing methods.