### PR TITLE
Add method to translate hex color codes

### DIFF
--- a/chat/src/main/java/net/md_5/bungee/api/ChatColor.java
+++ b/chat/src/main/java/net/md_5/bungee/api/ChatColor.java
@@ -226,6 +226,27 @@ public final class ChatColor
     }
 
     /**
+     * Translate a hex code within two tags to a colour code.
+     *
+     * @param starting tag which must precede the hex code.
+     * @param ending tag which must succeed the hex code.
+     * @param the message to be translated.
+     * @return the new string with the hex code translated to a colour code.
+     */
+    public static String translateHexColorCodes(String startTag, String endTag, String message)
+    {
+        final Pattern pattern = Pattern.compile(startTag + "(\\w{6})" + endTag);
+        Matcher matcher = pattern.matcher(message);
+        StringBuffer buffer = new StringBuffer();
+
+        while (matcher.find())
+        {
+            matcher.appendReplacement(buffer, ChatColor.of('#' + matcher.group(1)).toString());
+        }
+        return matcher.appendTail(buffer).toString();
+    }
+    
+    /**
      * Get the colour represented by the specified code.
      *
      * @param code the code to search for


### PR DESCRIPTION
Added a method to the ChatColor class which allows you to choose a start and end tag, for example, start: "#<", end: ">" and take any hex code inside the tags and translate it to a color code. It then returns the new string with anything from the beginning of the start tag to the end of the end tag replaced with the hex color code. This should be added because, at the moment, the hex color code requires developers to create either a class or a method just to use custom messages with hex colors. This would make a lot more sense if it was included the official API.