### PR TITLE
Add annotations about method behaviour: @Nullable, @NotNull, @Contract, @UnmodifiableView

### DIFF
--- a/api/src/main/java/net/md_5/bungee/Util.java
+++ b/api/src/main/java/net/md_5/bungee/Util.java
@@ -8,6 +8,8 @@ import java.net.SocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.UUID;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Series of utility classes to perform various operations.
@@ -23,7 +25,8 @@ public class Util
      * @param hostline in the format of 'host:port'
      * @return the constructed hostname + port.
      */
-    public static SocketAddress getAddr(String hostline)
+    @Contract(pure = true)
+    public static SocketAddress getAddr(@NotNull String hostline)
     {
         URI uri = null;
         try
@@ -63,6 +66,8 @@ public class Util
      * @param i the integer to format
      * @return the hex representation of the integer
      */
+    @NotNull
+    @Contract(pure = true)
     public static String hex(int i)
     {
         return String.format( "0x%02X", i );
@@ -75,7 +80,9 @@ public class Util
      * @param t the {@link Throwable} to format.
      * @return a string representing information about the {@link Throwable}
      */
-    public static String exception(Throwable t)
+    @NotNull
+    @Contract(pure = true)
+    public static String exception(@NotNull Throwable t)
     {
         // TODO: We should use clear manually written exceptions
         StackTraceElement[] trace = t.getStackTrace();
@@ -83,12 +90,16 @@ public class Util
                 + ( ( trace.length > 0 ) ? " @ " + t.getStackTrace()[0].getClassName() + ":" + t.getStackTrace()[0].getLineNumber() : "" );
     }
 
-    public static String csv(Iterable<?> objects)
+    @NotNull
+    @Contract(pure = true)
+    public static String csv(@NotNull Iterable<?> objects)
     {
         return format( objects, ", " );
     }
 
-    public static String format(Iterable<?> objects, String separators)
+    @NotNull
+    @Contract(pure = true)
+    public static String format(@NotNull Iterable<?> objects, @NotNull String separators)
     {
         return Joiner.on( separators ).join( objects );
     }
@@ -99,7 +110,9 @@ public class Util
      * @param uuid The string to be converted
      * @return The result
      */
-    public static UUID getUUID(String uuid)
+    @NotNull
+    @Contract(pure = true)
+    public static UUID getUUID(@NotNull String uuid)
     {
         return new UUID( UnsignedLongs.parseUnsignedLong( uuid.substring( 0, 16 ), 16 ), UnsignedLongs.parseUnsignedLong( uuid.substring( 16 ), 16 ) );
     }

--- a/api/src/main/java/net/md_5/bungee/api/AbstractReconnectHandler.java
+++ b/api/src/main/java/net/md_5/bungee/api/AbstractReconnectHandler.java
@@ -4,12 +4,13 @@ import com.google.common.base.Preconditions;
 import net.md_5.bungee.api.config.ServerInfo;
 import net.md_5.bungee.api.connection.PendingConnection;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
+import org.jetbrains.annotations.NotNull;
 
 public abstract class AbstractReconnectHandler implements ReconnectHandler
 {
 
     @Override
-    public ServerInfo getServer(ProxiedPlayer player)
+    public ServerInfo getServer(@NotNull ProxiedPlayer player)
     {
         ServerInfo server = getForcedHost( player.getPendingConnection() );
         if ( server == null )

--- a/api/src/main/java/net/md_5/bungee/api/CommandSender.java
+++ b/api/src/main/java/net/md_5/bungee/api/CommandSender.java
@@ -2,6 +2,9 @@ package net.md_5.bungee.api;
 
 import java.util.Collection;
 import net.md_5.bungee.api.chat.BaseComponent;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.UnmodifiableView;
 
 public interface CommandSender
 {
@@ -11,6 +14,8 @@ public interface CommandSender
      *
      * @return the senders username
      */
+    @NotNull
+    @Contract(pure = true)
     public String getName();
 
     /**
@@ -19,7 +24,7 @@ public interface CommandSender
      * @param message the message to send
      */
     @Deprecated
-    public void sendMessage(String message);
+    public void sendMessage(@NotNull String message);
 
     /**
      * Send several messages to this sender. Each message will be sent
@@ -28,21 +33,21 @@ public interface CommandSender
      * @param messages the messages to send
      */
     @Deprecated
-    public void sendMessages(String... messages);
+    public void sendMessages(@NotNull String... messages);
 
     /**
      * Send a message to this sender.
      *
      * @param message the message to send
      */
-    public void sendMessage(BaseComponent... message);
+    public void sendMessage(@NotNull BaseComponent... message);
 
     /**
      * Send a message to this sender.
      *
      * @param message the message to send
      */
-    public void sendMessage(BaseComponent message);
+    public void sendMessage(@NotNull BaseComponent message);
 
     /**
      * Get all groups this user is part of. This returns an unmodifiable
@@ -50,6 +55,8 @@ public interface CommandSender
      *
      * @return the users groups
      */
+    @NotNull
+    @UnmodifiableView
     public Collection<String> getGroups();
 
     /**
@@ -57,14 +64,14 @@ public interface CommandSender
      *
      * @param groups the groups to add
      */
-    public void addGroups(String... groups);
+    public void addGroups(@NotNull String... groups);
 
     /**
      * Remove groups from this user for the current session only.
      *
      * @param groups the groups to remove
      */
-    public void removeGroups(String... groups);
+    public void removeGroups(@NotNull String... groups);
 
     /**
      * Checks if this user has the specified permission node.
@@ -72,7 +79,7 @@ public interface CommandSender
      * @param permission the node to check
      * @return whether they have this node
      */
-    public boolean hasPermission(String permission);
+    public boolean hasPermission(@NotNull String permission);
 
     /**
      * Set a permission node for this user.
@@ -80,7 +87,7 @@ public interface CommandSender
      * @param permission the node to set
      * @param value the value of the node
      */
-    public void setPermission(String permission, boolean value);
+    public void setPermission(@NotNull String permission, boolean value);
 
     /**
      * Get all Permissions which this CommandSender has
@@ -88,5 +95,7 @@ public interface CommandSender
      * @return a unmodifiable Collection of Strings which represent their
      * permissions
      */
+    @NotNull
+    @UnmodifiableView
     public Collection<String> getPermissions();
 }

--- a/api/src/main/java/net/md_5/bungee/api/Favicon.java
+++ b/api/src/main/java/net/md_5/bungee/api/Favicon.java
@@ -13,6 +13,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Favicon shown in the server list.
@@ -37,6 +38,7 @@ public class Favicon
         }
     };
 
+    @NotNull
     public static TypeAdapter<Favicon> getFaviconTypeAdapter()
     {
         return FAVICON_TYPE_ADAPTER;
@@ -57,7 +59,8 @@ public class Favicon
      * @throws IllegalArgumentException if the favicon is larger than
      * {@link Short#MAX_VALUE} or not of dimensions 64x64 pixels.
      */
-    public static Favicon create(BufferedImage image)
+    @NotNull
+    public static Favicon create(@NotNull BufferedImage image)
     {
         // check size
         if ( image.getWidth() != 64 || image.getHeight() != 64 )
@@ -99,7 +102,8 @@ public class Favicon
      * @deprecated Use #create(java.awt.image.BufferedImage) instead
      */
     @Deprecated
-    public static Favicon create(String encodedString)
+    @NotNull
+    public static Favicon create(@NotNull String encodedString)
     {
         return new Favicon( encodedString );
     }

--- a/api/src/main/java/net/md_5/bungee/api/ProxyServer.java
+++ b/api/src/main/java/net/md_5/bungee/api/ProxyServer.java
@@ -16,11 +16,16 @@ import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.plugin.Plugin;
 import net.md_5.bungee.api.plugin.PluginManager;
 import net.md_5.bungee.api.scheduler.TaskScheduler;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.UnmodifiableView;
 
 public abstract class ProxyServer
 {
 
     @Getter
+    @NotNull
     private static ProxyServer instance;
 
     /**
@@ -41,6 +46,7 @@ public abstract class ProxyServer
      *
      * @return the name of this instance
      */
+    @NotNull
     public abstract String getName();
 
     /**
@@ -48,6 +54,7 @@ public abstract class ProxyServer
      *
      * @return the version of this instance
      */
+    @NotNull
     public abstract String getVersion();
 
     /**
@@ -57,7 +64,8 @@ public abstract class ProxyServer
      * @param args translation arguments
      * @return the localized string
      */
-    public abstract String getTranslation(String name, Object... args);
+    @NotNull
+    public abstract String getTranslation(@NotNull String name, @Nullable Object... args);
 
     /**
      * Gets the main logger which can be used as a suitable replacement for
@@ -65,6 +73,7 @@ public abstract class ProxyServer
      *
      * @return the {@link Logger} instance
      */
+    @NotNull
     public abstract Logger getLogger();
 
     /**
@@ -72,6 +81,8 @@ public abstract class ProxyServer
      *
      * @return all connected players
      */
+    @NotNull
+    @UnmodifiableView
     public abstract Collection<ProxiedPlayer> getPlayers();
 
     /**
@@ -80,7 +91,9 @@ public abstract class ProxyServer
      * @param name of the player
      * @return their player instance
      */
-    public abstract ProxiedPlayer getPlayer(String name);
+    @Nullable
+    @Contract("null -> null; !null -> _")
+    public abstract ProxiedPlayer getPlayer(@Nullable String name);
 
     /**
      * Gets a connected player via their UUID
@@ -88,7 +101,9 @@ public abstract class ProxyServer
      * @param uuid of the player
      * @return their player instance
      */
-    public abstract ProxiedPlayer getPlayer(UUID uuid);
+    @Nullable
+    @Contract("null -> null; !null -> _")
+    public abstract ProxiedPlayer getPlayer(@Nullable UUID uuid);
 
     /**
      * Return all servers registered to this proxy, keyed by name. Unlike the
@@ -97,6 +112,7 @@ public abstract class ProxyServer
      *
      * @return all registered remote server destinations
      */
+    @NotNull
     public abstract Map<String, ServerInfo> getServers();
 
     /**
@@ -105,7 +121,9 @@ public abstract class ProxyServer
      * @param name the name of the configured server
      * @return the server info belonging to the specified server
      */
-    public abstract ServerInfo getServerInfo(String name);
+    @Nullable
+    @Contract("null -> null; !null -> _")
+    public abstract ServerInfo getServerInfo(@Nullable String name);
 
     /**
      * Get the {@link PluginManager} associated with loading plugins and
@@ -114,6 +132,7 @@ public abstract class ProxyServer
      *
      * @return the plugin manager
      */
+    @NotNull
     public abstract PluginManager getPluginManager();
 
     /**
@@ -121,6 +140,7 @@ public abstract class ProxyServer
      *
      * @return the used configuration adapter
      */
+    @NotNull
     public abstract ConfigurationAdapter getConfigurationAdapter();
 
     /**
@@ -129,13 +149,14 @@ public abstract class ProxyServer
      *
      * @param adapter the adapter to use
      */
-    public abstract void setConfigurationAdapter(ConfigurationAdapter adapter);
+    public abstract void setConfigurationAdapter(@NotNull ConfigurationAdapter adapter);
 
     /**
      * Get the currently in use reconnect handler.
      *
      * @return the in use reconnect handler
      */
+    @Nullable
     public abstract ReconnectHandler getReconnectHandler();
 
     /**
@@ -143,7 +164,7 @@ public abstract class ProxyServer
      *
      * @param handler the new handler
      */
-    public abstract void setReconnectHandler(ReconnectHandler handler);
+    public abstract void setReconnectHandler(@Nullable ReconnectHandler handler);
 
     /**
      * Gracefully mark this instance for shutdown.
@@ -155,7 +176,7 @@ public abstract class ProxyServer
      *
      * @param reason the reason for stopping. This will be shown to players.
      */
-    public abstract void stop(String reason);
+    public abstract void stop(@NotNull String reason);
 
     /**
      * Register a channel for use with plugin messages. This is required by some
@@ -163,20 +184,22 @@ public abstract class ProxyServer
      *
      * @param channel the channel to register
      */
-    public abstract void registerChannel(String channel);
+    public abstract void registerChannel(@Nullable String channel);
 
     /**
      * Unregister a previously registered channel.
      *
      * @param channel the channel to unregister
      */
-    public abstract void unregisterChannel(String channel);
+    public abstract void unregisterChannel(@Nullable String channel);
 
     /**
      * Get an immutable set of all registered plugin channels.
      *
      * @return registered plugin channels
      */
+    @NotNull
+    @UnmodifiableView
     public abstract Collection<String> getChannels();
 
     /**
@@ -185,6 +208,7 @@ public abstract class ProxyServer
      * @return the supported Minecraft version
      */
     @Deprecated
+    @NotNull
     public abstract String getGameVersion();
 
     /**
@@ -205,7 +229,8 @@ public abstract class ProxyServer
      * @param restricted whether the server info restricted property will be set
      * @return the constructed instance
      */
-    public abstract ServerInfo constructServerInfo(String name, InetSocketAddress address, String motd, boolean restricted);
+    @NotNull
+    public abstract ServerInfo constructServerInfo(@NotNull String name, @NotNull InetSocketAddress address, String motd, boolean restricted);
 
     /**
      * Factory method to construct an implementation specific server info
@@ -217,7 +242,8 @@ public abstract class ProxyServer
      * @param restricted whether the server info restricted property will be set
      * @return the constructed instance
      */
-    public abstract ServerInfo constructServerInfo(String name, SocketAddress address, String motd, boolean restricted);
+    @NotNull
+    public abstract ServerInfo constructServerInfo(@NotNull String name, @NotNull SocketAddress address, String motd, boolean restricted);
 
     /**
      * Returns the console overlord for this proxy. Being the console, this
@@ -226,6 +252,7 @@ public abstract class ProxyServer
      *
      * @return the console command sender of this proxy
      */
+    @NotNull
     public abstract CommandSender getConsole();
 
     /**
@@ -233,6 +260,7 @@ public abstract class ProxyServer
      *
      * @return the folder used to load plugin
      */
+    @NotNull
     public abstract File getPluginsFolder();
 
     /**
@@ -240,6 +268,7 @@ public abstract class ProxyServer
      *
      * @return the in use scheduler
      */
+    @NotNull
     public abstract TaskScheduler getScheduler();
 
     /**
@@ -257,27 +286,28 @@ public abstract class ProxyServer
      * @param message the message to broadcast
      */
     @Deprecated
-    public abstract void broadcast(String message);
+    public abstract void broadcast(@NotNull String message);
 
     /**
      * Send the specified message to the console and all connected players.
      *
      * @param message the message to broadcast
      */
-    public abstract void broadcast(BaseComponent... message);
+    public abstract void broadcast(@NotNull BaseComponent... message);
 
     /**
      * Send the specified message to the console and all connected players.
      *
      * @param message the message to broadcast
      */
-    public abstract void broadcast(BaseComponent message);
+    public abstract void broadcast(@NotNull BaseComponent message);
 
     /**
      * Gets the commands which are disabled and will not be run on this proxy.
      *
      * @return the set of disabled commands
      */
+    @NotNull
     public abstract Collection<String> getDisabledCommands();
 
     /**
@@ -285,6 +315,7 @@ public abstract class ProxyServer
      *
      * @return the config.
      */
+    @NotNull
     public abstract ProxyConfig getConfig();
 
     /**
@@ -299,7 +330,8 @@ public abstract class ProxyServer
      * @return list of all possible players, singleton if there is an exact
      * match
      */
-    public abstract Collection<ProxiedPlayer> matchPlayer(String match);
+    @NotNull
+    public abstract Collection<ProxiedPlayer> matchPlayer(@NotNull String match);
 
     /**
      * Creates a new empty title configuration. In most cases you will want to
@@ -309,6 +341,6 @@ public abstract class ProxyServer
      * @return A new empty title configuration.
      * @see Title
      */
+    @NotNull
     public abstract Title createTitle();
-
 }

--- a/api/src/main/java/net/md_5/bungee/api/ReconnectHandler.java
+++ b/api/src/main/java/net/md_5/bungee/api/ReconnectHandler.java
@@ -2,6 +2,7 @@ package net.md_5.bungee.api;
 
 import net.md_5.bungee.api.config.ServerInfo;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
+import org.jetbrains.annotations.NotNull;
 
 public interface ReconnectHandler
 {
@@ -12,7 +13,7 @@ public interface ReconnectHandler
      * @param player the connecting player
      * @return the server to connect to
      */
-    ServerInfo getServer(ProxiedPlayer player);
+    ServerInfo getServer(@NotNull ProxiedPlayer player);
 
     /**
      * Save the server of this player before they disconnect so it can be
@@ -20,7 +21,7 @@ public interface ReconnectHandler
      *
      * @param player the player to save
      */
-    void setServer(ProxiedPlayer player); // TOOD: String + String arguments?
+    void setServer(@NotNull ProxiedPlayer player); // TOOD: String + String arguments?
 
     /**
      * Save all pending reconnect locations. Whilst not used for database

--- a/api/src/main/java/net/md_5/bungee/api/ServerConnectRequest.java
+++ b/api/src/main/java/net/md_5/bungee/api/ServerConnectRequest.java
@@ -6,6 +6,7 @@ import lombok.NonNull;
 import lombok.Setter;
 import net.md_5.bungee.api.config.ServerInfo;
 import net.md_5.bungee.api.event.ServerConnectEvent;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * A request to connect a server.
@@ -56,6 +57,7 @@ public class ServerConnectRequest
     /**
      * Callback to execute post request.
      */
+    @Nullable
     private final Callback<Result> callback;
     /**
      * Timeout in milliseconds for request.

--- a/api/src/main/java/net/md_5/bungee/api/ServerPing.java
+++ b/api/src/main/java/net/md_5/bungee/api/ServerPing.java
@@ -6,10 +6,13 @@ import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.NonNull;
 import lombok.ToString;
 import net.md_5.bungee.Util;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.TextComponent;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Represents the standard list data returned by opening a server in the
@@ -22,6 +25,7 @@ import net.md_5.bungee.api.chat.TextComponent;
 public class ServerPing
 {
 
+    @NonNull
     private Protocol version;
 
     @Data
@@ -32,6 +36,7 @@ public class ServerPing
         private String name;
         private int protocol;
     }
+    @NonNull
     private Players players;
 
     @Data
@@ -41,6 +46,7 @@ public class ServerPing
 
         private int max;
         private int online;
+        @Nullable
         private PlayerInfo[] sample;
     }
 
@@ -72,13 +78,16 @@ public class ServerPing
             }
         }
 
+        @NotNull
         public String getId()
         {
             return uniqueId.toString().replace( "-", "" );
         }
     }
 
+    @NonNull
     private BaseComponent description;
+    @Nullable
     private Favicon favicon;
 
     @Data
@@ -114,45 +123,49 @@ public class ServerPing
         this( version, players, new TextComponent( TextComponent.fromLegacyText( description ) ), favicon );
     }
 
+    @Nullable
     @Deprecated
     public String getFavicon()
     {
         return getFaviconObject() == null ? null : getFaviconObject().getEncoded();
     }
 
+    @Nullable
     public Favicon getFaviconObject()
     {
         return this.favicon;
     }
 
     @Deprecated
-    public void setFavicon(String favicon)
+    public void setFavicon(@Nullable String favicon)
     {
         setFavicon( favicon == null ? null : Favicon.create( favicon ) );
     }
 
-    public void setFavicon(Favicon favicon)
+    public void setFavicon(@Nullable Favicon favicon)
     {
         this.favicon = favicon;
     }
 
     @Deprecated
-    public void setDescription(String description)
+    public void setDescription(@NotNull String description)
     {
         this.description = new TextComponent( TextComponent.fromLegacyText( description ) );
     }
 
+    @NotNull
     @Deprecated
     public String getDescription()
     {
         return BaseComponent.toLegacyText( description );
     }
 
-    public void setDescriptionComponent(BaseComponent description)
+    public void setDescriptionComponent(@NotNull BaseComponent description)
     {
         this.description = description;
     }
 
+    @NotNull
     public BaseComponent getDescriptionComponent()
     {
         return description;

--- a/api/src/main/java/net/md_5/bungee/api/Title.java
+++ b/api/src/main/java/net/md_5/bungee/api/Title.java
@@ -2,6 +2,9 @@ package net.md_5.bungee.api;
 
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Represents a configuration of a title. A title in Minecraft consists of a
@@ -22,7 +25,8 @@ public interface Title
      * @param text The text to use as the title.
      * @return This title configuration.
      */
-    public Title title(BaseComponent text);
+    @Contract(mutates = "this", value = "_ -> this")
+    public Title title(@Nullable BaseComponent text);
 
     /**
      * Set the title to send to the player.
@@ -30,7 +34,8 @@ public interface Title
      * @param text The text to use as the title.
      * @return This title configuration.
      */
-    public Title title(BaseComponent... text);
+    @Contract(mutates = "this", value = "!null -> this")
+    public Title title(@NotNull BaseComponent... text);
 
     /**
      * Set the subtitle to send to the player.
@@ -38,7 +43,8 @@ public interface Title
      * @param text The text to use as the subtitle.
      * @return This title configuration.
      */
-    public Title subTitle(BaseComponent text);
+    @Contract(mutates = "this", value = "_ -> this")
+    public Title subTitle(@Nullable BaseComponent text);
 
     /**
      * Set the subtitle to send to the player.
@@ -46,7 +52,8 @@ public interface Title
      * @param text The text to use as the subtitle.
      * @return This title configuration.
      */
-    public Title subTitle(BaseComponent... text);
+    @Contract(mutates = "this", value = "!null -> this")
+    public Title subTitle(@NotNull BaseComponent... text);
 
     /**
      * Set the duration in ticks of the fade in effect of the title. Once this
@@ -57,6 +64,7 @@ public interface Title
      * @param ticks The amount of ticks (1/20 second) for the fade in effect.
      * @return This title configuration.
      */
+    @Contract(mutates = "this", value = "_ -> this")
     public Title fadeIn(int ticks);
 
     /**
@@ -68,6 +76,7 @@ public interface Title
      * @param ticks The amount of ticks (1/20 second) for the stay effect.
      * @return This title configuration.
      */
+    @Contract(mutates = "this", value = "_ -> this")
     public Title stay(int ticks);
 
     /**
@@ -77,6 +86,7 @@ public interface Title
      * @param ticks The amount of ticks (1/20 second) for the fade out effect.
      * @return This title configuration.
      */
+    @Contract(mutates = "this", value = "_ -> this")
     public Title fadeOut(int ticks);
 
     /**
@@ -85,6 +95,7 @@ public interface Title
      *
      * @return This title configuration.
      */
+    @Contract(mutates = "this", value = "-> this")
     public Title clear();
 
     /**
@@ -93,6 +104,7 @@ public interface Title
      *
      * @return This title configuration.
      */
+    @Contract(mutates = "this", value = "-> this")
     public Title reset();
 
     /**
@@ -102,5 +114,6 @@ public interface Title
      * @param player The player to send the title to.
      * @return This title configuration.
      */
-    public Title send(ProxiedPlayer player);
+    @Contract(value = "!null -> this")
+    public Title send(@NotNull ProxiedPlayer player);
 }

--- a/api/src/main/java/net/md_5/bungee/api/config/ConfigurationAdapter.java
+++ b/api/src/main/java/net/md_5/bungee/api/config/ConfigurationAdapter.java
@@ -2,6 +2,9 @@ package net.md_5.bungee.api.config;
 
 import java.util.Collection;
 import java.util.Map;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * This class allows plugins to set their own configuration adapter to load
@@ -23,7 +26,7 @@ public interface ConfigurationAdapter
      * @param def the default value
      * @return the retrieved integer
      */
-    public int getInt(String path, int def);
+    public int getInt(@NotNull String path, int def);
 
     /**
      * Gets a string from the specified path.
@@ -32,7 +35,9 @@ public interface ConfigurationAdapter
      * @param def the default value
      * @return the retrieved string
      */
-    public String getString(String path, String def);
+    @Nullable
+    @Contract("!null, !null -> !null; !null, null -> _")
+    public String getString(@NotNull String path, @Nullable String def);
 
     /**
      * Gets a boolean from the specified path.
@@ -41,7 +46,7 @@ public interface ConfigurationAdapter
      * @param def the default value
      * @return the retrieved boolean
      */
-    public boolean getBoolean(String path, boolean def);
+    public boolean getBoolean(@NotNull String path, boolean def);
 
     /**
      * Get a list from the specified path.
@@ -50,13 +55,16 @@ public interface ConfigurationAdapter
      * @param def the default value
      * @return the retrieved list
      */
-    public Collection<?> getList(String path, Collection<?> def);
+    @Nullable
+    @Contract("!null, !null -> !null; !null, null -> _")
+    public Collection<?> getList(@NotNull String path, @Nullable Collection<?> def);
 
     /**
      * Get the configuration all servers which may be accessible via the proxy.
      *
      * @return all accessible servers, keyed by name
      */
+    @NotNull
     public Map<String, ServerInfo> getServers();
 
     /**
@@ -64,6 +72,7 @@ public interface ConfigurationAdapter
      *
      * @return a list of all hosts to bind to
      */
+    @NotNull
     public Collection<ListenerInfo> getListeners();
 
     /**
@@ -72,14 +81,16 @@ public interface ConfigurationAdapter
      * @param player the player to check
      * @return all the player's groups.
      */
-    public Collection<String> getGroups(String player);
+    @NotNull
+    public Collection<String> getGroups(@Nullable String player);
 
     /**
      * Get all permission corresponding to the specified group. The result of
      * this method may or may not be cached, depending on the implementation.
      *
      * @param group the group to check
-     * @return all true permissions for this group
+     * @return all true permissions for this group, if group does not exist, collection is empty and unmodifiable
      */
+    @NotNull
     public Collection<String> getPermissions(String group);
 }

--- a/api/src/main/java/net/md_5/bungee/api/config/ServerInfo.java
+++ b/api/src/main/java/net/md_5/bungee/api/config/ServerInfo.java
@@ -7,6 +7,7 @@ import net.md_5.bungee.api.Callback;
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.ServerPing;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Class used to represent a server to connect to.
@@ -68,6 +69,7 @@ public interface ServerInfo
      *
      * @return access permission
      */
+    @NotNull
     String getPermission();
 
     /**
@@ -77,7 +79,7 @@ public interface ServerInfo
      * @param sender the player to check access for
      * @return whether access is granted to this server
      */
-    boolean canAccess(CommandSender sender);
+    boolean canAccess(@NotNull CommandSender sender);
 
     /**
      * Send data by any available means to this server. This data may be queued
@@ -90,7 +92,7 @@ public interface ServerInfo
      * @param channel the channel to send this data via
      * @param data the data to send
      */
-    void sendData(String channel, byte[] data);
+    void sendData(@NotNull String channel, @NotNull byte[] data);
 
     /**
      * Send data by any available means to this server.
@@ -107,12 +109,12 @@ public interface ServerInfo
      * <code>false</code> otherwise if queue is true, it has been queued, if it
      * is false it has been discarded.
      */
-    boolean sendData(String channel, byte[] data, boolean queue);
+    boolean sendData(@NotNull String channel, @NotNull byte[] data, boolean queue);
 
     /**
      * Asynchronously gets the current player count on this server.
      *
      * @param callback the callback to call when the count has been retrieved.
      */
-    void ping(Callback<ServerPing> callback);
+    void ping(@NotNull Callback<ServerPing> callback);
 }

--- a/api/src/main/java/net/md_5/bungee/api/connection/Connection.java
+++ b/api/src/main/java/net/md_5/bungee/api/connection/Connection.java
@@ -4,6 +4,7 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.protocol.DefinedPacket;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * A proxy connection is defined as a connection directly connected to a socket.
@@ -20,6 +21,7 @@ public interface Connection
      * @deprecated BungeeCord can accept connections via Unix domain sockets
      */
     @Deprecated
+    @NotNull
     InetSocketAddress getAddress();
 
     /**
@@ -27,6 +29,7 @@ public interface Connection
      *
      * @return the remote address
      */
+    @NotNull
     SocketAddress getSocketAddress();
 
     /**
@@ -38,7 +41,7 @@ public interface Connection
      * disconnect
      */
     @Deprecated
-    void disconnect(String reason);
+    void disconnect(@NotNull String reason);
 
     /**
      * Disconnects this end of the connection for the specified reason. If this
@@ -48,7 +51,7 @@ public interface Connection
      * @param reason the reason shown to the player / sent to the server on
      * disconnect
      */
-    void disconnect(BaseComponent... reason);
+    void disconnect(@NotNull BaseComponent... reason);
 
     /**
      * Disconnects this end of the connection for the specified reason. If this
@@ -58,7 +61,7 @@ public interface Connection
      * @param reason the reason shown to the player / sent to the server on
      * disconnect
      */
-    void disconnect(BaseComponent reason);
+    void disconnect(@NotNull BaseComponent reason);
 
     /**
      * Gets whether this connection is currently open, ie: not disconnected, and

--- a/api/src/main/java/net/md_5/bungee/api/connection/PendingConnection.java
+++ b/api/src/main/java/net/md_5/bungee/api/connection/PendingConnection.java
@@ -3,6 +3,8 @@ package net.md_5.bungee.api.connection;
 import java.net.InetSocketAddress;
 import java.util.UUID;
 import net.md_5.bungee.api.config.ListenerInfo;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Represents a user attempting to log into the proxy.
@@ -15,6 +17,7 @@ public interface PendingConnection extends Connection
      *
      * @return the requested username, or null if not set
      */
+    @Nullable
     String getName();
 
     /**
@@ -29,6 +32,7 @@ public interface PendingConnection extends Connection
      *
      * @return request virtual host or null if invalid / not specified.
      */
+    @NotNull
     InetSocketAddress getVirtualHost();
 
     /**
@@ -36,6 +40,7 @@ public interface PendingConnection extends Connection
      *
      * @return the accepting listener
      */
+    @NotNull
     ListenerInfo getListener();
 
     /**
@@ -52,6 +57,7 @@ public interface PendingConnection extends Connection
      *
      * @return the UUID
      */
+    @Nullable
     UUID getUniqueId();
 
     /**

--- a/api/src/main/java/net/md_5/bungee/api/connection/ProxiedPlayer.java
+++ b/api/src/main/java/net/md_5/bungee/api/connection/ProxiedPlayer.java
@@ -13,6 +13,9 @@ import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.config.ServerInfo;
 import net.md_5.bungee.api.event.ServerConnectEvent;
 import net.md_5.bungee.api.score.Scoreboard;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.UnmodifiableView;
 
 /**
  * Represents a player who's connection is being connected to somewhere else,
@@ -52,8 +55,9 @@ public interface ProxiedPlayer extends Connection, CommandSender
     /**
      * Gets this player's display name.
      *
-     * @return the players current display name
+     * @return the players current display name (default: player's name)
      */
+    @NotNull
     String getDisplayName();
 
     /**
@@ -62,7 +66,7 @@ public interface ProxiedPlayer extends Connection, CommandSender
      *
      * @param name the name to set
      */
-    void setDisplayName(String name);
+    void setDisplayName(@NotNull String name);
 
     /**
      * Send a message to the specified screen position of this player.
@@ -70,7 +74,7 @@ public interface ProxiedPlayer extends Connection, CommandSender
      * @param position the screen position
      * @param message the message to send
      */
-    public void sendMessage(ChatMessageType position, BaseComponent... message);
+    public void sendMessage(@NotNull ChatMessageType position, @NotNull BaseComponent... message);
 
     /**
      * Send a message to the specified screen position of this player.
@@ -78,7 +82,7 @@ public interface ProxiedPlayer extends Connection, CommandSender
      * @param position the screen position
      * @param message the message to send
      */
-    public void sendMessage(ChatMessageType position, BaseComponent message);
+    public void sendMessage(@NotNull ChatMessageType position, @NotNull BaseComponent message);
 
     /**
      * Connects / transfers this user to the specified connection, gracefully
@@ -87,7 +91,7 @@ public interface ProxiedPlayer extends Connection, CommandSender
      *
      * @param target the new server to connect to
      */
-    void connect(ServerInfo target);
+    void connect(@NotNull ServerInfo target);
 
     /**
      * Connects / transfers this user to the specified connection, gracefully
@@ -97,7 +101,7 @@ public interface ProxiedPlayer extends Connection, CommandSender
      * @param target the new server to connect to
      * @param reason the reason for connecting to the new server
      */
-    void connect(ServerInfo target, ServerConnectEvent.Reason reason);
+    void connect(@NotNull ServerInfo target, ServerConnectEvent.Reason reason);
 
     /**
      * Connects / transfers this user to the specified connection, gracefully
@@ -109,7 +113,7 @@ public interface ProxiedPlayer extends Connection, CommandSender
      * when an exception is encountered. The boolean parameter denotes success
      * (true) or failure (false).
      */
-    void connect(ServerInfo target, Callback<Boolean> callback);
+    void connect(@NotNull ServerInfo target, @Nullable Callback<Boolean> callback);
 
     /**
      * Connects / transfers this user to the specified connection, gracefully
@@ -122,7 +126,7 @@ public interface ProxiedPlayer extends Connection, CommandSender
      * (true) or failure (false).
      * @param reason the reason for connecting to the new server
      */
-    void connect(ServerInfo target, Callback<Boolean> callback, ServerConnectEvent.Reason reason);
+    void connect(@NotNull ServerInfo target, @Nullable Callback<Boolean> callback, @NotNull ServerConnectEvent.Reason reason);
 
     /**
      * Connects / transfers this user to the specified connection, gracefully
@@ -131,7 +135,7 @@ public interface ProxiedPlayer extends Connection, CommandSender
      *
      * @param request request to connect with
      */
-    void connect(ServerConnectRequest request);
+    void connect(@NotNull ServerConnectRequest request);
 
     /**
      * Gets the server this player is connected to.
@@ -157,13 +161,14 @@ public interface ProxiedPlayer extends Connection, CommandSender
      * @param channel the channel to send this data via
      * @param data the data to send
      */
-    void sendData(String channel, byte[] data);
+    void sendData(@NotNull String channel, @NotNull byte[] data);
 
     /**
      * Get the pending connection that belongs to this player.
      *
      * @return the pending connection that this player used
      */
+    @NotNull
     PendingConnection getPendingConnection();
 
     /**
@@ -171,13 +176,14 @@ public interface ProxiedPlayer extends Connection, CommandSender
      *
      * @param message the message to say
      */
-    void chat(String message);
+    void chat(@NotNull String message);
 
     /**
      * Get the server which this player will be sent to next time the log in.
      *
      * @return the server, or null if default
      */
+    @Nullable
     ServerInfo getReconnectServer();
 
     /**
@@ -185,7 +191,7 @@ public interface ProxiedPlayer extends Connection, CommandSender
      *
      * @param server the server to set
      */
-    void setReconnectServer(ServerInfo server);
+    void setReconnectServer(@Nullable ServerInfo server);
 
     /**
      * Get this connection's UUID, if set.
@@ -222,6 +228,7 @@ public interface ProxiedPlayer extends Connection, CommandSender
      *
      * @return the chat flags set, or a reasonable default
      */
+    @NotNull
     ChatMode getChatMode();
 
     /**
@@ -236,6 +243,7 @@ public interface ProxiedPlayer extends Connection, CommandSender
      *
      * @return the players skin setting
      */
+    @NotNull
     SkinConfiguration getSkinParts();
 
     /**
@@ -243,6 +251,7 @@ public interface ProxiedPlayer extends Connection, CommandSender
      *
      * @return main hand setting
      */
+    @NotNull
     MainHand getMainHand();
 
     /**
@@ -251,7 +260,7 @@ public interface ProxiedPlayer extends Connection, CommandSender
      * @param header The header for the tab player list, null to clear it.
      * @param footer The footer for the tab player list, null to clear it.
      */
-    void setTabHeader(BaseComponent header, BaseComponent footer);
+    void setTabHeader(@Nullable BaseComponent header, @Nullable BaseComponent footer);
 
     /**
      * Set the header and footer displayed in the tab player list.
@@ -259,7 +268,7 @@ public interface ProxiedPlayer extends Connection, CommandSender
      * @param header The header for the tab player list, null to clear it.
      * @param footer The footer for the tab player list, null to clear it.
      */
-    void setTabHeader(BaseComponent[] header, BaseComponent[] footer);
+    void setTabHeader(@Nullable BaseComponent[] header, @Nullable BaseComponent[] footer);
 
     /**
      * Clears the header and footer displayed in the tab player list.
@@ -273,7 +282,7 @@ public interface ProxiedPlayer extends Connection, CommandSender
      * @param title The title to send to the player.
      * @see Title
      */
-    void sendTitle(Title title);
+    void sendTitle(@NotNull Title title);
 
     /**
      * Gets whether this player is using a FML client.
@@ -313,6 +322,8 @@ public interface ProxiedPlayer extends Connection, CommandSender
      * the value is the version. Returns an empty list if the FML handshake has
      * not occurred for this {@link ProxiedPlayer} yet.
      */
+    @NotNull
+    @UnmodifiableView
     Map<String, String> getModList();
 
     /**
@@ -320,5 +331,6 @@ public interface ProxiedPlayer extends Connection, CommandSender
      *
      * @return this player's {@link Scoreboard}
      */
+    @NotNull
     Scoreboard getScoreboard();
 }

--- a/api/src/main/java/net/md_5/bungee/api/connection/Server.java
+++ b/api/src/main/java/net/md_5/bungee/api/connection/Server.java
@@ -1,6 +1,7 @@
 package net.md_5.bungee.api.connection;
 
 import net.md_5.bungee.api.config.ServerInfo;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Represents a destination which this proxy might connect to.
@@ -13,6 +14,7 @@ public interface Server extends Connection
      *
      * @return the {@link ServerInfo} for this server
      */
+    @NotNull
     public ServerInfo getInfo();
 
     /**
@@ -25,5 +27,5 @@ public interface Server extends Connection
      * @param channel the channel to send this data via
      * @param data the data to send
      */
-    public abstract void sendData(String channel, byte[] data);
+    public abstract void sendData(@NotNull String channel, @NotNull byte[] data);
 }

--- a/api/src/main/java/net/md_5/bungee/api/event/AsyncEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/AsyncEvent.java
@@ -13,6 +13,7 @@ import lombok.ToString;
 import net.md_5.bungee.api.Callback;
 import net.md_5.bungee.api.plugin.Event;
 import net.md_5.bungee.api.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Represents an event which depends on the result of asynchronous operations.
@@ -51,7 +52,7 @@ public class AsyncEvent<T> extends Event
      *
      * @param plugin the plugin registering this intent
      */
-    public void registerIntent(Plugin plugin)
+    public void registerIntent(@NotNull Plugin plugin)
     {
         Preconditions.checkState( !fired.get(), "Event %s has already been fired", this );
 
@@ -73,7 +74,7 @@ public class AsyncEvent<T> extends Event
      * @param plugin a plugin which has an intent registered for this event
      */
     @SuppressWarnings("unchecked")
-    public void completeIntent(Plugin plugin)
+    public void completeIntent(@NotNull Plugin plugin)
     {
         AtomicInteger intentCount = intents.get( plugin );
         Preconditions.checkState( intentCount != null && intentCount.get() > 0, "Plugin %s has not registered intents for event %s", plugin, this );

--- a/api/src/main/java/net/md_5/bungee/api/event/ChatEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/ChatEvent.java
@@ -1,7 +1,8 @@
 package net.md_5.bungee.api.event;
 
-import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.ProxyServer;
@@ -12,7 +13,8 @@ import net.md_5.bungee.api.plugin.PluginManager;
 /**
  * Event called when a player sends a message to a server.
  */
-@Data
+@Getter
+@Setter
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
 public class ChatEvent extends TargetedEvent implements Cancellable

--- a/api/src/main/java/net/md_5/bungee/api/event/ClientConnectEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/ClientConnectEvent.java
@@ -7,6 +7,7 @@ import lombok.ToString;
 import net.md_5.bungee.api.config.ListenerInfo;
 import net.md_5.bungee.api.plugin.Cancellable;
 import net.md_5.bungee.api.plugin.Event;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Event called to represent an initial client connection.
@@ -27,9 +28,11 @@ public class ClientConnectEvent extends Event implements Cancellable
     /**
      * Remote address of connection.
      */
+    @NotNull
     private final SocketAddress socketAddress;
     /**
      * Listener that accepted the connection.
      */
+    @NotNull
     private final ListenerInfo listener;
 }

--- a/api/src/main/java/net/md_5/bungee/api/event/LoginEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/LoginEvent.java
@@ -1,8 +1,8 @@
 package net.md_5.bungee.api.event;
 
 import lombok.AccessLevel;
-import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import net.md_5.bungee.api.Callback;
@@ -10,11 +10,13 @@ import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.api.connection.PendingConnection;
 import net.md_5.bungee.api.plugin.Cancellable;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Event called to represent a player logging in.
  */
-@Data
+@Getter
+@Setter
 @ToString(callSuper = false)
 @EqualsAndHashCode(callSuper = false)
 public class LoginEvent extends AsyncEvent<LoginEvent> implements Cancellable
@@ -27,14 +29,16 @@ public class LoginEvent extends AsyncEvent<LoginEvent> implements Cancellable
     /**
      * Message to use when kicking if this event is canceled.
      */
+    @NotNull
     @Setter(AccessLevel.NONE)
     private BaseComponent[] cancelReasonComponents;
     /**
      * Connection attempting to login.
      */
+    @NotNull
     private final PendingConnection connection;
 
-    public LoginEvent(PendingConnection connection, Callback<LoginEvent> done)
+    public LoginEvent(@NotNull PendingConnection connection, Callback<LoginEvent> done)
     {
         super( done );
         this.connection = connection;
@@ -44,6 +48,7 @@ public class LoginEvent extends AsyncEvent<LoginEvent> implements Cancellable
      * @return reason to be displayed
      * @deprecated Use component methods instead.
      */
+    @NotNull
     @Deprecated
     public String getCancelReason()
     {
@@ -57,12 +62,12 @@ public class LoginEvent extends AsyncEvent<LoginEvent> implements Cancellable
      * instead.
      */
     @Deprecated
-    public void setCancelReason(String cancelReason)
+    public void setCancelReason(@NotNull String cancelReason)
     {
         setCancelReason( TextComponent.fromLegacyText( cancelReason ) );
     }
 
-    public void setCancelReason(BaseComponent... cancelReason)
+    public void setCancelReason(@NotNull BaseComponent... cancelReason)
     {
         this.cancelReasonComponents = cancelReason;
     }

--- a/api/src/main/java/net/md_5/bungee/api/event/PermissionCheckEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/PermissionCheckEvent.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 import lombok.ToString;
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.plugin.Event;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Called when the permission of a CommandSender is checked.
@@ -22,10 +23,12 @@ public class PermissionCheckEvent extends Event
     /**
      * The command sender being checked for a permission.
      */
+    @NotNull
     private final CommandSender sender;
     /**
      * The permission to check.
      */
+    @NotNull
     private final String permission;
     /**
      * The outcome of this permission check.

--- a/api/src/main/java/net/md_5/bungee/api/event/PlayerDisconnectEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/PlayerDisconnectEvent.java
@@ -5,6 +5,7 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.plugin.Event;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Called when a player has left the proxy, it is not safe to call any methods
@@ -19,5 +20,6 @@ public class PlayerDisconnectEvent extends Event
     /**
      * Player disconnecting.
      */
+    @NotNull
     private final ProxiedPlayer player;
 }

--- a/api/src/main/java/net/md_5/bungee/api/event/PlayerHandshakeEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/PlayerHandshakeEvent.java
@@ -6,6 +6,7 @@ import lombok.ToString;
 import net.md_5.bungee.api.connection.PendingConnection;
 import net.md_5.bungee.api.plugin.Event;
 import net.md_5.bungee.protocol.packet.Handshake;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Event called to represent a player first making their presence and username
@@ -20,15 +21,11 @@ public class PlayerHandshakeEvent extends Event
     /**
      * Connection attempting to login.
      */
+    @NotNull
     private final PendingConnection connection;
     /**
      * The handshake.
      */
+    @NotNull
     private final Handshake handshake;
-
-    public PlayerHandshakeEvent(PendingConnection connection, Handshake handshake)
-    {
-        this.connection = connection;
-        this.handshake = handshake;
-    }
 }

--- a/api/src/main/java/net/md_5/bungee/api/event/PluginMessageEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/PluginMessageEvent.java
@@ -1,15 +1,18 @@
 package net.md_5.bungee.api.event;
 
-import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
 import net.md_5.bungee.api.connection.Connection;
 import net.md_5.bungee.api.plugin.Cancellable;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Event called when a plugin message is sent to the client or server.
  */
-@Data
+@Getter
+@Setter
 @ToString(callSuper = true, exclude = "data")
 @EqualsAndHashCode(callSuper = true)
 public class PluginMessageEvent extends TargetedEvent implements Cancellable
@@ -22,13 +25,15 @@ public class PluginMessageEvent extends TargetedEvent implements Cancellable
     /**
      * Tag specified for this plugin message.
      */
+    @NotNull
     private final String tag;
     /**
      * Data contained in this plugin message.
      */
+    @NotNull
     private final byte[] data;
 
-    public PluginMessageEvent(Connection sender, Connection receiver, String tag, byte[] data)
+    public PluginMessageEvent(Connection sender, Connection receiver, @NotNull String tag, byte[] data)
     {
         super( sender, receiver );
         this.tag = tag;

--- a/api/src/main/java/net/md_5/bungee/api/event/PostLoginEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/PostLoginEvent.java
@@ -5,6 +5,7 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.plugin.Event;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Event called as soon as a connection has a {@link ProxiedPlayer} and is ready
@@ -19,5 +20,6 @@ public class PostLoginEvent extends Event
     /**
      * The player involved with this event.
      */
+    @NotNull
     private final ProxiedPlayer player;
 }

--- a/api/src/main/java/net/md_5/bungee/api/event/PreLoginEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/PreLoginEvent.java
@@ -1,8 +1,8 @@
 package net.md_5.bungee.api.event;
 
 import lombok.AccessLevel;
-import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import net.md_5.bungee.api.Callback;
@@ -10,6 +10,7 @@ import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.api.connection.PendingConnection;
 import net.md_5.bungee.api.plugin.Cancellable;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Event called to represent a player first making their presence and username
@@ -19,7 +20,8 @@ import net.md_5.bungee.api.plugin.Cancellable;
  * in after authentication with Mojang's servers. Examples of attributes which
  * are not available include their UUID.
  */
-@Data
+@Getter
+@Setter
 @ToString(callSuper = false)
 @EqualsAndHashCode(callSuper = false)
 public class PreLoginEvent extends AsyncEvent<PreLoginEvent> implements Cancellable
@@ -32,6 +34,7 @@ public class PreLoginEvent extends AsyncEvent<PreLoginEvent> implements Cancella
     /**
      * Message to use when kicking if this event is canceled.
      */
+    @NotNull
     @Setter(AccessLevel.NONE)
     private BaseComponent[] cancelReasonComponents;
     /**

--- a/api/src/main/java/net/md_5/bungee/api/event/ProxyPingEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/ProxyPingEvent.java
@@ -1,7 +1,8 @@
 package net.md_5.bungee.api.event;
 
-import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
 import net.md_5.bungee.api.Callback;
 import net.md_5.bungee.api.ServerPing;
@@ -10,7 +11,8 @@ import net.md_5.bungee.api.connection.PendingConnection;
 /**
  * Called when the proxy is pinged with packet 0xFE from the server list.
  */
-@Data
+@Getter
+@Setter
 @ToString(callSuper = false)
 @EqualsAndHashCode(callSuper = false)
 public class ProxyPingEvent extends AsyncEvent<ProxyPingEvent>

--- a/api/src/main/java/net/md_5/bungee/api/event/ProxyReloadEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/ProxyReloadEvent.java
@@ -2,14 +2,13 @@ package net.md_5.bungee.api.event;
 
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.plugin.Event;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Called when somebody reloads BungeeCord
  */
-@Getter
 @AllArgsConstructor
 @EqualsAndHashCode(callSuper = false)
 public class ProxyReloadEvent extends Event
@@ -18,5 +17,6 @@ public class ProxyReloadEvent extends Event
     /**
      * Creator of the action.
      */
+    @NotNull
     private final CommandSender sender;
 }

--- a/api/src/main/java/net/md_5/bungee/api/event/ServerConnectEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/ServerConnectEvent.java
@@ -9,6 +9,8 @@ import net.md_5.bungee.api.config.ServerInfo;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.plugin.Cancellable;
 import net.md_5.bungee.api.plugin.Event;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Called when deciding to connect to a server. At the time when this event is
@@ -25,6 +27,7 @@ public class ServerConnectEvent extends Event implements Cancellable
     /**
      * Player connecting to a new server.
      */
+    @NotNull
     private final ProxiedPlayer player;
     /**
      * Server the player will be connected to.
@@ -34,10 +37,12 @@ public class ServerConnectEvent extends Event implements Cancellable
     /**
      * Reason for connecting to a new server.
      */
+    @NotNull
     private final Reason reason;
     /**
      * Request used to connect to given server.
      */
+    @Nullable
     private final ServerConnectRequest request;
     /**
      * Cancelled state.
@@ -56,7 +61,7 @@ public class ServerConnectEvent extends Event implements Cancellable
         this( player, target, reason, null );
     }
 
-    public ServerConnectEvent(ProxiedPlayer player, ServerInfo target, Reason reason, ServerConnectRequest request)
+    public ServerConnectEvent(@NotNull ProxiedPlayer player, @NotNull ServerInfo target, @NotNull Reason reason, @Nullable ServerConnectRequest request)
     {
         this.player = player;
         this.target = target;

--- a/api/src/main/java/net/md_5/bungee/api/event/ServerConnectedEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/ServerConnectedEvent.java
@@ -6,6 +6,7 @@ import lombok.ToString;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.connection.Server;
 import net.md_5.bungee.api.plugin.Event;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Not to be confused with {@link ServerConnectEvent}, this event is called once
@@ -22,9 +23,11 @@ public class ServerConnectedEvent extends Event
     /**
      * Player whom the server is for.
      */
+    @NotNull
     private final ProxiedPlayer player;
     /**
      * The server itself.
      */
+    @NotNull
     private final Server server;
 }

--- a/api/src/main/java/net/md_5/bungee/api/event/ServerDisconnectEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/ServerDisconnectEvent.java
@@ -1,6 +1,5 @@
 package net.md_5.bungee.api.event;
 
-import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
@@ -10,7 +9,6 @@ import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.plugin.Event;
 
 @Data
-@AllArgsConstructor
 @ToString(callSuper = false)
 @EqualsAndHashCode(callSuper = false)
 public class ServerDisconnectEvent extends Event

--- a/api/src/main/java/net/md_5/bungee/api/event/ServerKickEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/ServerKickEvent.java
@@ -9,6 +9,8 @@ import net.md_5.bungee.api.config.ServerInfo;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.plugin.Cancellable;
 import net.md_5.bungee.api.plugin.Event;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Represents a player getting kicked from a server.
@@ -26,23 +28,28 @@ public class ServerKickEvent extends Event implements Cancellable
     /**
      * Player being kicked.
      */
+    @NotNull
     private final ProxiedPlayer player;
     /**
      * The server the player was kicked from, should be used in preference to
      * {@link ProxiedPlayer#getServer()}.
      */
+    @NotNull
     private final ServerInfo kickedFrom;
     /**
      * Kick reason.
      */
+    @NotNull
     private BaseComponent[] kickReasonComponent;
     /**
      * Server to send player to if this event is cancelled.
      */
+    @Nullable
     private ServerInfo cancelServer;
     /**
      * State in which the kick occured.
      */
+    @NotNull
     private State state;
 
     public enum State
@@ -63,7 +70,7 @@ public class ServerKickEvent extends Event implements Cancellable
         this( player, player.getServer().getInfo(), kickReasonComponent, cancelServer, state );
     }
 
-    public ServerKickEvent(ProxiedPlayer player, ServerInfo kickedFrom, BaseComponent[] kickReasonComponent, ServerInfo cancelServer, State state)
+    public ServerKickEvent(@NotNull ProxiedPlayer player, @NotNull ServerInfo kickedFrom, BaseComponent[] kickReasonComponent, @Nullable ServerInfo cancelServer, @NotNull State state)
     {
         this.player = player;
         this.kickedFrom = kickedFrom;
@@ -79,7 +86,7 @@ public class ServerKickEvent extends Event implements Cancellable
     }
 
     @Deprecated
-    public void setKickReason(String reason)
+    public void setKickReason(@NotNull String reason)
     {
         kickReasonComponent = TextComponent.fromLegacyText( reason );
     }

--- a/api/src/main/java/net/md_5/bungee/api/event/ServerSwitchEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/ServerSwitchEvent.java
@@ -6,6 +6,8 @@ import lombok.ToString;
 import net.md_5.bungee.api.config.ServerInfo;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.plugin.Event;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Called when a player has changed servers.
@@ -19,10 +21,12 @@ public class ServerSwitchEvent extends Event
     /**
      * Player whom the server is for.
      */
+    @NotNull
     private final ProxiedPlayer player;
     /**
      * Server the player is switch from. May be null if initial proxy
      * connection.
      */
+    @Nullable
     private final ServerInfo from;
 }

--- a/api/src/main/java/net/md_5/bungee/api/event/SettingsChangedEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/SettingsChangedEvent.java
@@ -5,6 +5,7 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.plugin.Event;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Called after a {@link ProxiedPlayer} changed one or more of the following
@@ -28,5 +29,6 @@ public class SettingsChangedEvent extends Event
     /**
      * Player who changed the settings.
      */
+    @NotNull
     private final ProxiedPlayer player;
 }

--- a/api/src/main/java/net/md_5/bungee/api/event/TabCompleteEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/TabCompleteEvent.java
@@ -1,16 +1,19 @@
 package net.md_5.bungee.api.event;
 
 import java.util.List;
-import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
 import net.md_5.bungee.api.connection.Connection;
 import net.md_5.bungee.api.plugin.Cancellable;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Event called when a player uses tab completion.
  */
-@Data
+@Getter
+@Setter
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
 public class TabCompleteEvent extends TargetedEvent implements Cancellable
@@ -23,14 +26,16 @@ public class TabCompleteEvent extends TargetedEvent implements Cancellable
     /**
      * The message the player has already entered.
      */
+    @NotNull
     private final String cursor;
     /**
      * The suggestions that will be sent to the client. This list is mutable. If
      * this list is empty, the request will be forwarded to the server.
      */
+    @NotNull
     private final List<String> suggestions;
 
-    public TabCompleteEvent(Connection sender, Connection receiver, String cursor, List<String> suggestions)
+    public TabCompleteEvent(Connection sender, Connection receiver, @NotNull String cursor, @NotNull List<String> suggestions)
     {
         super( sender, receiver );
         this.cursor = cursor;

--- a/api/src/main/java/net/md_5/bungee/api/event/TabCompleteResponseEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/TabCompleteResponseEvent.java
@@ -1,11 +1,13 @@
 package net.md_5.bungee.api.event;
 
 import java.util.List;
-import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
 import net.md_5.bungee.api.connection.Connection;
 import net.md_5.bungee.api.plugin.Cancellable;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Event called when a backend server sends a response to a player asking to
@@ -13,7 +15,8 @@ import net.md_5.bungee.api.plugin.Cancellable;
  * BungeeCord or a plugin responds to a tab-complete request. Use
  * {@link TabCompleteEvent} for that.
  */
-@Data
+@Getter
+@Setter
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
 public class TabCompleteResponseEvent extends TargetedEvent implements Cancellable
@@ -28,9 +31,10 @@ public class TabCompleteResponseEvent extends TargetedEvent implements Cancellab
      * Mutable list of suggestions sent back to the player. If this list is
      * empty, an empty list is sent back to the client.
      */
+    @NotNull
     private final List<String> suggestions;
 
-    public TabCompleteResponseEvent(Connection sender, Connection receiver, List<String> suggestions)
+    public TabCompleteResponseEvent(Connection sender, Connection receiver, @NotNull List<String> suggestions)
     {
         super( sender, receiver );
         this.suggestions = suggestions;

--- a/api/src/main/java/net/md_5/bungee/api/event/TargetedEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/TargetedEvent.java
@@ -5,6 +5,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import net.md_5.bungee.api.connection.Connection;
 import net.md_5.bungee.api.plugin.Event;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * An event which occurs in the communication between two nodes.
@@ -18,6 +19,7 @@ public abstract class TargetedEvent extends Event
     /**
      * Creator of the action.
      */
+    @NotNull
     private final Connection sender;
     /**
      * Receiver of the action.

--- a/api/src/main/java/net/md_5/bungee/api/plugin/Command.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/Command.java
@@ -5,6 +5,8 @@ import lombok.AccessLevel;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import net.md_5.bungee.api.CommandSender;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * A command that can be executed by a {@link CommandSender}.
@@ -14,8 +16,11 @@ import net.md_5.bungee.api.CommandSender;
 public abstract class Command
 {
 
+    @NotNull
     private final String name;
+    @Nullable
     private final String permission;
+    @NotNull
     private final String[] aliases;
 
     /**
@@ -23,7 +28,7 @@ public abstract class Command
      *
      * @param name the name of this command
      */
-    public Command(String name)
+    public Command(@NotNull String name)
     {
         this( name, null );
     }
@@ -36,7 +41,7 @@ public abstract class Command
      * null or empty string allows it to be executed by everyone
      * @param aliases aliases which map back to this command
      */
-    public Command(String name, String permission, String... aliases)
+    public Command(@NotNull String name, @Nullable String permission, @NotNull String... aliases)
     {
         Preconditions.checkArgument( name != null, "name" );
         this.name = name;
@@ -50,7 +55,7 @@ public abstract class Command
      * @param sender the executor of this command
      * @param args arguments used to invoke this command
      */
-    public abstract void execute(CommandSender sender, String[] args);
+    public abstract void execute(@NotNull CommandSender sender, @NotNull String[] args);
 
     /**
      * Check if this command can be executed by the given sender.

--- a/api/src/main/java/net/md_5/bungee/api/plugin/Plugin.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/Plugin.java
@@ -11,6 +11,9 @@ import lombok.Getter;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.config.ConfigurationAdapter;
 import net.md_5.bungee.api.scheduler.GroupedThreadFactory;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Represents any Plugin that may be loaded at runtime to enhance existing
@@ -73,6 +76,8 @@ public class Plugin
      *
      * @return the data folder of this plugin
      */
+    @NotNull
+    @Contract(" -> new")
     public final File getDataFolder()
     {
         return new File( getProxy().getPluginsFolder(), getDescription().getName() );
@@ -86,6 +91,7 @@ public class Plugin
      * @return the stream for getting this resource, or null if it does not
      * exist
      */
+    @Nullable
     public final InputStream getResourceAsStream(String name)
     {
         return getClass().getClassLoader().getResourceAsStream( name );

--- a/api/src/main/java/net/md_5/bungee/api/plugin/PluginDescription.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/PluginDescription.java
@@ -6,6 +6,8 @@ import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * POJO representing the plugin.yml file.
@@ -19,33 +21,41 @@ public class PluginDescription
     /**
      * Friendly name of the plugin.
      */
+    @NotNull
     private String name;
     /**
      * Plugin main class. Needs to extend {@link Plugin}.
      */
+    @NotNull
     private String main;
     /**
      * Plugin version.
      */
+    @Nullable
     private String version;
     /**
      * Plugin author.
      */
+    @Nullable
     private String author;
     /**
      * Plugin hard dependencies.
      */
+    @NotNull
     private Set<String> depends = new HashSet<>();
     /**
      * Plugin soft dependencies.
      */
+    @NotNull
     private Set<String> softDepends = new HashSet<>();
     /**
      * File we were loaded from.
      */
+    @NotNull
     private File file = null;
     /**
      * Optional description.
      */
+    @Nullable
     private String description = null;
 }

--- a/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
@@ -31,6 +31,9 @@ import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.event.EventBus;
 import net.md_5.bungee.event.EventHandler;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
 import org.yaml.snakeyaml.introspector.PropertyUtils;
@@ -54,7 +57,6 @@ public final class PluginManager
     private final Multimap<Plugin, Command> commandsByPlugin = ArrayListMultimap.create();
     private final Multimap<Plugin, Listener> listenersByPlugin = ArrayListMultimap.create();
 
-    @SuppressWarnings("unchecked")
     public PluginManager(ProxyServer proxy)
     {
         this.proxy = proxy;
@@ -75,7 +77,7 @@ public final class PluginManager
      * @param plugin the plugin owning this command
      * @param command the command to register
      */
-    public void registerCommand(Plugin plugin, Command command)
+    public void registerCommand(Plugin plugin, @NotNull Command command)
     {
         commandMap.put( command.getName().toLowerCase( Locale.ROOT ), command );
         for ( String alias : command.getAliases() )
@@ -90,9 +92,9 @@ public final class PluginManager
      *
      * @param command the command to unregister
      */
-    public void unregisterCommand(Command command)
+    public void unregisterCommand(@NotNull Command command)
     {
-        while ( commandMap.values().remove( command ) );
+        while ( commandMap.values().remove( command ) ) ;
         commandsByPlugin.values().remove( command );
     }
 
@@ -106,7 +108,7 @@ public final class PluginManager
         for ( Iterator<Command> it = commandsByPlugin.get( plugin ).iterator(); it.hasNext(); )
         {
             Command command = it.next();
-            while ( commandMap.values().remove( command ) );
+            while ( commandMap.values().remove( command ) ) ;
             it.remove();
         }
     }
@@ -132,12 +134,12 @@ public final class PluginManager
      * @param sender the sender executing the command
      * @return whether the command will be handled
      */
-    public boolean isExecutableCommand(String commandName, CommandSender sender)
+    public boolean isExecutableCommand(@NotNull String commandName, @NotNull CommandSender sender)
     {
         return getCommandIfEnabled( commandName, sender ) != null;
     }
 
-    public boolean dispatchCommand(CommandSender sender, String commandLine)
+    public boolean dispatchCommand(@NotNull CommandSender sender, @NotNull String commandLine)
     {
         return dispatchCommand( sender, commandLine, null );
     }
@@ -153,16 +155,16 @@ public final class PluginManager
      * returned instead.
      * @return whether the command was handled
      */
-    public boolean dispatchCommand(CommandSender sender, String commandLine, List<String> tabResults)
+    public boolean dispatchCommand(@NotNull CommandSender sender, @NotNull String commandLine, @Nullable List<String> tabResults)
     {
         String[] split = commandLine.split( " ", -1 );
         // Check for chat that only contains " "
-        if ( split.length == 0 || split[0].isEmpty() )
+        if ( split.length == 0 || split[ 0 ].isEmpty() )
         {
             return false;
         }
 
-        Command command = getCommandIfEnabled( split[0], sender );
+        Command command = getCommandIfEnabled( split[ 0 ], sender );
         if ( command == null )
         {
             return false;
@@ -186,7 +188,7 @@ public final class PluginManager
                 {
                     proxy.getLogger().log( Level.INFO, "{0} executed command: /{1}", new Object[]
                     {
-                        sender.getName(), commandLine
+                            sender.getName(), commandLine
                     } );
                 }
                 command.execute( sender, args );
@@ -210,6 +212,7 @@ public final class PluginManager
      *
      * @return the set of loaded plugins
      */
+    @NotNull
     public Collection<Plugin> getPlugins()
     {
         return plugins.values();
@@ -221,7 +224,9 @@ public final class PluginManager
      * @param name of the plugin to retrieve
      * @return the retrieved plugin or null if not loaded
      */
-    public Plugin getPlugin(String name)
+    @Nullable
+    @Contract("null -> null; !null -> _")
+    public Plugin getPlugin(@Nullable String name)
     {
         return plugins.get( name );
     }
@@ -232,7 +237,7 @@ public final class PluginManager
         for ( Map.Entry<String, PluginDescription> entry : toLoad.entrySet() )
         {
             PluginDescription plugin = entry.getValue();
-            if ( !enablePlugin( pluginStatuses, new Stack<PluginDescription>(), plugin ) )
+            if ( !enablePlugin( pluginStatuses, new Stack<>(), plugin ) )
             {
                 ProxyServer.getInstance().getLogger().log( Level.WARNING, "Failed to enable {0}", entry.getKey() );
             }
@@ -348,7 +353,7 @@ public final class PluginManager
      *
      * @param folder the folder to search for plugins in
      */
-    public void detectPlugins(File folder)
+    public void detectPlugins(@NotNull File folder)
     {
         Preconditions.checkNotNull( folder, "folder" );
         Preconditions.checkArgument( folder.isDirectory(), "Must load from a directory" );
@@ -391,7 +396,8 @@ public final class PluginManager
      * @param event the event to call
      * @return the called event
      */
-    public <T extends Event> T callEvent(T event)
+    @NotNull
+    public <T extends Event> T callEvent(@NotNull T event)
     {
         Preconditions.checkNotNull( event, "event" );
 
@@ -418,7 +424,7 @@ public final class PluginManager
      * @param plugin the owning plugin
      * @param listener the listener to register events for
      */
-    public void registerListener(Plugin plugin, Listener listener)
+    public void registerListener(Plugin plugin, @NotNull Listener listener)
     {
         for ( Method method : listener.getClass().getDeclaredMethods() )
         {
@@ -434,7 +440,7 @@ public final class PluginManager
      *
      * @param listener the listener to unregister
      */
-    public void unregisterListener(Listener listener)
+    public void unregisterListener(@NotNull Listener listener)
     {
         eventBus.unregister( listener );
         listenersByPlugin.values().remove( listener );
@@ -459,6 +465,7 @@ public final class PluginManager
      *
      * @return commands
      */
+    @NotNull
     public Collection<Map.Entry<String, Command>> getCommands()
     {
         return Collections.unmodifiableCollection( commandMap.entrySet() );

--- a/api/src/main/java/net/md_5/bungee/api/plugin/TabExecutor.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/TabExecutor.java
@@ -1,9 +1,10 @@
 package net.md_5.bungee.api.plugin;
 
 import net.md_5.bungee.api.CommandSender;
+import org.jetbrains.annotations.NotNull;
 
 public interface TabExecutor
 {
 
-    public Iterable<String> onTabComplete(CommandSender sender, String[] args);
+    public Iterable<String> onTabComplete(@NotNull CommandSender sender, @NotNull String[] args);
 }

--- a/api/src/main/java/net/md_5/bungee/api/scheduler/GroupedThreadFactory.java
+++ b/api/src/main/java/net/md_5/bungee/api/scheduler/GroupedThreadFactory.java
@@ -3,6 +3,7 @@ package net.md_5.bungee.api.scheduler;
 import java.util.concurrent.ThreadFactory;
 import lombok.Data;
 import net.md_5.bungee.api.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
 
 @Data
 @Deprecated
@@ -27,7 +28,7 @@ public class GroupedThreadFactory implements ThreadFactory
     }
 
     @Override
-    public Thread newThread(Runnable r)
+    public Thread newThread(@NotNull Runnable r)
     {
         return new Thread( group, r );
     }

--- a/api/src/main/java/net/md_5/bungee/api/scheduler/ScheduledTask.java
+++ b/api/src/main/java/net/md_5/bungee/api/scheduler/ScheduledTask.java
@@ -1,6 +1,7 @@
 package net.md_5.bungee.api.scheduler;
 
 import net.md_5.bungee.api.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Represents a task scheduled for execution by the {@link TaskScheduler}.
@@ -20,6 +21,7 @@ public interface ScheduledTask
      *
      * @return the owning plugin
      */
+    @NotNull
     Plugin getOwner();
 
     /**
@@ -27,6 +29,7 @@ public interface ScheduledTask
      *
      * @return the {@link Runnable} behind this task
      */
+    @NotNull
     Runnable getTask();
 
     /**

--- a/api/src/main/java/net/md_5/bungee/api/scheduler/TaskScheduler.java
+++ b/api/src/main/java/net/md_5/bungee/api/scheduler/TaskScheduler.java
@@ -3,6 +3,8 @@ package net.md_5.bungee.api.scheduler;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import net.md_5.bungee.api.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * This interface represents a scheduler which may be used to queue, delay and
@@ -25,7 +27,7 @@ public interface TaskScheduler
      *
      * @param task the task to cancel
      */
-    void cancel(ScheduledTask task);
+    void cancel(@NotNull ScheduledTask task);
 
     /**
      * Cancel all tasks owned by this plugin, this preventing them from being
@@ -34,7 +36,7 @@ public interface TaskScheduler
      * @param plugin the plugin owning the tasks to be cancelled
      * @return the number of tasks cancelled by this method
      */
-    int cancel(Plugin plugin);
+    int cancel(@Nullable Plugin plugin);
 
     /**
      * Schedule a task to be executed asynchronously. The task will commence
@@ -44,7 +46,8 @@ public interface TaskScheduler
      * @param task the task to run
      * @return the scheduled task
      */
-    ScheduledTask runAsync(Plugin owner, Runnable task);
+    @NotNull
+    ScheduledTask runAsync(@NotNull Plugin owner, @NotNull Runnable task);
 
     /**
      * Schedules a task to be executed asynchronously after the specified delay
@@ -56,7 +59,8 @@ public interface TaskScheduler
      * @param unit the unit in which the delay will be measured
      * @return the scheduled task
      */
-    ScheduledTask schedule(Plugin owner, Runnable task, long delay, TimeUnit unit);
+    @NotNull
+    ScheduledTask schedule(@NotNull Plugin owner, @NotNull Runnable task, long delay, @NotNull TimeUnit unit);
 
     /**
      * Schedules a task to be executed asynchronously after the specified delay
@@ -71,7 +75,8 @@ public interface TaskScheduler
      * @param unit the unit in which the delay and period will be measured
      * @return the scheduled task
      */
-    ScheduledTask schedule(Plugin owner, Runnable task, long delay, long period, TimeUnit unit);
+    @NotNull
+    ScheduledTask schedule(@NotNull Plugin owner, @NotNull Runnable task, long delay, long period, @NotNull TimeUnit unit);
 
     /**
      * Get the unsafe methods of this class.

--- a/api/src/main/java/net/md_5/bungee/command/PlayerCommand.java
+++ b/api/src/main/java/net/md_5/bungee/command/PlayerCommand.java
@@ -9,6 +9,7 @@ import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.plugin.Command;
 import net.md_5.bungee.api.plugin.TabExecutor;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * @deprecated internal use only
@@ -28,7 +29,7 @@ public abstract class PlayerCommand extends Command implements TabExecutor
     }
 
     @Override
-    public Iterable<String> onTabComplete(CommandSender sender, String[] args)
+    public Iterable<String> onTabComplete(@NotNull CommandSender sender, String[] args)
     {
         final String lastArg = ( args.length > 0 ) ? args[args.length - 1].toLowerCase( Locale.ROOT ) : "";
         return Iterables.transform( Iterables.filter( ProxyServer.getInstance().getPlayers(), new Predicate<ProxiedPlayer>()

--- a/api/src/test/java/net/md_5/bungee/api/ServerConnectRequestTest.java
+++ b/api/src/test/java/net/md_5/bungee/api/ServerConnectRequestTest.java
@@ -6,6 +6,7 @@ import java.util.Collection;
 import net.md_5.bungee.api.config.ServerInfo;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.event.ServerConnectEvent;
+import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 
 public class ServerConnectRequestTest
@@ -50,30 +51,31 @@ public class ServerConnectRequestTest
         }
 
         @Override
+        @NotNull
         public String getPermission()
         {
             return null;
         }
 
         @Override
-        public boolean canAccess(CommandSender sender)
+        public boolean canAccess(@NotNull CommandSender sender)
         {
             return true;
         }
 
         @Override
-        public void sendData(String channel, byte[] data)
+        public void sendData(@NotNull String channel, byte[] data)
         {
         }
 
         @Override
-        public boolean sendData(String channel, byte[] data, boolean queue)
+        public boolean sendData(@NotNull String channel, byte[] data, boolean queue)
         {
             return false;
         }
 
         @Override
-        public void ping(Callback<ServerPing> callback)
+        public void ping(@NotNull Callback<ServerPing> callback)
         {
         }
     };

--- a/chat/src/main/java/net/md_5/bungee/api/ChatColor.java
+++ b/chat/src/main/java/net/md_5/bungee/api/ChatColor.java
@@ -8,6 +8,9 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.regex.Pattern;
 import lombok.Getter;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Simplistic enumeration of all supported color values for chat.
@@ -24,15 +27,15 @@ public final class ChatColor
     /**
      * Pattern to remove all colour codes.
      */
-    public static final Pattern STRIP_COLOR_PATTERN = Pattern.compile( "(?i)" + String.valueOf( COLOR_CHAR ) + "[0-9A-FK-ORX]" );
+    public static final Pattern STRIP_COLOR_PATTERN = Pattern.compile( "(?i)" + COLOR_CHAR + "[0-9A-FK-ORX]" );
     /**
      * Colour instances keyed by their active character.
      */
-    private static final Map<Character, ChatColor> BY_CHAR = new HashMap<Character, ChatColor>();
+    private static final Map<Character, ChatColor> BY_CHAR = new HashMap<>();
     /**
      * Colour instances keyed by their name.
      */
-    private static final Map<String, ChatColor> BY_NAME = new HashMap<String, ChatColor>();
+    private static final Map<String, ChatColor> BY_NAME = new HashMap<>();
     /**
      * Represents black.
      */
@@ -174,6 +177,7 @@ public final class ChatColor
     }
 
     @Override
+    @Contract(value = "null -> false", pure = true)
     public boolean equals(Object obj)
     {
         if ( this == obj )
@@ -190,6 +194,7 @@ public final class ChatColor
     }
 
     @Override
+    @Contract(pure = true)
     public String toString()
     {
         return toString;
@@ -201,6 +206,7 @@ public final class ChatColor
      * @param input String to strip of color
      * @return A copy of the input string, without any coloring
      */
+    @Contract(value = "null -> null; !null -> new", pure = true)
     public static String stripColor(final String input)
     {
         if ( input == null )
@@ -211,15 +217,17 @@ public final class ChatColor
         return STRIP_COLOR_PATTERN.matcher( input ).replaceAll( "" );
     }
 
-    public static String translateAlternateColorCodes(char altColorChar, String textToTranslate)
+    @NotNull
+    @Contract(value = "_, !null -> new", pure = true)
+    public static String translateAlternateColorCodes(char altColorChar, @NotNull String textToTranslate)
     {
         char[] b = textToTranslate.toCharArray();
         for ( int i = 0; i < b.length - 1; i++ )
         {
-            if ( b[i] == altColorChar && ALL_CODES.indexOf( b[i + 1] ) > -1 )
+            if ( b[ i ] == altColorChar && ALL_CODES.indexOf( b[ i + 1 ] ) > -1 )
             {
-                b[i] = ChatColor.COLOR_CHAR;
-                b[i + 1] = Character.toLowerCase( b[i + 1] );
+                b[ i ] = ChatColor.COLOR_CHAR;
+                b[ i + 1 ] = Character.toLowerCase( b[ i + 1 ] );
             }
         }
         return new String( b );
@@ -231,19 +239,25 @@ public final class ChatColor
      * @param code the code to search for
      * @return the mapped colour, or null if non exists
      */
+    @Nullable
+    @Contract(pure = true)
     public static ChatColor getByChar(char code)
     {
         return BY_CHAR.get( code );
     }
 
-    public static ChatColor of(Color color)
+    @NotNull
+    @Contract(pure = true)
+    public static ChatColor of(@NotNull Color color)
     {
         return of( "#" + Integer.toHexString( color.getRGB() ).substring( 2 ) );
     }
 
-    public static ChatColor of(String string)
+    @NotNull
+    @Contract(pure = true)
+    public static ChatColor of(@NotNull String string)
     {
-        Preconditions.checkArgument( string != null, "string cannot be null" );
+        Preconditions.checkNotNull( string, "string cannot be null" );
         if ( string.startsWith( "#" ) && string.length() == 7 )
         {
             int rgb;
@@ -280,8 +294,10 @@ public final class ChatColor
      * @return ChatColor
      * @deprecated holdover from when this class was an enum
      */
+    @NotNull
+    @Contract(pure = true)
     @Deprecated
-    public static ChatColor valueOf(String name)
+    public static ChatColor valueOf(@NotNull String name)
     {
         Preconditions.checkNotNull( name, "Name is null" );
 
@@ -297,10 +313,12 @@ public final class ChatColor
      * @return copied array of all colors and formats
      * @deprecated holdover from when this class was an enum
      */
+    @NotNull
+    @Contract(pure = true)
     @Deprecated
     public static ChatColor[] values()
     {
-        return BY_CHAR.values().toArray( new ChatColor[ BY_CHAR.values().size() ] );
+        return BY_CHAR.values().toArray( new ChatColor[ 0 ] );
     }
 
     /**
@@ -309,6 +327,8 @@ public final class ChatColor
      * @return constant name
      * @deprecated holdover from when this class was an enum
      */
+    @NotNull
+    @Contract(pure = true)
     @Deprecated
     public String name()
     {
@@ -321,6 +341,7 @@ public final class ChatColor
      * @return ordinal
      * @deprecated holdover from when this class was an enum
      */
+    @Contract(pure = true)
     @Deprecated
     public int ordinal()
     {

--- a/chat/src/main/java/net/md_5/bungee/api/chat/BaseComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/BaseComponent.java
@@ -9,6 +9,8 @@ import lombok.Setter;
 import lombok.ToString;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.chat.ComponentBuilder.FormatRetention;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 @Setter
 @ToString(exclude = "parent")
@@ -22,47 +24,56 @@ public abstract class BaseComponent
     /**
      * The color of this component and any child components (unless overridden)
      */
+    @Nullable
     private ChatColor color;
     /**
      * The font of this component and any child components (unless overridden)
      */
+    @Nullable
     private String font;
     /**
      * Whether this component and any child components (unless overridden) is
      * bold
      */
+    @Nullable
     private Boolean bold;
     /**
      * Whether this component and any child components (unless overridden) is
      * italic
      */
+    @Nullable
     private Boolean italic;
     /**
      * Whether this component and any child components (unless overridden) is
      * underlined
      */
+    @Nullable
     private Boolean underlined;
     /**
      * Whether this component and any child components (unless overridden) is
      * strikethrough
      */
+    @Nullable
     private Boolean strikethrough;
     /**
      * Whether this component and any child components (unless overridden) is
      * obfuscated
      */
+    @Nullable
     private Boolean obfuscated;
     /**
      * The text to insert into the chat when this component (and child
      * components) are clicked while pressing the shift key
      */
     @Getter
+    @Nullable
     private String insertion;
 
     /**
      * Appended components that inherit this component's formatting and events
      */
     @Getter
+    @Nullable
     private List<BaseComponent> extra;
 
     /**
@@ -70,12 +81,14 @@ public abstract class BaseComponent
      * clicked
      */
     @Getter
+    @Nullable
     private ClickEvent clickEvent;
     /**
      * The action to perform when this component (and child components) are
      * hovered over
      */
     @Getter
+    @Nullable
     private HoverEvent hoverEvent;
 
     /**
@@ -88,7 +101,7 @@ public abstract class BaseComponent
     {
     }
 
-    BaseComponent(BaseComponent old)
+    BaseComponent(@NotNull BaseComponent old)
     {
         copyFormatting( old, FormatRetention.ALL, true );
 
@@ -107,7 +120,7 @@ public abstract class BaseComponent
      *
      * @param component the component to copy from
      */
-    public void copyFormatting(BaseComponent component)
+    public void copyFormatting(@NotNull BaseComponent component)
     {
         copyFormatting( component, FormatRetention.ALL, true );
     }
@@ -119,7 +132,7 @@ public abstract class BaseComponent
      * @param replace if already set formatting should be replaced by the new
      * component
      */
-    public void copyFormatting(BaseComponent component, boolean replace)
+    public void copyFormatting(@NotNull BaseComponent component, boolean replace)
     {
         copyFormatting( component, FormatRetention.ALL, replace );
     }
@@ -128,11 +141,14 @@ public abstract class BaseComponent
      * Copies the specified formatting of a BaseComponent.
      *
      * @param component the component to copy from
-     * @param retention the formatting to copy
+     * @param retention the formatting to copy, {@code null} behaves like {@link FormatRetention#NONE FormatRetention.NONE}
      * @param replace if already set formatting should be replaced by the new
      * component
+     * @throws java.lang.NullPointerException if {@code component} is null, {@code retention} is neither {@code null}
+     * nor {@link FormatRetention#NONE NONE} and either {@code replace} is true or any formatting is not yet set in this
+     * component
      */
-    public void copyFormatting(BaseComponent component, FormatRetention retention, boolean replace)
+    public void copyFormatting(BaseComponent component, @Nullable FormatRetention retention, boolean replace)
     {
         if ( retention == FormatRetention.EVENTS || retention == FormatRetention.ALL )
         {
@@ -187,7 +203,7 @@ public abstract class BaseComponent
      *
      * @param retention the formatting to retain
      */
-    public void retain(FormatRetention retention)
+    public void retain(@Nullable FormatRetention retention)
     {
         if ( retention == FormatRetention.FORMATTING || retention == FormatRetention.NONE )
         {
@@ -211,6 +227,7 @@ public abstract class BaseComponent
      *
      * @return The duplicate of this BaseComponent
      */
+    @NotNull
     public abstract BaseComponent duplicate();
 
     /**
@@ -220,6 +237,7 @@ public abstract class BaseComponent
      * @deprecated API use discouraged, use traditional duplicate
      */
     @Deprecated
+    @NotNull
     public BaseComponent duplicateWithoutFormatting()
     {
         BaseComponent component = duplicate();
@@ -234,7 +252,8 @@ public abstract class BaseComponent
      * @param components the components to convert
      * @return the string in the old format
      */
-    public static String toLegacyText(BaseComponent... components)
+    @NotNull
+    public static String toLegacyText(@NotNull BaseComponent... components)
     {
         StringBuilder builder = new StringBuilder();
         for ( BaseComponent msg : components )
@@ -250,7 +269,8 @@ public abstract class BaseComponent
      * @param components the components to convert
      * @return the string as plain text
      */
-    public static String toPlainText(BaseComponent... components)
+    @NotNull
+    public static String toPlainText(@NotNull BaseComponent... components)
     {
         StringBuilder builder = new StringBuilder();
         for ( BaseComponent msg : components )
@@ -267,6 +287,7 @@ public abstract class BaseComponent
      *
      * @return the color of this component
      */
+    @Nullable
     public ChatColor getColor()
     {
         if ( color == null )
@@ -286,6 +307,7 @@ public abstract class BaseComponent
      *
      * @return the color of this component
      */
+    @Nullable
     public ChatColor getColorRaw()
     {
         return color;
@@ -297,6 +319,7 @@ public abstract class BaseComponent
      *
      * @return the font of this component, or null if default font
      */
+    @Nullable
     public String getFont()
     {
         if ( font == null )
@@ -316,6 +339,7 @@ public abstract class BaseComponent
      *
      * @return the font of this component
      */
+    @Nullable
     public String getFontRaw()
     {
         return font;
@@ -343,6 +367,7 @@ public abstract class BaseComponent
      *
      * @return whether the component is bold
      */
+    @Nullable
     public Boolean isBoldRaw()
     {
         return bold;
@@ -370,6 +395,7 @@ public abstract class BaseComponent
      *
      * @return whether the component is italic
      */
+    @Nullable
     public Boolean isItalicRaw()
     {
         return italic;
@@ -397,6 +423,7 @@ public abstract class BaseComponent
      *
      * @return whether the component is underlined
      */
+    @Nullable
     public Boolean isUnderlinedRaw()
     {
         return underlined;
@@ -424,6 +451,7 @@ public abstract class BaseComponent
      *
      * @return whether the component is strikethrough
      */
+    @Nullable
     public Boolean isStrikethroughRaw()
     {
         return strikethrough;
@@ -451,12 +479,13 @@ public abstract class BaseComponent
      *
      * @return whether the component is obfuscated
      */
+    @Nullable
     public Boolean isObfuscatedRaw()
     {
         return obfuscated;
     }
 
-    public void setExtra(List<BaseComponent> components)
+    public void setExtra(@NotNull List<BaseComponent> components)
     {
         for ( BaseComponent component : components )
         {
@@ -471,7 +500,7 @@ public abstract class BaseComponent
      *
      * @param text the text to append
      */
-    public void addExtra(String text)
+    public void addExtra(@NotNull String text)
     {
         addExtra( new TextComponent( text ) );
     }
@@ -482,11 +511,11 @@ public abstract class BaseComponent
      *
      * @param component the component to append
      */
-    public void addExtra(BaseComponent component)
+    public void addExtra(@NotNull BaseComponent component)
     {
         if ( extra == null )
         {
-            extra = new ArrayList<BaseComponent>();
+            extra = new ArrayList<>();
         }
         component.parent = this;
         extra.add( component );
@@ -510,6 +539,7 @@ public abstract class BaseComponent
      *
      * @return the string as plain text
      */
+    @NotNull
     public String toPlainText()
     {
         StringBuilder builder = new StringBuilder();
@@ -534,6 +564,7 @@ public abstract class BaseComponent
      *
      * @return the string in the old format
      */
+    @NotNull
     public String toLegacyText()
     {
         StringBuilder builder = new StringBuilder();

--- a/chat/src/main/java/net/md_5/bungee/api/chat/ComponentBuilder.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/ComponentBuilder.java
@@ -6,6 +6,9 @@ import java.util.List;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import net.md_5.bungee.api.ChatColor;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * <p>
@@ -37,7 +40,7 @@ public final class ComponentBuilder
     @Getter
     private int cursor = -1;
     @Getter
-    private final List<BaseComponent> parts = new ArrayList<BaseComponent>();
+    private final List<BaseComponent> parts = new ArrayList<>();
     private BaseComponent dummy;
 
     private ComponentBuilder(BaseComponent[] parts)
@@ -57,7 +60,7 @@ public final class ComponentBuilder
      */
     public ComponentBuilder(ComponentBuilder original)
     {
-        this( original.parts.toArray( new BaseComponent[ original.parts.size() ] ) );
+        this( original.parts.toArray( new BaseComponent[ 0 ] ) );
     }
 
     /**
@@ -90,6 +93,7 @@ public final class ComponentBuilder
         {
             dummy = new BaseComponent()
             {
+                @NotNull
                 @Override
                 public BaseComponent duplicate()
                 {
@@ -105,6 +109,7 @@ public final class ComponentBuilder
      *
      * @return this ComponentBuilder for chaining
      */
+    @Contract(value = "-> this", mutates = "this")
     public ComponentBuilder resetCursor()
     {
         cursor = parts.size() - 1;
@@ -120,11 +125,12 @@ public final class ComponentBuilder
      * @throws IndexOutOfBoundsException if the index is out of range
      * ({@code index < 0 || index >= size()})
      */
+    @Contract(value = "_ -> this", mutates = "this")
     public ComponentBuilder setCursor(int pos) throws IndexOutOfBoundsException
     {
         if ( ( this.cursor != pos ) && ( pos < 0 || pos >= parts.size() ) )
         {
-            throw new IndexOutOfBoundsException( "Cursor out of bounds (expected between 0 + " + ( parts.size() - 1 ) + ")" );
+            throw new IndexOutOfBoundsException( String.format( "Cursor out of bounds (expected between 0 and %d, but was %d)", parts.size() - 1, pos ) );
         }
 
         this.cursor = pos;
@@ -139,6 +145,8 @@ public final class ComponentBuilder
      * @param component the component to append
      * @return this ComponentBuilder for chaining
      */
+    @NotNull
+    @Contract(mutates = "this")
     public ComponentBuilder append(BaseComponent component)
     {
         return append( component, FormatRetention.ALL );
@@ -153,7 +161,9 @@ public final class ComponentBuilder
      * @param retention the formatting to retain
      * @return this ComponentBuilder for chaining
      */
-    public ComponentBuilder append(BaseComponent component, FormatRetention retention)
+    @NotNull
+    @Contract(value = "_, _ -> this", mutates = "this")
+    public ComponentBuilder append(BaseComponent component, @Nullable FormatRetention retention)
     {
         BaseComponent previous = ( parts.isEmpty() ) ? null : parts.get( parts.size() - 1 );
         if ( previous == null )
@@ -178,6 +188,7 @@ public final class ComponentBuilder
      * @param components the components to append
      * @return this ComponentBuilder for chaining
      */
+    @Contract(value = "_ -> this", mutates = "this")
     public ComponentBuilder append(BaseComponent[] components)
     {
         return append( components, FormatRetention.ALL );
@@ -192,7 +203,8 @@ public final class ComponentBuilder
      * @param retention the formatting to retain
      * @return this ComponentBuilder for chaining
      */
-    public ComponentBuilder append(BaseComponent[] components, FormatRetention retention)
+    @Contract(value = "_, _ -> this", mutates = "this")
+    public ComponentBuilder append(@NotNull BaseComponent[] components, @Nullable FormatRetention retention)
     {
         Preconditions.checkArgument( components.length != 0, "No components to append" );
 
@@ -211,6 +223,8 @@ public final class ComponentBuilder
      * @param text the text to append
      * @return this ComponentBuilder for chaining
      */
+    @NotNull
+    @Contract(value = "_ -> this", mutates = "this")
     public ComponentBuilder append(String text)
     {
         return append( text, FormatRetention.ALL );
@@ -224,7 +238,8 @@ public final class ComponentBuilder
      * @param text the text to append
      * @return this ComponentBuilder for chaining
      */
-    public ComponentBuilder appendLegacy(String text)
+    @Contract(value = "!null -> this; null -> fail", mutates = "this")
+    public ComponentBuilder appendLegacy(@NotNull String text)
     {
         return append( TextComponent.fromLegacyText( text ) );
     }
@@ -238,6 +253,8 @@ public final class ComponentBuilder
      * @param retention the formatting to retain
      * @return this ComponentBuilder for chaining
      */
+    @NotNull
+    @Contract(value = "_, _ -> this", mutates = "this")
     public ComponentBuilder append(String text, FormatRetention retention)
     {
         return append( new TextComponent( text ), retention );
@@ -253,7 +270,7 @@ public final class ComponentBuilder
      * @param joiner joiner used for operation
      * @return this ComponentBuilder for chaining
      */
-    public ComponentBuilder append(Joiner joiner)
+    public ComponentBuilder append(@NotNull Joiner joiner)
     {
         return joiner.join( this, FormatRetention.ALL );
     }
@@ -269,7 +286,7 @@ public final class ComponentBuilder
      * @param retention the formatting to retain
      * @return this ComponentBuilder for chaining
      */
-    public ComponentBuilder append(Joiner joiner, FormatRetention retention)
+    public ComponentBuilder append(@NotNull Joiner joiner, FormatRetention retention)
     {
         return joiner.join( this, retention );
     }
@@ -281,6 +298,7 @@ public final class ComponentBuilder
      * @throws IndexOutOfBoundsException if the index is out of range
      * ({@code index < 0 || index >= size()})
      */
+    @Contract(mutates = "this")
     public void removeComponent(int pos) throws IndexOutOfBoundsException
     {
         if ( parts.remove( pos ) != null )
@@ -297,6 +315,7 @@ public final class ComponentBuilder
      * @throws IndexOutOfBoundsException if the index is out of range
      * ({@code index < 0 || index >= size()})
      */
+    @Contract(pure = true)
     public BaseComponent getComponent(int pos) throws IndexOutOfBoundsException
     {
         return parts.get( pos );
@@ -307,6 +326,7 @@ public final class ComponentBuilder
      *
      * @return the active component or null if builder is empty
      */
+    @Contract(pure = true)
     public BaseComponent getCurrentComponent()
     {
         return ( cursor == -1 ) ? getDummy() : parts.get( cursor );
@@ -318,7 +338,8 @@ public final class ComponentBuilder
      * @param color the new color
      * @return this ComponentBuilder for chaining
      */
-    public ComponentBuilder color(ChatColor color)
+    @Contract(mutates = "this")
+    public ComponentBuilder color(@Nullable ChatColor color)
     {
         getCurrentComponent().setColor( color );
         return this;
@@ -330,7 +351,8 @@ public final class ComponentBuilder
      * @param font the new font
      * @return this ComponentBuilder for chaining
      */
-    public ComponentBuilder font(String font)
+    @Contract(mutates = "this")
+    public ComponentBuilder font(@Nullable String font)
     {
         getCurrentComponent().setFont( font );
         return this;
@@ -342,6 +364,7 @@ public final class ComponentBuilder
      * @param bold whether this part is bold
      * @return this ComponentBuilder for chaining
      */
+    @Contract(value = "_ -> this", mutates = "this")
     public ComponentBuilder bold(boolean bold)
     {
         getCurrentComponent().setBold( bold );
@@ -354,6 +377,7 @@ public final class ComponentBuilder
      * @param italic whether this part is italic
      * @return this ComponentBuilder for chaining
      */
+    @Contract(value = "_ -> this", mutates = "this")
     public ComponentBuilder italic(boolean italic)
     {
         getCurrentComponent().setItalic( italic );
@@ -366,6 +390,7 @@ public final class ComponentBuilder
      * @param underlined whether this part is underlined
      * @return this ComponentBuilder for chaining
      */
+    @Contract(value = "_ -> this", mutates = "this")
     public ComponentBuilder underlined(boolean underlined)
     {
         getCurrentComponent().setUnderlined( underlined );
@@ -378,6 +403,7 @@ public final class ComponentBuilder
      * @param strikethrough whether this part is strikethrough
      * @return this ComponentBuilder for chaining
      */
+    @Contract(value = "_ -> this", mutates = "this")
     public ComponentBuilder strikethrough(boolean strikethrough)
     {
         getCurrentComponent().setStrikethrough( strikethrough );
@@ -390,6 +416,7 @@ public final class ComponentBuilder
      * @param obfuscated whether this part is obfuscated
      * @return this ComponentBuilder for chaining
      */
+    @Contract(value = "_ -> this", mutates = "this")
     public ComponentBuilder obfuscated(boolean obfuscated)
     {
         getCurrentComponent().setObfuscated( obfuscated );
@@ -402,7 +429,8 @@ public final class ComponentBuilder
      * @param insertion the insertion text
      * @return this ComponentBuilder for chaining
      */
-    public ComponentBuilder insertion(String insertion)
+    @Contract(value = "_ -> this", mutates = "this")
+    public ComponentBuilder insertion(@Nullable String insertion)
     {
         getCurrentComponent().setInsertion( insertion );
         return this;
@@ -414,7 +442,8 @@ public final class ComponentBuilder
      * @param clickEvent the click event
      * @return this ComponentBuilder for chaining
      */
-    public ComponentBuilder event(ClickEvent clickEvent)
+    @Contract(value = "_ -> this", mutates = "this")
+    public ComponentBuilder event(@Nullable ClickEvent clickEvent)
     {
         getCurrentComponent().setClickEvent( clickEvent );
         return this;
@@ -426,7 +455,8 @@ public final class ComponentBuilder
      * @param hoverEvent the hover event
      * @return this ComponentBuilder for chaining
      */
-    public ComponentBuilder event(HoverEvent hoverEvent)
+    @Contract(value = "_ -> this", mutates = "this")
+    public ComponentBuilder event(@Nullable HoverEvent hoverEvent)
     {
         getCurrentComponent().setHoverEvent( hoverEvent );
         return this;
@@ -437,6 +467,7 @@ public final class ComponentBuilder
      *
      * @return this ComponentBuilder for chaining
      */
+    @Contract(value = "-> this", mutates = "this")
     public ComponentBuilder reset()
     {
         return retain( FormatRetention.NONE );
@@ -448,7 +479,8 @@ public final class ComponentBuilder
      * @param retention the formatting to retain
      * @return this ComponentBuilder for chaining
      */
-    public ComponentBuilder retain(FormatRetention retention)
+    @Contract(value = "_ -> this", mutates = "this")
+    public ComponentBuilder retain(@Nullable FormatRetention retention)
     {
         getCurrentComponent().retain( retention );
         return this;
@@ -460,13 +492,14 @@ public final class ComponentBuilder
      *
      * @return the created components
      */
+    @NotNull
     public BaseComponent[] create()
     {
         BaseComponent[] cloned = new BaseComponent[ parts.size() ];
         int i = 0;
         for ( BaseComponent part : parts )
         {
-            cloned[i++] = part.duplicate();
+            cloned[ i++ ] = part.duplicate();
         }
         return cloned;
     }
@@ -513,6 +546,6 @@ public final class ComponentBuilder
          * @param retention the formatting to possibly retain
          * @return input componentBuilder for chaining
          */
-        ComponentBuilder join(ComponentBuilder componentBuilder, FormatRetention retention);
+        ComponentBuilder join(@NotNull ComponentBuilder componentBuilder, FormatRetention retention);
     }
 }

--- a/chat/src/main/java/net/md_5/bungee/api/chat/HoverEvent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/HoverEvent.java
@@ -14,6 +14,7 @@ import net.md_5.bungee.api.chat.hover.content.Entity;
 import net.md_5.bungee.api.chat.hover.content.Item;
 import net.md_5.bungee.api.chat.hover.content.Text;
 import net.md_5.bungee.chat.ComponentSerializer;
+import org.jetbrains.annotations.NotNull;
 
 @Getter
 @ToString
@@ -42,7 +43,7 @@ public final class HoverEvent
      * @param action action of this event
      * @param contents array of contents, provide at least one
      */
-    public HoverEvent(Action action, Content... contents)
+    public HoverEvent(Action action, @NotNull Content... contents)
     {
         Preconditions.checkArgument( contents.length != 0,
                 "Must contain at least one content" );
@@ -127,7 +128,8 @@ public final class HoverEvent
      * @param array if to return the arrayed class
      * @return the class
      */
-    public static Class<?> getClass(HoverEvent.Action action, boolean array)
+    @NotNull
+    public static Class<?> getClass(@NotNull HoverEvent.Action action, boolean array)
     {
         Preconditions.checkArgument( action != null, "action" );
 

--- a/chat/src/main/java/net/md_5/bungee/api/chat/KeybindComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/KeybindComponent.java
@@ -5,6 +5,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
 
 @Getter
 @Setter
@@ -26,7 +28,7 @@ public final class KeybindComponent extends BaseComponent
      *
      * @param original the original for the new keybind component.
      */
-    public KeybindComponent(KeybindComponent original)
+    public KeybindComponent(@NotNull KeybindComponent original)
     {
         super( original );
         setKeybind( original.getKeybind() );
@@ -44,6 +46,8 @@ public final class KeybindComponent extends BaseComponent
     }
 
     @Override
+    @NotNull
+    @Contract(value = " -> new", pure = true)
     public KeybindComponent duplicate()
     {
         return new KeybindComponent( this );

--- a/chat/src/main/java/net/md_5/bungee/api/chat/ScoreComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/ScoreComponent.java
@@ -5,6 +5,8 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * This component displays the score based on a player score on the scoreboard.
@@ -70,7 +72,7 @@ public final class ScoreComponent extends BaseComponent
      *
      * @param original the original for the new score component
      */
-    public ScoreComponent(ScoreComponent original)
+    public ScoreComponent(@NotNull ScoreComponent original)
     {
         super( original );
         setName( original.getName() );
@@ -78,6 +80,8 @@ public final class ScoreComponent extends BaseComponent
         setValue( original.getValue() );
     }
 
+    @NotNull
+    @Contract(value = " -> new", pure = true)
     @Override
     public ScoreComponent duplicate()
     {

--- a/chat/src/main/java/net/md_5/bungee/api/chat/SelectorComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/SelectorComponent.java
@@ -5,6 +5,8 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * This component processes a target selector into a pre-formatted set of
@@ -38,12 +40,14 @@ public final class SelectorComponent extends BaseComponent
      *
      * @param original the original for the new selector component
      */
-    public SelectorComponent(SelectorComponent original)
+    public SelectorComponent(@NotNull SelectorComponent original)
     {
         super( original );
         setSelector( original.getSelector() );
     }
 
+    @NotNull
+    @Contract(" -> new")
     @Override
     public SelectorComponent duplicate()
     {

--- a/chat/src/main/java/net/md_5/bungee/api/chat/TextComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/TextComponent.java
@@ -9,6 +9,9 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import net.md_5.bungee.api.ChatColor;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 @Getter
 @Setter
@@ -27,7 +30,9 @@ public final class TextComponent extends BaseComponent
      * @param message the text to convert
      * @return the components needed to print the message to the client
      */
-    public static BaseComponent[] fromLegacyText(String message)
+    @NotNull
+    @Contract(pure = true)
+    public static BaseComponent[] fromLegacyText(@NotNull String message)
     {
         return fromLegacyText( message, ChatColor.WHITE );
     }
@@ -42,9 +47,11 @@ public final class TextComponent extends BaseComponent
      * (i.e. after ChatColor.RESET).
      * @return the components needed to print the message to the client
      */
-    public static BaseComponent[] fromLegacyText(String message, ChatColor defaultColor)
+    @NotNull
+    @Contract(pure = true)
+    public static BaseComponent[] fromLegacyText(@NotNull String message, @Nullable ChatColor defaultColor)
     {
-        ArrayList<BaseComponent> components = new ArrayList<BaseComponent>();
+        ArrayList<BaseComponent> components = new ArrayList<>();
         StringBuilder builder = new StringBuilder();
         TextComponent component = new TextComponent();
         Matcher matcher = url.matcher( message );
@@ -157,7 +164,7 @@ public final class TextComponent extends BaseComponent
         component.setText( builder.toString() );
         components.add( component );
 
-        return components.toArray( new BaseComponent[ components.size() ] );
+        return components.toArray( new BaseComponent[ 0 ] );
     }
 
     /**
@@ -179,7 +186,7 @@ public final class TextComponent extends BaseComponent
      *
      * @param textComponent the component to copy from
      */
-    public TextComponent(TextComponent textComponent)
+    public TextComponent(@NotNull TextComponent textComponent)
     {
         super( textComponent );
         setText( textComponent.getText() );
@@ -191,14 +198,14 @@ public final class TextComponent extends BaseComponent
      *
      * @param extras the extras to set
      */
-    public TextComponent(BaseComponent... extras)
+    public TextComponent(@NotNull BaseComponent... extras)
     {
         this();
         if ( extras.length == 0 )
         {
             return;
         }
-        setExtra( new ArrayList<BaseComponent>( Arrays.asList( extras ) ) );
+        setExtra( new ArrayList<>( Arrays.asList( extras ) ) );
     }
 
     /**
@@ -207,6 +214,8 @@ public final class TextComponent extends BaseComponent
      * @return the duplicate of this TextComponent.
      */
     @Override
+    @NotNull
+    @Contract(pure = true)
     public TextComponent duplicate()
     {
         return new TextComponent( this );
@@ -228,6 +237,8 @@ public final class TextComponent extends BaseComponent
     }
 
     @Override
+    @NotNull
+    @Contract(pure = true)
     public String toString()
     {
         return String.format( "TextComponent{text=%s, %s}", text, super.toString() );

--- a/chat/src/main/java/net/md_5/bungee/api/chat/TranslatableComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/TranslatableComponent.java
@@ -10,6 +10,8 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 import net.md_5.bungee.chat.TranslationRegistry;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
 
 @Getter
 @Setter
@@ -36,14 +38,14 @@ public final class TranslatableComponent extends BaseComponent
      *
      * @param original the original for the new translatable component.
      */
-    public TranslatableComponent(TranslatableComponent original)
+    public TranslatableComponent(@NotNull TranslatableComponent original)
     {
         super( original );
         setTranslate( original.getTranslate() );
 
         if ( original.getWith() != null )
         {
-            List<BaseComponent> temp = new ArrayList<BaseComponent>();
+            List<BaseComponent> temp = new ArrayList<>();
             for ( BaseComponent baseComponent : original.getWith() )
             {
                 temp.add( baseComponent.duplicate() );
@@ -67,7 +69,7 @@ public final class TranslatableComponent extends BaseComponent
         setTranslate( translate );
         if ( with != null && with.length != 0 )
         {
-            List<BaseComponent> temp = new ArrayList<BaseComponent>();
+            List<BaseComponent> temp = new ArrayList<>();
             for ( Object w : with )
             {
                 if ( w instanceof BaseComponent )
@@ -87,6 +89,8 @@ public final class TranslatableComponent extends BaseComponent
      *
      * @return the duplicate of this TranslatableComponent.
      */
+    @NotNull
+    @Contract(" -> new")
     @Override
     public TranslatableComponent duplicate()
     {

--- a/chat/src/main/java/net/md_5/bungee/chat/BaseComponentSerializer.java
+++ b/chat/src/main/java/net/md_5/bungee/chat/BaseComponentSerializer.java
@@ -16,11 +16,12 @@ import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.ClickEvent;
 import net.md_5.bungee.api.chat.HoverEvent;
 import net.md_5.bungee.api.chat.hover.content.Content;
+import org.jetbrains.annotations.NotNull;
 
 public class BaseComponentSerializer
 {
 
-    protected void deserialize(JsonObject object, BaseComponent component, JsonDeserializationContext context)
+    protected void deserialize(@NotNull JsonObject object, BaseComponent component, JsonDeserializationContext context)
     {
         if ( object.has( "color" ) )
         {

--- a/chat/src/main/java/net/md_5/bungee/chat/ComponentSerializer.java
+++ b/chat/src/main/java/net/md_5/bungee/chat/ComponentSerializer.java
@@ -23,6 +23,8 @@ import net.md_5.bungee.api.chat.hover.content.Item;
 import net.md_5.bungee.api.chat.hover.content.ItemSerializer;
 import net.md_5.bungee.api.chat.hover.content.Text;
 import net.md_5.bungee.api.chat.hover.content.TextSerializer;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class ComponentSerializer implements JsonDeserializer<BaseComponent>
 {
@@ -41,9 +43,10 @@ public class ComponentSerializer implements JsonDeserializer<BaseComponent>
             registerTypeAdapter( ItemTag.class, new ItemTag.Serializer() ).
             create();
 
-    public static final ThreadLocal<Set<BaseComponent>> serializedComponents = new ThreadLocal<Set<BaseComponent>>();
+    public static final ThreadLocal<Set<BaseComponent>> serializedComponents = new ThreadLocal<>();
 
-    public static BaseComponent[] parse(String json)
+    @NotNull
+    public static BaseComponent[] parse(@NotNull String json)
     {
         JsonElement jsonElement = JSON_PARSER.parse( json );
 
@@ -59,17 +62,20 @@ public class ComponentSerializer implements JsonDeserializer<BaseComponent>
         }
     }
 
-    public static String toString(Object object)
+    @NotNull
+    public static String toString(@Nullable Object object)
     {
         return gson.toJson( object );
     }
 
-    public static String toString(BaseComponent component)
+    @NotNull
+    public static String toString(@Nullable BaseComponent component)
     {
         return gson.toJson( component );
     }
 
-    public static String toString(BaseComponent... components)
+    @NotNull
+    public static String toString(@NotNull BaseComponent... components)
     {
         if ( components.length == 1 )
         {
@@ -81,7 +87,7 @@ public class ComponentSerializer implements JsonDeserializer<BaseComponent>
     }
 
     @Override
-    public BaseComponent deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException
+    public BaseComponent deserialize(@NotNull JsonElement json, @Nullable Type typeOfT, @NotNull JsonDeserializationContext context) throws JsonParseException
     {
         if ( json.isJsonPrimitive() )
         {

--- a/chat/src/main/java/net/md_5/bungee/chat/KeybindComponentSerializer.java
+++ b/chat/src/main/java/net/md_5/bungee/chat/KeybindComponentSerializer.java
@@ -9,12 +9,13 @@ import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 import java.lang.reflect.Type;
 import net.md_5.bungee.api.chat.KeybindComponent;
+import org.jetbrains.annotations.NotNull;
 
 public class KeybindComponentSerializer extends BaseComponentSerializer implements JsonSerializer<KeybindComponent>, JsonDeserializer<KeybindComponent>
 {
 
     @Override
-    public KeybindComponent deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException
+    public KeybindComponent deserialize(@NotNull JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException
     {
         JsonObject object = json.getAsJsonObject();
         if ( !object.has( "keybind" ) )

--- a/chat/src/main/java/net/md_5/bungee/chat/ScoreComponentSerializer.java
+++ b/chat/src/main/java/net/md_5/bungee/chat/ScoreComponentSerializer.java
@@ -9,12 +9,13 @@ import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 import java.lang.reflect.Type;
 import net.md_5.bungee.api.chat.ScoreComponent;
+import org.jetbrains.annotations.NotNull;
 
 public class ScoreComponentSerializer extends BaseComponentSerializer implements JsonSerializer<ScoreComponent>, JsonDeserializer<ScoreComponent>
 {
 
     @Override
-    public ScoreComponent deserialize(JsonElement element, Type type, JsonDeserializationContext context) throws JsonParseException
+    public ScoreComponent deserialize(@NotNull JsonElement element, Type type, JsonDeserializationContext context) throws JsonParseException
     {
         JsonObject json = element.getAsJsonObject();
         if ( !json.has( "score" ) )

--- a/chat/src/main/java/net/md_5/bungee/chat/SelectorComponentSerializer.java
+++ b/chat/src/main/java/net/md_5/bungee/chat/SelectorComponentSerializer.java
@@ -9,12 +9,13 @@ import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 import java.lang.reflect.Type;
 import net.md_5.bungee.api.chat.SelectorComponent;
+import org.jetbrains.annotations.NotNull;
 
 public class SelectorComponentSerializer extends BaseComponentSerializer implements JsonSerializer<SelectorComponent>, JsonDeserializer<SelectorComponent>
 {
 
     @Override
-    public SelectorComponent deserialize(JsonElement element, Type type, JsonDeserializationContext context) throws JsonParseException
+    public SelectorComponent deserialize(@NotNull JsonElement element, Type type, JsonDeserializationContext context) throws JsonParseException
     {
         JsonObject object = element.getAsJsonObject();
         if ( !object.has( "selector" ) )

--- a/chat/src/main/java/net/md_5/bungee/chat/TextComponentSerializer.java
+++ b/chat/src/main/java/net/md_5/bungee/chat/TextComponentSerializer.java
@@ -11,12 +11,13 @@ import java.lang.reflect.Type;
 import java.util.List;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.TextComponent;
+import org.jetbrains.annotations.NotNull;
 
 public class TextComponentSerializer extends BaseComponentSerializer implements JsonSerializer<TextComponent>, JsonDeserializer<TextComponent>
 {
 
     @Override
-    public TextComponent deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException
+    public TextComponent deserialize(@NotNull JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException
     {
         TextComponent component = new TextComponent();
         JsonObject object = json.getAsJsonObject();

--- a/chat/src/main/java/net/md_5/bungee/chat/TranslatableComponentSerializer.java
+++ b/chat/src/main/java/net/md_5/bungee/chat/TranslatableComponentSerializer.java
@@ -11,12 +11,13 @@ import java.lang.reflect.Type;
 import java.util.Arrays;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.TranslatableComponent;
+import org.jetbrains.annotations.NotNull;
 
 public class TranslatableComponentSerializer extends BaseComponentSerializer implements JsonSerializer<TranslatableComponent>, JsonDeserializer<TranslatableComponent>
 {
 
     @Override
-    public TranslatableComponent deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException
+    public TranslatableComponent deserialize(@NotNull JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException
     {
         TranslatableComponent component = new TranslatableComponent();
         JsonObject object = json.getAsJsonObject();

--- a/chat/src/main/java/net/md_5/bungee/chat/TranslationRegistry.java
+++ b/chat/src/main/java/net/md_5/bungee/chat/TranslationRegistry.java
@@ -15,6 +15,7 @@ import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import org.jetbrains.annotations.Contract;
 
 @Data
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -54,6 +55,7 @@ public final class TranslationRegistry
         providers.add( provider );
     }
 
+    @Contract(pure = true)
     public String translate(String s)
     {
         for ( TranslationProvider provider : providers )

--- a/config/src/main/java/net/md_5/bungee/config/Configuration.java
+++ b/config/src/main/java/net/md_5/bungee/config/Configuration.java
@@ -7,6 +7,9 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public final class Configuration
 {
@@ -20,7 +23,7 @@ public final class Configuration
         this( null );
     }
 
-    public Configuration(Configuration defaults)
+    public Configuration(@Nullable Configuration defaults)
     {
         this( new LinkedHashMap<String, Object>(), defaults );
     }
@@ -44,7 +47,9 @@ public final class Configuration
         }
     }
 
-    private Configuration getSectionFor(String path)
+    @NotNull
+    @Contract(pure = true)
+    private Configuration getSectionFor(@NotNull String path)
     {
         int index = path.indexOf( SEPARATOR );
         if ( index == -1 )
@@ -63,15 +68,19 @@ public final class Configuration
         return (Configuration) section;
     }
 
-    private String getChild(String path)
+    @NotNull
+    @Contract(pure = true)
+    private String getChild(@NotNull String path)
     {
         int index = path.indexOf( SEPARATOR );
         return ( index == -1 ) ? path : path.substring( index + 1 );
     }
 
     /*------------------------------------------------------------------------*/
+    @Nullable
+    @Contract(value = "!null, !null -> !null; !null, null -> _", pure = true)
     @SuppressWarnings("unchecked")
-    public <T> T get(String path, T def)
+    public <T> T get(@NotNull String path, @Nullable T def)
     {
         Configuration section = getSectionFor( path );
         Object val;
@@ -91,22 +100,27 @@ public final class Configuration
         return ( val != null ) ? (T) val : def;
     }
 
-    public boolean contains(String path)
+    @Contract(pure = true)
+    public boolean contains(@NotNull String path)
     {
         return get( path, null ) != null;
     }
 
-    public Object get(String path)
+    @Nullable
+    @Contract(pure = true)
+    public Object get(@NotNull String path)
     {
         return get( path, getDefault( path ) );
     }
 
-    public Object getDefault(String path)
+    @Nullable
+    public Object getDefault(@NotNull String path)
     {
         return ( defaults == null ) ? null : defaults.get( path );
     }
 
-    public void set(String path, Object value)
+    @Contract(mutates = "this")
+    public void set(@NotNull String path, @Nullable Object value)
     {
         if ( value instanceof Map )
         {
@@ -130,7 +144,9 @@ public final class Configuration
     }
 
     /*------------------------------------------------------------------------*/
-    public Configuration getSection(String path)
+    @NotNull
+    @Contract(pure = true)
+    public Configuration getSection(@NotNull String path)
     {
         Object def = getDefault( path );
         return (Configuration) get( path, ( def instanceof Configuration ) ? def : new Configuration( ( defaults == null ) ? null : defaults.getSection( path ) ) );
@@ -141,25 +157,30 @@ public final class Configuration
      *
      * @return top level keys for this section
      */
+    @NotNull
+    @Contract(pure = true)
     public Collection<String> getKeys()
     {
         return new LinkedHashSet<>( self.keySet() );
     }
 
     /*------------------------------------------------------------------------*/
-    public byte getByte(String path)
+    @Contract(pure = true)
+    public byte getByte(@NotNull String path)
     {
         Object def = getDefault( path );
         return getByte( path, ( def instanceof Number ) ? ( (Number) def ).byteValue() : 0 );
     }
 
-    public byte getByte(String path, byte def)
+    @Contract(pure = true)
+    public byte getByte(@NotNull String path, byte def)
     {
         Object val = get( path, def );
         return ( val instanceof Number ) ? ( (Number) val ).byteValue() : def;
     }
 
-    public List<Byte> getByteList(String path)
+    @Contract(pure = true)
+    public List<Byte> getByteList(@NotNull String path)
     {
         List<?> list = getList( path );
         List<Byte> result = new ArrayList<>();
@@ -175,19 +196,23 @@ public final class Configuration
         return result;
     }
 
-    public short getShort(String path)
+    @Contract(pure = true)
+    public short getShort(@NotNull String path)
     {
         Object def = getDefault( path );
         return getShort( path, ( def instanceof Number ) ? ( (Number) def ).shortValue() : 0 );
     }
 
-    public short getShort(String path, short def)
+    @Contract(pure = true)
+    public short getShort(@NotNull String path, short def)
     {
         Object val = get( path, def );
         return ( val instanceof Number ) ? ( (Number) val ).shortValue() : def;
     }
 
-    public List<Short> getShortList(String path)
+    @NotNull
+    @Contract(pure = true)
+    public List<Short> getShortList(@NotNull String path)
     {
         List<?> list = getList( path );
         List<Short> result = new ArrayList<>();
@@ -203,19 +228,23 @@ public final class Configuration
         return result;
     }
 
-    public int getInt(String path)
+    @Contract(pure = true)
+    public int getInt(@NotNull String path)
     {
         Object def = getDefault( path );
         return getInt( path, ( def instanceof Number ) ? ( (Number) def ).intValue() : 0 );
     }
 
-    public int getInt(String path, int def)
+    @Contract(pure = true)
+    public int getInt(@NotNull String path, int def)
     {
         Object val = get( path, def );
         return ( val instanceof Number ) ? ( (Number) val ).intValue() : def;
     }
 
-    public List<Integer> getIntList(String path)
+    @NotNull
+    @Contract(pure = true)
+    public List<Integer> getIntList(@NotNull String path)
     {
         List<?> list = getList( path );
         List<Integer> result = new ArrayList<>();
@@ -231,19 +260,23 @@ public final class Configuration
         return result;
     }
 
-    public long getLong(String path)
+    @Contract(pure = true)
+    public long getLong(@NotNull String path)
     {
         Object def = getDefault( path );
         return getLong( path, ( def instanceof Number ) ? ( (Number) def ).longValue() : 0 );
     }
 
-    public long getLong(String path, long def)
+    @Contract(pure = true)
+    public long getLong(@NotNull String path, long def)
     {
         Object val = get( path, def );
         return ( val instanceof Number ) ? ( (Number) val ).longValue() : def;
     }
 
-    public List<Long> getLongList(String path)
+    @NotNull
+    @Contract(pure = true)
+    public List<Long> getLongList(@NotNull String path)
     {
         List<?> list = getList( path );
         List<Long> result = new ArrayList<>();
@@ -259,19 +292,23 @@ public final class Configuration
         return result;
     }
 
-    public float getFloat(String path)
+    @Contract(pure = true)
+    public float getFloat(@NotNull String path)
     {
         Object def = getDefault( path );
         return getFloat( path, ( def instanceof Number ) ? ( (Number) def ).floatValue() : 0 );
     }
 
-    public float getFloat(String path, float def)
+    @Contract(pure = true)
+    public float getFloat(@NotNull String path, float def)
     {
         Object val = get( path, def );
         return ( val instanceof Number ) ? ( (Number) val ).floatValue() : def;
     }
 
-    public List<Float> getFloatList(String path)
+    @NotNull
+    @Contract(pure = true)
+    public List<Float> getFloatList(@NotNull String path)
     {
         List<?> list = getList( path );
         List<Float> result = new ArrayList<>();
@@ -287,19 +324,23 @@ public final class Configuration
         return result;
     }
 
-    public double getDouble(String path)
+    @Contract(pure = true)
+    public double getDouble(@NotNull String path)
     {
         Object def = getDefault( path );
         return getDouble( path, ( def instanceof Number ) ? ( (Number) def ).doubleValue() : 0 );
     }
 
-    public double getDouble(String path, double def)
+    @Contract(pure = true)
+    public double getDouble(@NotNull String path, double def)
     {
         Object val = get( path, def );
         return ( val instanceof Number ) ? ( (Number) val ).doubleValue() : def;
     }
 
-    public List<Double> getDoubleList(String path)
+    @NotNull
+    @Contract(pure = true)
+    public List<Double> getDoubleList(@NotNull String path)
     {
         List<?> list = getList( path );
         List<Double> result = new ArrayList<>();
@@ -315,19 +356,23 @@ public final class Configuration
         return result;
     }
 
-    public boolean getBoolean(String path)
+    @Contract(pure = true)
+    public boolean getBoolean(@NotNull String path)
     {
         Object def = getDefault( path );
         return getBoolean( path, ( def instanceof Boolean ) ? (Boolean) def : false );
     }
 
-    public boolean getBoolean(String path, boolean def)
+    @Contract(pure = true)
+    public boolean getBoolean(@NotNull String path, boolean def)
     {
         Object val = get( path, def );
         return ( val instanceof Boolean ) ? (Boolean) val : def;
     }
 
-    public List<Boolean> getBooleanList(String path)
+    @NotNull
+    @Contract(pure = true)
+    public List<Boolean> getBooleanList(@NotNull String path)
     {
         List<?> list = getList( path );
         List<Boolean> result = new ArrayList<>();
@@ -343,19 +388,23 @@ public final class Configuration
         return result;
     }
 
-    public char getChar(String path)
+    @Contract(pure = true)
+    public char getChar(@NotNull String path)
     {
         Object def = getDefault( path );
         return getChar( path, ( def instanceof Character ) ? (Character) def : '\u0000' );
     }
 
-    public char getChar(String path, char def)
+    @Contract(pure = true)
+    public char getChar(@NotNull String path, char def)
     {
         Object val = get( path, def );
         return ( val instanceof Character ) ? (Character) val : def;
     }
 
-    public List<Character> getCharList(String path)
+    @NotNull
+    @Contract(pure = true)
+    public List<Character> getCharList(@NotNull String path)
     {
         List<?> list = getList( path );
         List<Character> result = new ArrayList<>();
@@ -371,19 +420,25 @@ public final class Configuration
         return result;
     }
 
-    public String getString(String path)
+    @NotNull
+    @Contract(pure = true)
+    public String getString(@NotNull String path)
     {
         Object def = getDefault( path );
         return getString( path, ( def instanceof String ) ? (String) def : "" );
     }
 
-    public String getString(String path, String def)
+    @Nullable
+    @Contract(value = "!null, null -> _;!null, !null -> !null", pure = true)
+    public String getString(@NotNull String path, @Nullable String def)
     {
         Object val = get( path, def );
         return ( val instanceof String ) ? (String) val : def;
     }
 
-    public List<String> getStringList(String path)
+    @NotNull
+    @Contract(pure = true)
+    public List<String> getStringList(@NotNull String path)
     {
         List<?> list = getList( path );
         List<String> result = new ArrayList<>();
@@ -400,13 +455,17 @@ public final class Configuration
     }
 
     /*------------------------------------------------------------------------*/
-    public List<?> getList(String path)
+    @NotNull
+    @Contract(pure = true)
+    public List<?> getList(@NotNull String path)
     {
         Object def = getDefault( path );
         return getList( path, ( def instanceof List<?> ) ? (List<?>) def : Collections.EMPTY_LIST );
     }
 
-    public List<?> getList(String path, List<?> def)
+    @Nullable
+    @Contract(value = "!null, !null -> !null; !null, null -> _; null, _ -> fail", pure = true)
+    public List<?> getList(@NotNull String path, @Nullable List<?> def)
     {
         Object val = get( path, def );
         return ( val instanceof List<?> ) ? (List<?>) val : def;

--- a/config/src/main/java/net/md_5/bungee/config/ConfigurationProvider.java
+++ b/config/src/main/java/net/md_5/bungee/config/ConfigurationProvider.java
@@ -7,6 +7,8 @@ import java.io.Reader;
 import java.io.Writer;
 import java.util.HashMap;
 import java.util.Map;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public abstract class ConfigurationProvider
 {
@@ -38,23 +40,23 @@ public abstract class ConfigurationProvider
     }
 
     /*------------------------------------------------------------------------*/
-    public abstract void save(Configuration config, File file) throws IOException;
+    public abstract void save(@NotNull Configuration config, @NotNull File file) throws IOException;
 
-    public abstract void save(Configuration config, Writer writer);
+    public abstract void save(@NotNull Configuration config, @NotNull Writer writer);
 
-    public abstract Configuration load(File file) throws IOException;
+    public abstract Configuration load(@NotNull File file) throws IOException;
 
-    public abstract Configuration load(File file, Configuration defaults) throws IOException;
+    public abstract Configuration load(@NotNull File file, @Nullable Configuration defaults) throws IOException;
 
-    public abstract Configuration load(Reader reader);
+    public abstract Configuration load(@NotNull Reader reader);
 
-    public abstract Configuration load(Reader reader, Configuration defaults);
+    public abstract Configuration load(@NotNull Reader reader, @Nullable Configuration defaults);
 
-    public abstract Configuration load(InputStream is);
+    public abstract Configuration load(@NotNull InputStream is);
 
-    public abstract Configuration load(InputStream is, Configuration defaults);
+    public abstract Configuration load(@NotNull InputStream is, @Nullable Configuration defaults);
 
-    public abstract Configuration load(String string);
+    public abstract Configuration load(@NotNull String string);
 
-    public abstract Configuration load(String string, Configuration defaults);
+    public abstract Configuration load(@NotNull String string, @Nullable Configuration defaults);
 }

--- a/config/src/main/java/net/md_5/bungee/config/JsonConfiguration.java
+++ b/config/src/main/java/net/md_5/bungee/config/JsonConfiguration.java
@@ -20,6 +20,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.jetbrains.annotations.NotNull;
 
 @NoArgsConstructor(access = AccessLevel.PACKAGE)
 public class JsonConfiguration extends ConfigurationProvider
@@ -35,7 +36,7 @@ public class JsonConfiguration extends ConfigurationProvider
     } ).create();
 
     @Override
-    public void save(Configuration config, File file) throws IOException
+    public void save(@NotNull Configuration config, @NotNull File file) throws IOException
     {
         try ( Writer writer = new OutputStreamWriter( new FileOutputStream( file ), Charsets.UTF_8 ) )
         {
@@ -44,19 +45,19 @@ public class JsonConfiguration extends ConfigurationProvider
     }
 
     @Override
-    public void save(Configuration config, Writer writer)
+    public void save(@NotNull Configuration config, @NotNull Writer writer)
     {
         json.toJson( config.self, writer );
     }
 
     @Override
-    public Configuration load(File file) throws IOException
+    public Configuration load(@NotNull File file) throws IOException
     {
         return load( file, null );
     }
 
     @Override
-    public Configuration load(File file, Configuration defaults) throws IOException
+    public Configuration load(@NotNull File file, Configuration defaults) throws IOException
     {
         try ( FileInputStream is = new FileInputStream( file ) )
         {
@@ -65,14 +66,14 @@ public class JsonConfiguration extends ConfigurationProvider
     }
 
     @Override
-    public Configuration load(Reader reader)
+    public Configuration load(@NotNull Reader reader)
     {
         return load( reader, null );
     }
 
     @Override
     @SuppressWarnings("unchecked")
-    public Configuration load(Reader reader, Configuration defaults)
+    public Configuration load(@NotNull Reader reader, Configuration defaults)
     {
         Map<String, Object> map = json.fromJson( reader, LinkedHashMap.class );
         if ( map == null )
@@ -83,26 +84,26 @@ public class JsonConfiguration extends ConfigurationProvider
     }
 
     @Override
-    public Configuration load(InputStream is)
+    public Configuration load(@NotNull InputStream is)
     {
         return load( is, null );
     }
 
     @Override
-    public Configuration load(InputStream is, Configuration defaults)
+    public Configuration load(@NotNull InputStream is, Configuration defaults)
     {
         return load( new InputStreamReader( is, Charsets.UTF_8 ), defaults );
     }
 
     @Override
-    public Configuration load(String string)
+    public Configuration load(@NotNull String string)
     {
         return load( string, null );
     }
 
     @Override
     @SuppressWarnings("unchecked")
-    public Configuration load(String string, Configuration defaults)
+    public Configuration load(@NotNull String string, Configuration defaults)
     {
         Map<String, Object> map = json.fromJson( string, LinkedHashMap.class );
         if ( map == null )

--- a/config/src/main/java/net/md_5/bungee/config/YamlConfiguration.java
+++ b/config/src/main/java/net/md_5/bungee/config/YamlConfiguration.java
@@ -13,6 +13,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.jetbrains.annotations.NotNull;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
@@ -51,7 +52,7 @@ public class YamlConfiguration extends ConfigurationProvider
     };
 
     @Override
-    public void save(Configuration config, File file) throws IOException
+    public void save(@NotNull Configuration config, @NotNull File file) throws IOException
     {
         try ( Writer writer = new OutputStreamWriter( new FileOutputStream( file ), Charsets.UTF_8 ) )
         {
@@ -60,19 +61,19 @@ public class YamlConfiguration extends ConfigurationProvider
     }
 
     @Override
-    public void save(Configuration config, Writer writer)
+    public void save(@NotNull Configuration config, @NotNull Writer writer)
     {
         yaml.get().dump( config.self, writer );
     }
 
     @Override
-    public Configuration load(File file) throws IOException
+    public Configuration load(@NotNull File file) throws IOException
     {
         return load( file, null );
     }
 
     @Override
-    public Configuration load(File file, Configuration defaults) throws IOException
+    public Configuration load(@NotNull File file, Configuration defaults) throws IOException
     {
         try ( FileInputStream is = new FileInputStream( file ) )
         {
@@ -81,14 +82,14 @@ public class YamlConfiguration extends ConfigurationProvider
     }
 
     @Override
-    public Configuration load(Reader reader)
+    public Configuration load(@NotNull Reader reader)
     {
         return load( reader, null );
     }
 
     @Override
     @SuppressWarnings("unchecked")
-    public Configuration load(Reader reader, Configuration defaults)
+    public Configuration load(@NotNull Reader reader, Configuration defaults)
     {
         Map<String, Object> map = yaml.get().loadAs( reader, LinkedHashMap.class );
         if ( map == null )
@@ -99,14 +100,14 @@ public class YamlConfiguration extends ConfigurationProvider
     }
 
     @Override
-    public Configuration load(InputStream is)
+    public Configuration load(@NotNull InputStream is)
     {
         return load( is, null );
     }
 
     @Override
     @SuppressWarnings("unchecked")
-    public Configuration load(InputStream is, Configuration defaults)
+    public Configuration load(@NotNull InputStream is, Configuration defaults)
     {
         Map<String, Object> map = yaml.get().loadAs( is, LinkedHashMap.class );
         if ( map == null )
@@ -117,14 +118,14 @@ public class YamlConfiguration extends ConfigurationProvider
     }
 
     @Override
-    public Configuration load(String string)
+    public Configuration load(@NotNull String string)
     {
         return load( string, null );
     }
 
     @Override
     @SuppressWarnings("unchecked")
-    public Configuration load(String string, Configuration defaults)
+    public Configuration load(@NotNull String string, Configuration defaults)
     {
         Map<String, Object> map = yaml.get().loadAs( string, LinkedHashMap.class );
         if ( map == null )

--- a/event/src/main/java/net/md_5/bungee/event/EventBus.java
+++ b/event/src/main/java/net/md_5/bungee/event/EventBus.java
@@ -14,6 +14,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.jetbrains.annotations.NotNull;
 
 public class EventBus
 {
@@ -93,7 +94,7 @@ public class EventBus
         return handler;
     }
 
-    public void register(Object listener)
+    public void register(@NotNull Object listener)
     {
         Map<Class<?>, Map<Byte, Set<Method>>> handler = findHandlers( listener );
         lock.lock();
@@ -126,7 +127,7 @@ public class EventBus
         }
     }
 
-    public void unregister(Object listener)
+    public void unregister(@NotNull Object listener)
     {
         Map<Class<?>, Map<Byte, Set<Method>>> handler = findHandlers( listener );
         lock.lock();

--- a/module/cmd-alert/src/main/java/net/md_5/bungee/module/cmd/alert/CommandAlert.java
+++ b/module/cmd-alert/src/main/java/net/md_5/bungee/module/cmd/alert/CommandAlert.java
@@ -5,6 +5,7 @@ import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.api.plugin.Command;
+import org.jetbrains.annotations.NotNull;
 
 public class CommandAlert extends Command
 {
@@ -15,7 +16,7 @@ public class CommandAlert extends Command
     }
 
     @Override
-    public void execute(CommandSender sender, String[] args)
+    public void execute(@NotNull CommandSender sender, String[] args)
     {
         if ( args.length == 0 )
         {

--- a/module/cmd-alert/src/main/java/net/md_5/bungee/module/cmd/alert/CommandAlertRaw.java
+++ b/module/cmd-alert/src/main/java/net/md_5/bungee/module/cmd/alert/CommandAlertRaw.java
@@ -9,6 +9,7 @@ import net.md_5.bungee.api.chat.HoverEvent;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.plugin.Command;
 import net.md_5.bungee.chat.ComponentSerializer;
+import org.jetbrains.annotations.NotNull;
 
 public class CommandAlertRaw extends Command
 {
@@ -19,7 +20,7 @@ public class CommandAlertRaw extends Command
     }
 
     @Override
-    public void execute(CommandSender sender, String[] args)
+    public void execute(@NotNull CommandSender sender, String[] args)
     {
         if ( args.length == 0 )
         {

--- a/module/cmd-find/src/main/java/net/md_5/bungee/module/cmd/find/CommandFind.java
+++ b/module/cmd-find/src/main/java/net/md_5/bungee/module/cmd/find/CommandFind.java
@@ -4,6 +4,7 @@ import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.command.PlayerCommand;
+import org.jetbrains.annotations.NotNull;
 
 public class CommandFind extends PlayerCommand
 {
@@ -14,7 +15,7 @@ public class CommandFind extends PlayerCommand
     }
 
     @Override
-    public void execute(CommandSender sender, String[] args)
+    public void execute(@NotNull CommandSender sender, String[] args)
     {
         if ( args.length != 1 )
         {

--- a/module/cmd-list/src/main/java/net/md_5/bungee/module/cmd/list/CommandList.java
+++ b/module/cmd-list/src/main/java/net/md_5/bungee/module/cmd/list/CommandList.java
@@ -10,6 +10,7 @@ import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.config.ServerInfo;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.plugin.Command;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Command to list all players connected to the proxy.
@@ -23,7 +24,7 @@ public class CommandList extends Command
     }
 
     @Override
-    public void execute(CommandSender sender, String[] args)
+    public void execute(@NotNull CommandSender sender, String[] args)
     {
         for ( ServerInfo server : ProxyServer.getInstance().getServers().values() )
         {

--- a/module/cmd-send/src/main/java/net/md_5/bungee/module/cmd/send/CommandSend.java
+++ b/module/cmd-send/src/main/java/net/md_5/bungee/module/cmd/send/CommandSend.java
@@ -22,6 +22,7 @@ import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.event.ServerConnectEvent;
 import net.md_5.bungee.api.plugin.Command;
 import net.md_5.bungee.api.plugin.TabExecutor;
+import org.jetbrains.annotations.NotNull;
 
 public class CommandSend extends Command implements TabExecutor
 {
@@ -97,7 +98,7 @@ public class CommandSend extends Command implements TabExecutor
     }
 
     @Override
-    public void execute(CommandSender sender, String[] args)
+    public void execute(@NotNull CommandSender sender, String[] args)
     {
         if ( args.length != 2 )
         {
@@ -158,7 +159,7 @@ public class CommandSend extends Command implements TabExecutor
     }
 
     @Override
-    public Iterable<String> onTabComplete(CommandSender sender, String[] args)
+    public Iterable<String> onTabComplete(@NotNull CommandSender sender, String[] args)
     {
         if ( args.length > 2 || args.length == 0 )
         {

--- a/module/cmd-server/src/main/java/net/md_5/bungee/module/cmd/server/CommandServer.java
+++ b/module/cmd-server/src/main/java/net/md_5/bungee/module/cmd/server/CommandServer.java
@@ -17,6 +17,7 @@ import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.event.ServerConnectEvent;
 import net.md_5.bungee.api.plugin.Command;
 import net.md_5.bungee.api.plugin.TabExecutor;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Command to list and switch a player between available servers.
@@ -30,7 +31,7 @@ public class CommandServer extends Command implements TabExecutor
     }
 
     @Override
-    public void execute(CommandSender sender, String[] args)
+    public void execute(@NotNull CommandSender sender, String[] args)
     {
         Map<String, ServerInfo> servers = ProxyServer.getInstance().getServers();
         if ( args.length == 0 )
@@ -81,7 +82,7 @@ public class CommandServer extends Command implements TabExecutor
     }
 
     @Override
-    public Iterable<String> onTabComplete(final CommandSender sender, final String[] args)
+    public Iterable<String> onTabComplete(final @NotNull CommandSender sender, final String[] args)
     {
         return ( args.length > 1 ) ? Collections.EMPTY_LIST : Iterables.transform( Iterables.filter( ProxyServer.getInstance().getServers().values(), new Predicate<ServerInfo>()
         {

--- a/module/reconnect-yaml/src/main/java/net/md_5/bungee/module/reconnect/yaml/YamlReconnectHandler.java
+++ b/module/reconnect-yaml/src/main/java/net/md_5/bungee/module/reconnect/yaml/YamlReconnectHandler.java
@@ -15,6 +15,7 @@ import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.config.ServerInfo;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.util.CaseInsensitiveMap;
+import org.jetbrains.annotations.NotNull;
 import org.yaml.snakeyaml.Yaml;
 
 public class YamlReconnectHandler extends AbstractReconnectHandler
@@ -68,7 +69,7 @@ public class YamlReconnectHandler extends AbstractReconnectHandler
     }
 
     @Override
-    public void setServer(ProxiedPlayer player)
+    public void setServer(@NotNull ProxiedPlayer player)
     {
         lock.writeLock().lock();
         try

--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <version>19.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>1.18.10</version>

--- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
@@ -95,6 +95,7 @@ import net.md_5.bungee.query.RemoteQuery;
 import net.md_5.bungee.scheduler.BungeeScheduler;
 import net.md_5.bungee.util.CaseInsensitiveMap;
 import org.fusesource.jansi.AnsiConsole;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Main BungeeCord proxy class.
@@ -399,7 +400,7 @@ public class BungeeCord extends ProxyServer
     }
 
     @Override
-    public void stop(final String reason)
+    public void stop(final @NotNull String reason)
     {
         new Thread( "Shutdown Thread" )
         {
@@ -526,12 +527,14 @@ public class BungeeCord extends ProxyServer
     }
 
     @Override
+    @NotNull
     public String getName()
     {
         return "BungeeCord";
     }
 
     @Override
+    @NotNull
     public String getVersion()
     {
         return ( BungeeCord.class.getPackage().getImplementationVersion() == null ) ? "unknown" : BungeeCord.class.getPackage().getImplementationVersion();
@@ -553,7 +556,8 @@ public class BungeeCord extends ProxyServer
     }
 
     @Override
-    public String getTranslation(String name, Object... args)
+    @NotNull
+    public String getTranslation(@NotNull String name, Object... args)
     {
         String translation = "<translation '" + name + "' missing>";
         try
@@ -567,6 +571,7 @@ public class BungeeCord extends ProxyServer
 
     @Override
     @SuppressWarnings("unchecked")
+    @NotNull
     public Collection<ProxiedPlayer> getPlayers()
     {
         connectionLock.readLock().lock();
@@ -624,6 +629,7 @@ public class BungeeCord extends ProxyServer
     }
 
     @Override
+    @NotNull
     public Map<String, ServerInfo> getServers()
     {
         return config.getServers();
@@ -651,6 +657,7 @@ public class BungeeCord extends ProxyServer
 
     @Override
     @Synchronized("pluginChannels")
+    @NotNull
     public Collection<String> getChannels()
     {
         return Collections.unmodifiableCollection( pluginChannels );
@@ -673,31 +680,35 @@ public class BungeeCord extends ProxyServer
     }
 
     @Override
+    @NotNull
     public String getGameVersion()
     {
         return ProtocolConstants.SUPPORTED_VERSIONS.get( 0 ) + "-" + ProtocolConstants.SUPPORTED_VERSIONS.get( ProtocolConstants.SUPPORTED_VERSIONS.size() - 1 );
     }
 
     @Override
-    public ServerInfo constructServerInfo(String name, InetSocketAddress address, String motd, boolean restricted)
+    @NotNull
+    public ServerInfo constructServerInfo(@NotNull String name, @NotNull InetSocketAddress address, String motd, boolean restricted)
     {
         return constructServerInfo( name, (SocketAddress) address, motd, restricted );
     }
 
     @Override
-    public ServerInfo constructServerInfo(String name, SocketAddress address, String motd, boolean restricted)
+    @NotNull
+    public ServerInfo constructServerInfo(@NotNull String name, @NotNull SocketAddress address, String motd, boolean restricted)
     {
         return new BungeeServerInfo( name, address, motd, restricted );
     }
 
     @Override
+    @NotNull
     public CommandSender getConsole()
     {
         return ConsoleCommandSender.getInstance();
     }
 
     @Override
-    public void broadcast(String message)
+    public void broadcast(@NotNull String message)
     {
         broadcast( TextComponent.fromLegacyText( message ) );
     }
@@ -713,7 +724,7 @@ public class BungeeCord extends ProxyServer
     }
 
     @Override
-    public void broadcast(BaseComponent message)
+    public void broadcast(@NotNull BaseComponent message)
     {
         getConsole().sendMessage( message.toLegacyText() );
         for ( ProxiedPlayer player : getPlayers() )
@@ -755,13 +766,15 @@ public class BungeeCord extends ProxyServer
     }
 
     @Override
+    @NotNull
     public Collection<String> getDisabledCommands()
     {
         return config.getDisabledCommands();
     }
 
     @Override
-    public Collection<ProxiedPlayer> matchPlayer(final String partialName)
+    @NotNull
+    public Collection<ProxiedPlayer> matchPlayer(final @NotNull String partialName)
     {
         Preconditions.checkNotNull( partialName, "partialName" );
 
@@ -783,6 +796,7 @@ public class BungeeCord extends ProxyServer
     }
 
     @Override
+    @NotNull
     public Title createTitle()
     {
         return new BungeeTitle();

--- a/proxy/src/main/java/net/md_5/bungee/BungeeServerInfo.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeServerInfo.java
@@ -30,6 +30,7 @@ import net.md_5.bungee.netty.HandlerBoss;
 import net.md_5.bungee.netty.PipelineUtils;
 import net.md_5.bungee.protocol.DefinedPacket;
 import net.md_5.bungee.protocol.packet.PluginMessage;
+import org.jetbrains.annotations.NotNull;
 
 // CHECKSTYLE:OFF
 @RequiredArgsConstructor
@@ -73,13 +74,14 @@ public class BungeeServerInfo implements ServerInfo
     }
 
     @Override
+    @NotNull
     public String getPermission()
     {
         return "bungeecord.server." + name;
     }
 
     @Override
-    public boolean canAccess(CommandSender player)
+    public boolean canAccess(@NotNull CommandSender player)
     {
         Preconditions.checkNotNull( player, "player" );
         return !restricted || player.hasPermission( getPermission() );
@@ -98,14 +100,14 @@ public class BungeeServerInfo implements ServerInfo
     }
 
     @Override
-    public void sendData(String channel, byte[] data)
+    public void sendData(@NotNull String channel, byte[] data)
     {
         sendData( channel, data, true );
     }
 
     // TODO: Don't like this method
     @Override
-    public boolean sendData(String channel, byte[] data, boolean queue)
+    public boolean sendData(@NotNull String channel, byte[] data, boolean queue)
     {
         Preconditions.checkNotNull( channel, "channel" );
         Preconditions.checkNotNull( data, "data" );
@@ -144,7 +146,7 @@ public class BungeeServerInfo implements ServerInfo
     }
 
     @Override
-    public void ping(final Callback<ServerPing> callback)
+    public void ping(final @NotNull Callback<ServerPing> callback)
     {
         ping( callback, ProxyServer.getInstance().getProtocolVersion() );
     }

--- a/proxy/src/main/java/net/md_5/bungee/BungeeTitle.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeTitle.java
@@ -6,6 +6,7 @@ import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.chat.ComponentSerializer;
 import net.md_5.bungee.protocol.DefinedPacket;
 import net.md_5.bungee.protocol.packet.Title.Action;
+import org.jetbrains.annotations.NotNull;
 
 public class BungeeTitle implements Title
 {
@@ -149,7 +150,7 @@ public class BungeeTitle implements Title
     }
 
     @Override
-    public Title send(ProxiedPlayer player)
+    public Title send(@NotNull ProxiedPlayer player)
     {
         sendPacket( player, clear );
         sendPacket( player, reset );

--- a/proxy/src/main/java/net/md_5/bungee/ServerConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/ServerConnection.java
@@ -14,6 +14,7 @@ import net.md_5.bungee.api.connection.Server;
 import net.md_5.bungee.netty.ChannelWrapper;
 import net.md_5.bungee.protocol.DefinedPacket;
 import net.md_5.bungee.protocol.packet.PluginMessage;
+import org.jetbrains.annotations.NotNull;
 
 @RequiredArgsConstructor
 public class ServerConnection implements Server
@@ -41,13 +42,13 @@ public class ServerConnection implements Server
     };
 
     @Override
-    public void sendData(String channel, byte[] data)
+    public void sendData(@NotNull String channel, byte[] data)
     {
         unsafe().sendPacket( new PluginMessage( channel, data, forgeServer ) );
     }
 
     @Override
-    public void disconnect(String reason)
+    public void disconnect(@NotNull String reason)
     {
         disconnect();
     }
@@ -61,18 +62,20 @@ public class ServerConnection implements Server
     }
 
     @Override
-    public void disconnect(BaseComponent reason)
+    public void disconnect(@NotNull BaseComponent reason)
     {
         disconnect();
     }
 
     @Override
+    @NotNull
     public InetSocketAddress getAddress()
     {
         return (InetSocketAddress) getSocketAddress();
     }
 
     @Override
+    @NotNull
     public SocketAddress getSocketAddress()
     {
         return getInfo().getAddress();

--- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
@@ -63,6 +63,7 @@ import net.md_5.bungee.tab.ServerUnique;
 import net.md_5.bungee.tab.TabList;
 import net.md_5.bungee.util.CaseInsensitiveSet;
 import net.md_5.bungee.util.ChatComponentTransformer;
+import org.jetbrains.annotations.NotNull;
 
 @RequiredArgsConstructor
 public final class UserConnection implements ProxiedPlayer
@@ -179,32 +180,32 @@ public final class UserConnection implements ProxiedPlayer
     }
 
     @Override
-    public void setDisplayName(String name)
+    public void setDisplayName(@NotNull String name)
     {
         Preconditions.checkNotNull( name, "displayName" );
         displayName = name;
     }
 
     @Override
-    public void connect(ServerInfo target)
+    public void connect(@NotNull ServerInfo target)
     {
         connect( target, null, ServerConnectEvent.Reason.PLUGIN );
     }
 
     @Override
-    public void connect(ServerInfo target, ServerConnectEvent.Reason reason)
+    public void connect(@NotNull ServerInfo target, ServerConnectEvent.Reason reason)
     {
         connect( target, null, false, reason );
     }
 
     @Override
-    public void connect(ServerInfo target, Callback<Boolean> callback)
+    public void connect(@NotNull ServerInfo target, Callback<Boolean> callback)
     {
         connect( target, callback, false, ServerConnectEvent.Reason.PLUGIN );
     }
 
     @Override
-    public void connect(ServerInfo target, Callback<Boolean> callback, ServerConnectEvent.Reason reason)
+    public void connect(@NotNull ServerInfo target, Callback<Boolean> callback, ServerConnectEvent.@NotNull Reason reason)
     {
         connect( target, callback, false, reason );
     }
@@ -269,7 +270,7 @@ public final class UserConnection implements ProxiedPlayer
     }
 
     @Override
-    public void connect(final ServerConnectRequest request)
+    public void connect(final @NotNull ServerConnectRequest request)
     {
         Preconditions.checkNotNull( request, "request" );
 
@@ -371,7 +372,7 @@ public final class UserConnection implements ProxiedPlayer
     }
 
     @Override
-    public void disconnect(String reason)
+    public void disconnect(@NotNull String reason)
     {
         disconnect0( TextComponent.fromLegacyText( reason ) );
     }
@@ -383,7 +384,7 @@ public final class UserConnection implements ProxiedPlayer
     }
 
     @Override
-    public void disconnect(BaseComponent reason)
+    public void disconnect(@NotNull BaseComponent reason)
     {
         disconnect0( reason );
     }
@@ -408,14 +409,14 @@ public final class UserConnection implements ProxiedPlayer
     }
 
     @Override
-    public void chat(String message)
+    public void chat(@NotNull String message)
     {
         Preconditions.checkState( server != null, "Not connected to server" );
         server.getCh().write( new Chat( message ) );
     }
 
     @Override
-    public void sendMessage(String message)
+    public void sendMessage(@NotNull String message)
     {
         sendMessage( TextComponent.fromLegacyText( message ) );
     }
@@ -436,7 +437,7 @@ public final class UserConnection implements ProxiedPlayer
     }
 
     @Override
-    public void sendMessage(BaseComponent message)
+    public void sendMessage(@NotNull BaseComponent message)
     {
         sendMessage( ChatMessageType.SYSTEM, message );
     }
@@ -447,7 +448,7 @@ public final class UserConnection implements ProxiedPlayer
     }
 
     @Override
-    public void sendMessage(ChatMessageType position, BaseComponent... message)
+    public void sendMessage(@NotNull ChatMessageType position, BaseComponent... message)
     {
         // transform score components
         message = ChatComponentTransformer.getInstance().transform( this, true, message );
@@ -473,7 +474,7 @@ public final class UserConnection implements ProxiedPlayer
     }
 
     @Override
-    public void sendMessage(ChatMessageType position, BaseComponent message)
+    public void sendMessage(@NotNull ChatMessageType position, @NotNull BaseComponent message)
     {
         message = ChatComponentTransformer.getInstance().transform( this, true, message )[0];
 
@@ -488,24 +489,27 @@ public final class UserConnection implements ProxiedPlayer
     }
 
     @Override
-    public void sendData(String channel, byte[] data)
+    public void sendData(@NotNull String channel, byte[] data)
     {
         unsafe().sendPacket( new PluginMessage( channel, data, forgeClientHandler.isForgeUser() ) );
     }
 
     @Override
+    @NotNull
     public InetSocketAddress getAddress()
     {
         return (InetSocketAddress) getSocketAddress();
     }
 
     @Override
+    @NotNull
     public SocketAddress getSocketAddress()
     {
         return ch.getRemoteAddress();
     }
 
     @Override
+    @NotNull
     public Collection<String> getGroups()
     {
         return Collections.unmodifiableCollection( groups );
@@ -538,13 +542,13 @@ public final class UserConnection implements ProxiedPlayer
     }
 
     @Override
-    public boolean hasPermission(String permission)
+    public boolean hasPermission(@NotNull String permission)
     {
         return bungee.getPluginManager().callEvent( new PermissionCheckEvent( this, permission, permissions.contains( permission ) ) ).hasPermission();
     }
 
     @Override
-    public void setPermission(String permission, boolean value)
+    public void setPermission(@NotNull String permission, boolean value)
     {
         if ( value )
         {
@@ -556,6 +560,7 @@ public final class UserConnection implements ProxiedPlayer
     }
 
     @Override
+    @NotNull
     public Collection<String> getPermissions()
     {
         return Collections.unmodifiableCollection( permissions );
@@ -604,7 +609,7 @@ public final class UserConnection implements ProxiedPlayer
     }
 
     @Override
-    public ProxiedPlayer.ChatMode getChatMode()
+    public ProxiedPlayer.@NotNull ChatMode getChatMode()
     {
         if ( settings == null )
         {
@@ -630,13 +635,14 @@ public final class UserConnection implements ProxiedPlayer
     }
 
     @Override
+    @NotNull
     public SkinConfiguration getSkinParts()
     {
         return ( settings != null ) ? new PlayerSkinConfiguration( settings.getSkinParts() ) : PlayerSkinConfiguration.SKIN_SHOW_ALL;
     }
 
     @Override
-    public ProxiedPlayer.MainHand getMainHand()
+    public ProxiedPlayer.@NotNull MainHand getMainHand()
     {
         return ( settings == null || settings.getMainHand() == 1 ) ? ProxiedPlayer.MainHand.RIGHT : ProxiedPlayer.MainHand.LEFT;
     }
@@ -648,6 +654,7 @@ public final class UserConnection implements ProxiedPlayer
     }
 
     @Override
+    @NotNull
     public Map<String, String> getModList()
     {
         if ( forgeClientHandler.getClientModList() == null )
@@ -692,7 +699,7 @@ public final class UserConnection implements ProxiedPlayer
     }
 
     @Override
-    public void sendTitle(Title title)
+    public void sendTitle(@NotNull Title title)
     {
         title.send( this );
     }
@@ -719,6 +726,7 @@ public final class UserConnection implements ProxiedPlayer
     }
 
     @Override
+    @NotNull
     public Scoreboard getScoreboard()
     {
         return serverSentScoreboard;

--- a/proxy/src/main/java/net/md_5/bungee/command/CommandBungee.java
+++ b/proxy/src/main/java/net/md_5/bungee/command/CommandBungee.java
@@ -4,6 +4,7 @@ import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.plugin.Command;
+import org.jetbrains.annotations.NotNull;
 
 public class CommandBungee extends Command
 {
@@ -14,7 +15,7 @@ public class CommandBungee extends Command
     }
 
     @Override
-    public void execute(CommandSender sender, String[] args)
+    public void execute(@NotNull CommandSender sender, String[] args)
     {
         sender.sendMessage( ChatColor.BLUE + "This server is running BungeeCord version " + ProxyServer.getInstance().getVersion() + " by md_5" );
     }

--- a/proxy/src/main/java/net/md_5/bungee/command/CommandEnd.java
+++ b/proxy/src/main/java/net/md_5/bungee/command/CommandEnd.java
@@ -4,6 +4,7 @@ import com.google.common.base.Joiner;
 import net.md_5.bungee.BungeeCord;
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.plugin.Command;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Command to terminate the proxy instance. May only be used by the console by
@@ -18,7 +19,7 @@ public class CommandEnd extends Command
     }
 
     @Override
-    public void execute(CommandSender sender, String[] args)
+    public void execute(@NotNull CommandSender sender, String[] args)
     {
         if ( args.length == 0 )
         {

--- a/proxy/src/main/java/net/md_5/bungee/command/CommandIP.java
+++ b/proxy/src/main/java/net/md_5/bungee/command/CommandIP.java
@@ -3,6 +3,7 @@ package net.md_5.bungee.command;
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
+import org.jetbrains.annotations.NotNull;
 
 public class CommandIP extends PlayerCommand
 {
@@ -13,7 +14,7 @@ public class CommandIP extends PlayerCommand
     }
 
     @Override
-    public void execute(CommandSender sender, String[] args)
+    public void execute(@NotNull CommandSender sender, String[] args)
     {
         if ( args.length < 1 )
         {

--- a/proxy/src/main/java/net/md_5/bungee/command/CommandPerms.java
+++ b/proxy/src/main/java/net/md_5/bungee/command/CommandPerms.java
@@ -6,6 +6,7 @@ import net.md_5.bungee.Util;
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.plugin.Command;
+import org.jetbrains.annotations.NotNull;
 
 public class CommandPerms extends Command
 {
@@ -16,7 +17,7 @@ public class CommandPerms extends Command
     }
 
     @Override
-    public void execute(CommandSender sender, String[] args)
+    public void execute(@NotNull CommandSender sender, String[] args)
     {
         Set<String> permissions = new HashSet<>();
         for ( String group : sender.getGroups() )

--- a/proxy/src/main/java/net/md_5/bungee/command/CommandReload.java
+++ b/proxy/src/main/java/net/md_5/bungee/command/CommandReload.java
@@ -5,6 +5,7 @@ import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.event.ProxyReloadEvent;
 import net.md_5.bungee.api.plugin.Command;
+import org.jetbrains.annotations.NotNull;
 
 public class CommandReload extends Command
 {
@@ -15,7 +16,7 @@ public class CommandReload extends Command
     }
 
     @Override
-    public void execute(CommandSender sender, String[] args)
+    public void execute(@NotNull CommandSender sender, String[] args)
     {
         BungeeCord.getInstance().config.load();
         BungeeCord.getInstance().reloadMessages();

--- a/proxy/src/main/java/net/md_5/bungee/command/ConsoleCommandSender.java
+++ b/proxy/src/main/java/net/md_5/bungee/command/ConsoleCommandSender.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.chat.BaseComponent;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Command sender representing the proxy console.
@@ -20,7 +21,7 @@ public final class ConsoleCommandSender implements CommandSender
     private static final ConsoleCommandSender instance = new ConsoleCommandSender();
 
     @Override
-    public void sendMessage(String message)
+    public void sendMessage(@NotNull String message)
     {
         ProxyServer.getInstance().getLogger().info( message );
     }
@@ -41,18 +42,20 @@ public final class ConsoleCommandSender implements CommandSender
     }
 
     @Override
-    public void sendMessage(BaseComponent message)
+    public void sendMessage(@NotNull BaseComponent message)
     {
         sendMessage( message.toLegacyText() );
     }
 
     @Override
+    @NotNull
     public String getName()
     {
         return "CONSOLE";
     }
 
     @Override
+    @NotNull
     public Collection<String> getGroups()
     {
         return Collections.emptySet();
@@ -71,18 +74,19 @@ public final class ConsoleCommandSender implements CommandSender
     }
 
     @Override
-    public boolean hasPermission(String permission)
+    public boolean hasPermission(@NotNull String permission)
     {
         return true;
     }
 
     @Override
-    public void setPermission(String permission, boolean value)
+    public void setPermission(@NotNull String permission, boolean value)
     {
         throw new UnsupportedOperationException( "Console has all permissions" );
     }
 
     @Override
+    @NotNull
     public Collection<String> getPermissions()
     {
         return Collections.emptySet();

--- a/proxy/src/main/java/net/md_5/bungee/conf/YamlConfig.java
+++ b/proxy/src/main/java/net/md_5/bungee/conf/YamlConfig.java
@@ -29,6 +29,7 @@ import net.md_5.bungee.api.config.ConfigurationAdapter;
 import net.md_5.bungee.api.config.ListenerInfo;
 import net.md_5.bungee.api.config.ServerInfo;
 import net.md_5.bungee.util.CaseInsensitiveMap;
+import org.jetbrains.annotations.NotNull;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.error.YAMLException;
@@ -187,25 +188,26 @@ public class YamlConfig implements ConfigurationAdapter
     }
 
     @Override
-    public int getInt(String path, int def)
+    public int getInt(@NotNull String path, int def)
     {
         return get( path, def );
     }
 
     @Override
-    public String getString(String path, String def)
+    public String getString(@NotNull String path, String def)
     {
         return get( path, def );
     }
 
     @Override
-    public boolean getBoolean(String path, boolean def)
+    public boolean getBoolean(@NotNull String path, boolean def)
     {
         return get( path, def );
     }
 
     @Override
     @SuppressWarnings("unchecked")
+    @NotNull
     public Map<String, ServerInfo> getServers()
     {
         Map<String, Map<String, Object>> base = get( "servers", (Map) Collections.singletonMap( "lobby", new HashMap<>() ) );
@@ -229,6 +231,7 @@ public class YamlConfig implements ConfigurationAdapter
     @Override
     @SuppressWarnings("unchecked")
     @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE")
+    @NotNull
     public Collection<ListenerInfo> getListeners()
     {
         Collection<Map<String, Object>> base = get( "listeners", (Collection) Arrays.asList( new Map[]
@@ -297,22 +300,24 @@ public class YamlConfig implements ConfigurationAdapter
 
     @Override
     @SuppressWarnings("unchecked")
+    @NotNull
     public Collection<String> getGroups(String player)
     {
         Collection<String> groups = get( "groups." + player, null );
-        Collection<String> ret = ( groups == null ) ? new HashSet<String>() : new HashSet<>( groups );
+        Collection<String> ret = ( groups == null ) ? new HashSet<>() : new HashSet<>( groups );
         ret.add( "default" );
         return ret;
     }
 
     @Override
-    public Collection<?> getList(String path, Collection<?> def)
+    public Collection<?> getList(@NotNull String path, Collection<?> def)
     {
         return get( path, def );
     }
 
     @Override
     @SuppressWarnings("unchecked")
+    @NotNull
     public Collection<String> getPermissions(String group)
     {
         Collection<String> permissions = get( "permissions." + group, null );

--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -65,6 +65,7 @@ import net.md_5.bungee.protocol.packet.StatusResponse;
 import net.md_5.bungee.util.BoundedArrayList;
 import net.md_5.bungee.util.BufUtil;
 import net.md_5.bungee.util.QuietException;
+import org.jetbrains.annotations.NotNull;
 
 @RequiredArgsConstructor
 public class InitialHandler extends PacketHandler implements PendingConnection
@@ -567,7 +568,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
     }
 
     @Override
-    public void disconnect(String reason)
+    public void disconnect(@NotNull String reason)
     {
         if ( canSendKickMessage() )
         {
@@ -591,7 +592,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
     }
 
     @Override
-    public void disconnect(BaseComponent reason)
+    public void disconnect(@NotNull BaseComponent reason)
     {
         disconnect( new BaseComponent[]
         {
@@ -612,12 +613,14 @@ public class InitialHandler extends PacketHandler implements PendingConnection
     }
 
     @Override
+    @NotNull
     public InetSocketAddress getAddress()
     {
         return (InetSocketAddress) getSocketAddress();
     }
 
     @Override
+    @NotNull
     public SocketAddress getSocketAddress()
     {
         return ch.getRemoteAddress();

--- a/proxy/src/main/java/net/md_5/bungee/scheduler/BungeeScheduler.java
+++ b/proxy/src/main/java/net/md_5/bungee/scheduler/BungeeScheduler.java
@@ -15,14 +15,15 @@ import java.util.concurrent.atomic.AtomicInteger;
 import net.md_5.bungee.api.plugin.Plugin;
 import net.md_5.bungee.api.scheduler.ScheduledTask;
 import net.md_5.bungee.api.scheduler.TaskScheduler;
+import org.jetbrains.annotations.NotNull;
 
 public class BungeeScheduler implements TaskScheduler
 {
 
     private final Object lock = new Object();
     private final AtomicInteger taskCounter = new AtomicInteger();
-    private final TIntObjectMap<BungeeTask> tasks = TCollections.synchronizedMap( new TIntObjectHashMap<BungeeTask>() );
-    private final Multimap<Plugin, BungeeTask> tasksByPlugin = Multimaps.synchronizedMultimap( HashMultimap.<Plugin, BungeeTask>create() );
+    private final TIntObjectMap<BungeeTask> tasks = TCollections.synchronizedMap( new TIntObjectHashMap<>() );
+    private final Multimap<Plugin, BungeeTask> tasksByPlugin = Multimaps.synchronizedMultimap( HashMultimap.create() );
     //
     private final Unsafe unsafe = new Unsafe()
     {
@@ -53,7 +54,7 @@ public class BungeeScheduler implements TaskScheduler
     }
 
     @Override
-    public void cancel(ScheduledTask task)
+    public void cancel(@NotNull ScheduledTask task)
     {
         task.cancel();
     }
@@ -77,19 +78,22 @@ public class BungeeScheduler implements TaskScheduler
     }
 
     @Override
-    public ScheduledTask runAsync(Plugin owner, Runnable task)
+    @NotNull
+    public ScheduledTask runAsync(@NotNull Plugin owner, @NotNull Runnable task)
     {
         return schedule( owner, task, 0, TimeUnit.MILLISECONDS );
     }
 
     @Override
-    public ScheduledTask schedule(Plugin owner, Runnable task, long delay, TimeUnit unit)
+    @NotNull
+    public ScheduledTask schedule(@NotNull Plugin owner, @NotNull Runnable task, long delay, @NotNull TimeUnit unit)
     {
         return schedule( owner, task, delay, 0, unit );
     }
 
     @Override
-    public ScheduledTask schedule(Plugin owner, Runnable task, long delay, long period, TimeUnit unit)
+    @NotNull
+    public ScheduledTask schedule(@NotNull Plugin owner, @NotNull Runnable task, long delay, long period, @NotNull TimeUnit unit)
     {
         Preconditions.checkNotNull( owner, "owner" );
         Preconditions.checkNotNull( task, "task" );


### PR DESCRIPTION
Mostly done only for public methods in the API and then used inspections to also mark methods of implementing classes.

Problem:
- Development of BungeeCord plugins in Kotlin makes nullability as uncertain as in java
- Certain methods in Configuration never return null although some might expect it
- While some IDEs like IntelliJ can infer a couple of these annotations (especially a couple Nullable/NotNull ones), it is not able to infer all annotations added in this commit

Solution:
Adding jetbrains-annotations dependency (apache license 2.0). It provides a couple useful annotations like @NotNull, @Nullable and @Contract
I've chosen to not use @lombok.NonNull as it'd add additional, unwanted null checks when added to parameters.
I've also seen that usage of javax annotations could lead to licensing problems ( https://github.com/google/guava/issues/2960 ), also javax does not have @Contract
@Contract provides the ability to say which parameters affect nullability and failure of the method in some cases where it is clear. Also it allows to mark methods without side effects (pure), those calls can be removed if its return value is not used.

Marked as draft, as maybe some want to add or edit some Nullability annotations and I also want to do another review before.