### PR TITLE
[WIP/Discussion] Improving TabCompleteEvent and TabCompleteResponseEvent to handle 1.13+ suggestions

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/event/BrigadierSuggestionsEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/BrigadierSuggestionsEvent.java
@@ -1,6 +1,6 @@
 package net.md_5.bungee.api.event;
 
-import java.util.List;
+import com.mojang.brigadier.suggestion.Suggestions;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -8,14 +8,13 @@ import net.md_5.bungee.api.connection.Connection;
 import net.md_5.bungee.api.plugin.Cancellable;
 
 /**
- * Event called when a player uses tab completion.
- * For 1.13+ clients, you can also use {@link BrigadierSuggestionsEvent} for
- * more control of the suggestions.
+ * Event called when an 1.13+ player uses tab completion.
+ * This event is fired after {@link TabCompleteEvent}.
  */
 @Data
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public class TabCompleteEvent extends TargetedEvent implements Cancellable
+public class BrigadierSuggestionsEvent extends TargetedEvent implements Cancellable
 {
 
     /**
@@ -27,12 +26,12 @@ public class TabCompleteEvent extends TargetedEvent implements Cancellable
      */
     private final String cursor;
     /**
-     * The suggestions that will be sent to the client. This list is mutable. If
-     * this list is empty, the request will be forwarded to the server.
+     * The suggestions that will be sent to the client. If this list is empty,
+     * the request will be forwarded to the server.
      */
-    private final List<String> suggestions;
+    private Suggestions suggestions;
 
-    public TabCompleteEvent(Connection sender, Connection receiver, String cursor, List<String> suggestions)
+    public BrigadierSuggestionsEvent(Connection sender, Connection receiver, String cursor, Suggestions suggestions)
     {
         super( sender, receiver );
         this.cursor = cursor;


### PR DESCRIPTION
(in italic is the original message)
_The goal is to give the transaction id of the `TabCompleteRequest` paquet, so plugin developers may send a custom `TabCompleteResponse` with full control of the `Suggestions` and `Suggestion` data (suggestions range and tooltips)._

_I understand that plugin developers should not directly send packets to the client, but let BungeeCord deals with that. The thing is that improving TabCompleteEvent to allow control of suggestions metadata (range and tooltips) may break current API (especially for tooltips, that would require replacing `List<String>` with `List<Suggestion>` or `Suggestions` in the event API)._

### EDIT:
So I edited my commit with a new approach. Based on the discussion below, I implemented the "new event" solution since it seams simpler to implement and to deal with conflict between old API and new API usage.

- [ ] tests TODO
- [ ] what about TabCompleteResponseEvent ?