### PR TITLE
Prevent normal packets on HANDSHAKE

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -144,6 +144,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
     @Override
     public void handle(PacketWrapper packet) throws Exception
     {
+        Preconditions.checkState( thisState == State.HANDSHAKE, "Not expecting Packet on HANDSHAKE" );
         if ( packet.packet == null )
         {
             throw new QuietException( "Unexpected packet received during login process! " + BufUtil.dump( packet.buf, 16 ) );
@@ -153,6 +154,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
     @Override
     public void handle(PluginMessage pluginMessage) throws Exception
     {
+        Preconditions.checkState( thisState == State.HANDSHAKE, "Not expecting PluginMessage on HANDSHAKE" );
         // TODO: Unregister?
         if ( PluginMessage.SHOULD_RELAY.apply( pluginMessage ) )
         {

--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -144,7 +144,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
     @Override
     public void handle(PacketWrapper packet) throws Exception
     {
-        Preconditions.checkState( thisState == State.HANDSHAKE, "Not expecting Packet on HANDSHAKE" );
+        Preconditions.checkState( thisState != State.HANDSHAKE, "Not expecting Packet on HANDSHAKE" );
         if ( packet.packet == null )
         {
             throw new QuietException( "Unexpected packet received during login process! " + BufUtil.dump( packet.buf, 16 ) );
@@ -154,7 +154,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
     @Override
     public void handle(PluginMessage pluginMessage) throws Exception
     {
-        Preconditions.checkState( thisState == State.HANDSHAKE, "Not expecting PluginMessage on HANDSHAKE" );
+        Preconditions.checkState( thisState != State.HANDSHAKE, "Not expecting PluginMessage on HANDSHAKE" );
         // TODO: Unregister?
         if ( PluginMessage.SHOULD_RELAY.apply( pluginMessage ) )
         {


### PR DESCRIPTION
Prevent "junk" packets during HANDSHAKE to avoid Netty thread overloading.

Please improve the code. My knowledge on Netty is minimal and i am just trying to bring fixes to BungeeCord.

Tested and working against "(not really) empty/null ping" exploit.