### PR TITLE
Don't frame packets for dead connections

### DIFF
--- a/protocol/src/main/java/net/md_5/bungee/protocol/LegacyDecoder.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/LegacyDecoder.java
@@ -14,6 +14,13 @@ public class LegacyDecoder extends ByteToMessageDecoder
     @Override
     protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception
     {
+        // See check in Varint21FrameDecoder for more details
+        if ( !ctx.channel().isActive() )
+        {
+            in.skipBytes( in.readableBytes() );
+            return;
+        }
+
         if ( !in.isReadable() )
         {
             return;

--- a/protocol/src/main/java/net/md_5/bungee/protocol/MinecraftDecoder.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/MinecraftDecoder.java
@@ -20,6 +20,13 @@ public class MinecraftDecoder extends MessageToMessageDecoder<ByteBuf>
     @Override
     protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception
     {
+        // See Varint21FrameDecoder for the general reasoning. We add this here as ByteToMessageDecoder#handlerRemoved()
+        // will fire any cumulated data through the pipeline, so we want to try and stop it here.
+        if ( !ctx.channel().isActive() )
+        {
+            return;
+        }
+
         Protocol.DirectionData prot = ( server ) ? protocol.TO_SERVER : protocol.TO_CLIENT;
         ByteBuf slice = in.copy(); // Can't slice this one due to EntityMap :(
 

--- a/protocol/src/main/java/net/md_5/bungee/protocol/Varint21FrameDecoder.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/Varint21FrameDecoder.java
@@ -15,6 +15,16 @@ public class Varint21FrameDecoder extends ByteToMessageDecoder
     @Override
     protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception
     {
+        // If we decode an invalid packet and an exception is thrown (thus triggering a close of the connection),
+        // the Netty ByteToMessageDecoder will continue to frame more packets and potentially call fireChannelRead()
+        // on them, likely with more invalid packets. Therefore, check if the connection is no longer active and if so
+        // sliently discard the packet.
+        if ( !ctx.channel().isActive() )
+        {
+            in.skipBytes( in.readableBytes() );
+            return;
+        }
+
         in.markReaderIndex();
 
         final byte[] buf = new byte[ 3 ];


### PR DESCRIPTION
Prior fixes such as #2902, #2901, #2876, and #2719 (probably others) fail to actually fix this issue (known as "nullping" or "bungeesmasher" by users who don't know any better).

This PR contains an actual fix (which is fundamentally very simple), and I will aim to explain the problem in deep detail, and provide some actual thoughts on the matter. This is all stream-of-consciousness, but my motivation for pushing this up now is merely to get this off my mind.

# The problem

The problem is, fundamentally speaking, the proxy will continue to decode packets even after the channel that sent them is disconnected. Assuming Netty uses an initial recvbuf size of 1,024 bytes, we can batch 512 properly-framed but invalid packets (one byte for length, the other byte for the packet ID).

This can be very simply evidenced by just sending 512 copies of `\0x01\0x00` to the proxy over multiple connections. This will produce around 512 exceptions. Creating an exception is fairly expensive due to stack trace generation (if you [believe Aleksey Shipilev](https://shipilev.net/blog/2014/exceptional-performance/)).

# The solution

See the code - we add a check for `Varint21FrameDecoder` to silently discard any further packets if the connection was closed afterwards.

# A bit of commentary

This community has a severe lackadaisical approach to security problems, discovering them and then locking up both the PoC methods and fixes behind paid resources (with some of these actors being quite insidious). For me to even discover this fix, it took me months of painstakingly extracting information from random people in the community. I have since devised this proven fix and it is being used in Velocity and Paper with great success. _I would urge this to get pulled ASAP._

I've brought this up to Mojang directly for them to solve, and hope a fix comes in 1.16.2 or 1.17.