### PR TITLE
[Breaking] Dont attempt to deserialize tag

### DIFF
--- a/chat/src/main/java/net/md_5/bungee/api/chat/HoverEvent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/HoverEvent.java
@@ -6,6 +6,7 @@ import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 import java.lang.reflect.Type;
@@ -121,7 +122,7 @@ public final class HoverEvent
         }
     }
 
-    @Data
+    @Getter
     @ToString
     public static class ContentText extends Content
     {
@@ -131,7 +132,7 @@ public final class HoverEvent
          *
          * May be a component or raw text depending on constructor used.
          */
-        private Object value;
+        private final Object value;
 
         public ContentText(BaseComponent[] value)
         {
@@ -297,6 +298,30 @@ public final class HoverEvent
             {
                 JsonObject value = element.getAsJsonObject();
 
+                int count = -1;
+                if ( value.has( "Count" ) )
+                {
+                    JsonPrimitive countObj = value.get( "Count" ).getAsJsonPrimitive();
+                    if ( countObj.isNumber() )
+                    {
+                        count = countObj.getAsInt();
+                    } else if ( countObj.isString() )
+                    {
+                        String cString = countObj.getAsString();
+                        if ( cString.endsWith( "b" ) )
+                        {
+                            cString = cString.substring( 0, cString.length() - 1 );
+                        }
+                        try
+                        {
+                            count = Integer.parseInt( cString );
+                        } catch ( NumberFormatException ex )
+                        {
+                            throw new JsonParseException( "Could not parse count: " + ex );
+                        }
+                    }
+                }
+                
                 return new ContentItem(
                         ( value.has( "id" ) ) ? value.get( "id" ).getAsString() : null,
                         ( value.has( "Count" ) ) ? value.get( "Count" ).getAsInt() : -1,

--- a/chat/src/main/java/net/md_5/bungee/api/chat/ItemTag.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/ItemTag.java
@@ -1,20 +1,18 @@
 package net.md_5.bungee.api.chat;
 
-import com.google.gson.JsonArray;
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 import java.lang.reflect.Type;
-import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.Singular;
@@ -23,23 +21,32 @@ import lombok.ToString;
 /**
  * Metadata for use in conjunction with {@link HoverEvent.Action#SHOW_ITEM}
  */
-@ToString(callSuper = true)
+@Builder(builderClassName = "Builder", access = AccessLevel.PRIVATE)
+@ToString(of = "nbt")
+@EqualsAndHashCode(of = "nbt")
 @Setter
-@Builder(builderClassName = "Builder", access = AccessLevel.PUBLIC)
 @AllArgsConstructor
-@EqualsAndHashCode
 public final class ItemTag
 {
 
+    @Getter
+    private final String nbt;
+
     private BaseComponent name;
     @Singular("ench")
-    private List<Enchantment> enchantments = new ArrayList<>();
+    private List<Enchantment> enchantments;
     @Singular("lore")
-    private List<BaseComponent[]> lore = new ArrayList<>();
+    private List<BaseComponent[]> lore;
     private Boolean unbreakable;
 
-    private ItemTag()
+    private ItemTag(String nbt)
     {
+        this.nbt = nbt;
+    }
+
+    public static ItemTag ofNbt(String nbt)
+    {
+        return new ItemTag( nbt );
     }
 
     @RequiredArgsConstructor
@@ -56,103 +63,13 @@ public final class ItemTag
         @Override
         public ItemTag deserialize(JsonElement element, Type type, JsonDeserializationContext context) throws JsonParseException
         {
-            ItemTag itemTag = new ItemTag();
-            JsonObject object = element.getAsJsonObject();
-            if ( object.has( "ench" ) )
-            {
-                for ( JsonElement jsonElement : object.get( "ench" ).getAsJsonArray() )
-                {
-                    JsonObject next = jsonElement.getAsJsonObject();
-                    itemTag.enchantments.add( new Enchantment( next.get( "id" ).getAsInt(), next.get( "lvl" ).getAsInt() ) );
-                }
-            }
-            if ( object.has( "Unbreakable" ) )
-            {
-                int status = object.get( "Unbreakable" ).getAsInt();
-                if ( status == 1 )
-                {
-                    itemTag.unbreakable = true;
-                } else if ( status == 0 )
-                {
-                    itemTag.unbreakable = false;
-                }
-            }
-            if ( object.has( "display" ) )
-            {
-                JsonObject display = object.get( "display" ).getAsJsonObject();
-                if ( display.has( "Name" ) )
-                {
-                    itemTag.name = context.deserialize( display.get( "Name" ).getAsJsonObject(), BaseComponent.class );
-                }
-
-                if ( display.has( "Lore" ) )
-                {
-                    JsonElement lore = display.get( "Lore" );
-                    if ( lore.isJsonArray() )
-                    {
-                        for ( JsonElement loreIt : lore.getAsJsonArray() )
-                        {
-                            if ( loreIt.isJsonArray() )
-                            {
-                                itemTag.lore.add( context.deserialize( loreIt, BaseComponent[].class ) );
-                            } else
-                            {
-                                itemTag.lore.add( new BaseComponent[]
-                                {
-                                    context.deserialize( loreIt, BaseComponent.class )
-                                } );
-                            }
-                        }
-                    } else
-                    {
-                        itemTag.lore.add( context.deserialize( display.get( "Lore" ), BaseComponent[].class ) );
-                    }
-                }
-            }
-            return itemTag;
+            return ofNbt( element.toString().replace( "\"", "" ) );
         }
 
         @Override
         public JsonElement serialize(ItemTag itemTag, Type type, JsonSerializationContext context)
         {
-            JsonObject object = new JsonObject();
-
-            if ( !itemTag.enchantments.isEmpty() )
-            {
-                JsonArray enchArray = new JsonArray();
-                for ( Enchantment ench : itemTag.enchantments )
-                {
-                    JsonObject enchObj = new JsonObject();
-                    enchObj.addProperty( "id", ench.id );
-                    enchObj.addProperty( "lvl", ench.level );
-                    enchArray.add( enchObj );
-                }
-                object.add( "ench", enchArray );
-            }
-
-            if ( itemTag.unbreakable != null )
-            {
-                object.addProperty( "Unbreakable", ( itemTag.unbreakable ) ? 1 : 0 );
-            }
-
-            JsonObject display = new JsonObject();
-
-            if ( itemTag.name != null )
-            {
-                display.add( "Name", context.serialize( itemTag.name ) );
-            }
-
-            if ( !itemTag.lore.isEmpty() )
-            {
-                display.add( "Lore", context.serialize( itemTag.lore ) );
-            }
-
-            if ( display.size() != 0 )
-            {
-                object.add( "display", display );
-            }
-
-            return object;
+            return context.serialize( itemTag.getNbt() );
         }
     }
 }

--- a/chat/src/main/java/net/md_5/bungee/chat/TextComponentSerializer.java
+++ b/chat/src/main/java/net/md_5/bungee/chat/TextComponentSerializer.java
@@ -20,8 +20,12 @@ public class TextComponentSerializer extends BaseComponentSerializer implements 
     {
         TextComponent component = new TextComponent();
         JsonObject object = json.getAsJsonObject();
-        deserialize( object, component, context );
+        if ( !object.has( "text" ) )
+        {
+            throw new JsonParseException( "Could not parse JSON: missing 'text' property" );
+        }
         component.setText( object.get( "text" ).getAsString() );
+        deserialize( object, component, context );
         return component;
     }
 

--- a/chat/src/test/java/net/md_5/bungee/api/chat/ComponentsTest.java
+++ b/chat/src/test/java/net/md_5/bungee/api/chat/ComponentsTest.java
@@ -13,6 +13,29 @@ public class ComponentsTest
 {
 
     @Test
+    public void testItemParse()
+    {
+        String json = "{\"extra\":[{\"text\":\"[\"},{\"extra\":[{\"translate\":\"block.minecraft.dirt\"}],\"text\":\"\"},{\"text\":\"]\"}],\"hoverEvent\":{\"action\":\"show_item\",\"value\":[{\"text\":\"{id:\\\"minecraft:dirt\\\",Count:1b}\"}]},\"text\":\"\"}";
+        BaseComponent[] component = ComponentSerializer.parse( json );
+        String serialised = ComponentSerializer.toString( component );
+        BaseComponent[] deserialised = ComponentSerializer.parse( serialised );
+        Assert.assertEquals( TextComponent.toLegacyText( deserialised ), TextComponent.toLegacyText( component ) );
+        //////////
+        TextComponent component1 = new TextComponent( "HoverableText" );
+        String nbt = "{display:{Name:{text:Hello},Lore:[{text:Line_1},{text:Line_2}]},ench:[{id:49,lvl:5}],Unbreakable:1}}";
+        HoverEvent.ContentItem contentItem = new HoverEvent.ContentItem( "minecraft:wood", 1, ItemTag.ofNbt( nbt ) );
+        HoverEvent hoverEvent = new HoverEvent( HoverEvent.Action.SHOW_ITEM, contentItem );
+        component1.setHoverEvent( hoverEvent );
+        json = ComponentSerializer.toString( component1 );
+        component = ComponentSerializer.parse( json );
+        HoverEvent.ContentItem parsedContentItem = ( (HoverEvent.ContentItem) component[ 0 ].getHoverEvent().getContents().get( 0 ) );
+        Assert.assertEquals( contentItem, parsedContentItem );
+        Assert.assertEquals( contentItem.getCount(), parsedContentItem.getCount() );
+        Assert.assertEquals( contentItem.getId(), parsedContentItem.getId() );
+        Assert.assertEquals( nbt, parsedContentItem.getTag().getNbt() );
+    }
+
+    @Test
     public void testEmptyComponentBuilder()
     {
         ComponentBuilder builder = new ComponentBuilder();
@@ -124,6 +147,7 @@ public class ComponentsTest
         );
     }
 
+    /*
     @Test
     public void testItemTag()
     {
@@ -144,6 +168,7 @@ public class ComponentsTest
         BaseComponent[] deserialised = ComponentSerializer.parse( serialised );
         Assert.assertEquals( TextComponent.toLegacyText( deserialised ), TextComponent.toLegacyText( component ) );
     }
+     */
 
     @Test
     public void testModernShowAdvancement()


### PR DESCRIPTION
As Bungee doesn't have a NBT/Mojangson (de)serializer it was decided in #2887 to only operate on the JSON provided by the deserialisation and disallow plugins to use the ItemTag Builder API until implemented properly.
The Unit Test demonstrates that this works and returns the values it should.
Improved the 'Count' object deserialization to be more rigid.
Throw JsonParseException when deserializing a text component that doesn't have 'text' field. I made this change because this highlighted a lot of obvious problems when I was debugging and even without this change anyway it would throw a NullPointerException.