### PR TITLE
Add getters to ItemTag and Enchantment class

### DIFF
--- a/chat/src/main/java/net/md_5/bungee/api/chat/ItemTag.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/ItemTag.java
@@ -15,6 +15,7 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.Singular;
@@ -24,6 +25,7 @@ import lombok.ToString;
  * Metadata for use in conjunction with {@link HoverEvent.Action#SHOW_ITEM}
  */
 @ToString(callSuper = true)
+@Getter
 @Setter
 @Builder(builderClassName = "Builder", access = AccessLevel.PUBLIC)
 @AllArgsConstructor
@@ -42,6 +44,7 @@ public final class ItemTag
     {
     }
 
+    @Getter
     @RequiredArgsConstructor
     public static class Enchantment
     {


### PR DESCRIPTION
This adds getters for the private fields in the ItemTag and Enchantment classes in order to get these values without having to serialize the object and manually getting them from the map. This might be useful in a case where you want to edit certain components/events or want to serialize them to a different format.