### PR TITLE
Various stability updates

### DIFF
--- a/chat/src/main/java/net/md_5/bungee/api/chat/ItemTag.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/ItemTag.java
@@ -63,7 +63,14 @@ public final class ItemTag
         @Override
         public ItemTag deserialize(JsonElement element, Type type, JsonDeserializationContext context) throws JsonParseException
         {
-            return ofNbt( element.toString().replace( "\"", "" ) );
+            // Remove the enclosing string quotes.
+            String eString = element.toString();
+            if ( eString.length() >= 2 && eString.charAt( 0 ) == '\"' && eString.charAt( eString.length() - 1 ) == '\"' )
+            {
+                eString = eString.substring( 1, eString.length() - 1 );
+            }
+
+            return ItemTag.ofNbt( eString );
         }
 
         @Override

--- a/chat/src/main/java/net/md_5/bungee/api/chat/hover/content/ItemSerializer.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/hover/content/ItemSerializer.java
@@ -30,7 +30,9 @@ public class ItemSerializer implements JsonSerializer<Item>, JsonDeserializer<It
             } else if ( countObj.isString() )
             {
                 String cString = countObj.getAsString();
-                if ( cString.endsWith( "b" ) )
+                char last = cString.charAt( cString.length() - 1 );
+                // Check for all number suffixes
+                if ( last == 'b' || last == 's' || last == 'l' || last == 'f' || last == 'd' )
                 {
                     cString = cString.substring( 0, cString.length() - 1 );
                 }

--- a/chat/src/main/java/net/md_5/bungee/api/chat/hover/content/TextSerializer.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/hover/content/TextSerializer.java
@@ -18,9 +18,9 @@ public class TextSerializer implements JsonSerializer<Text>, JsonDeserializer<Te
         if ( element.isJsonArray() )
         {
             return new Text( context.<BaseComponent[]>deserialize( element, BaseComponent[].class ) );
-        } else if ( element.getAsJsonObject().isJsonPrimitive() )
+        } else if ( element.isJsonPrimitive() )
         {
-            return new Text( element.getAsJsonObject().getAsJsonPrimitive().getAsString() );
+            return new Text( element.getAsJsonPrimitive().getAsString() );
         } else
         {
             return new Text( new BaseComponent[]

--- a/chat/src/main/java/net/md_5/bungee/chat/KeybindComponentSerializer.java
+++ b/chat/src/main/java/net/md_5/bungee/chat/KeybindComponentSerializer.java
@@ -16,8 +16,12 @@ public class KeybindComponentSerializer extends BaseComponentSerializer implemen
     @Override
     public KeybindComponent deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException
     {
-        KeybindComponent component = new KeybindComponent();
         JsonObject object = json.getAsJsonObject();
+        if ( !object.has( "keybind" ) )
+        {
+            throw new JsonParseException( "Could not parse JSON: missing 'keybind' property" );
+        }
+        KeybindComponent component = new KeybindComponent();
         deserialize( object, component, context );
         component.setKeybind( object.get( "keybind" ).getAsString() );
         return component;

--- a/chat/src/main/java/net/md_5/bungee/chat/ScoreComponentSerializer.java
+++ b/chat/src/main/java/net/md_5/bungee/chat/ScoreComponentSerializer.java
@@ -17,6 +17,10 @@ public class ScoreComponentSerializer extends BaseComponentSerializer implements
     public ScoreComponent deserialize(JsonElement element, Type type, JsonDeserializationContext context) throws JsonParseException
     {
         JsonObject json = element.getAsJsonObject();
+        if ( !json.has( "score" ) )
+        {
+            throw new JsonParseException( "Could not parse JSON: missing 'score' property" );
+        }
         JsonObject score = json.get( "score" ).getAsJsonObject();
         if ( !score.has( "name" ) || !score.has( "objective" ) )
         {

--- a/chat/src/main/java/net/md_5/bungee/chat/SelectorComponentSerializer.java
+++ b/chat/src/main/java/net/md_5/bungee/chat/SelectorComponentSerializer.java
@@ -17,6 +17,10 @@ public class SelectorComponentSerializer extends BaseComponentSerializer impleme
     public SelectorComponent deserialize(JsonElement element, Type type, JsonDeserializationContext context) throws JsonParseException
     {
         JsonObject object = element.getAsJsonObject();
+        if ( !object.has( "selector" ) )
+        {
+            throw new JsonParseException( "Could not parse JSON: missing 'selector' property" );
+        }
         SelectorComponent component = new SelectorComponent( object.get( "selector" ).getAsString() );
         deserialize( object, component, context );
         return component;

--- a/chat/src/main/java/net/md_5/bungee/chat/TranslatableComponentSerializer.java
+++ b/chat/src/main/java/net/md_5/bungee/chat/TranslatableComponentSerializer.java
@@ -21,6 +21,10 @@ public class TranslatableComponentSerializer extends BaseComponentSerializer imp
         TranslatableComponent component = new TranslatableComponent();
         JsonObject object = json.getAsJsonObject();
         deserialize( object, component, context );
+        if ( !object.has( "translate" ) )
+        {
+            throw new JsonParseException( "Could not parse JSON: missing 'translate' property" );
+        }
         component.setTranslate( object.get( "translate" ).getAsString() );
         if ( object.has( "with" ) )
         {


### PR DESCRIPTION
Closes #2898 
 
- Check if a value CAN be parsed as a BaseComponent[] before attempting to parse it through the Content deserialiser
- When removing enclosing quotes from deserialised NBT, don't remove all quotes as they may have been escaping
- Check for ALL the number suffix types
- Throw JSONParseException if: no selector in selector component, no translate in translate component, etc.
- JsonObject is not JsonPrimitive
- Cleaned up unit tests a bit