### PR TITLE
Add system property to change plugins folder

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
@@ -152,7 +152,7 @@ public class BungeeCord extends ProxyServer
     private ConfigurationAdapter configurationAdapter = new YamlConfig();
     private final Collection<String> pluginChannels = new HashSet<>();
     @Getter
-    private final File pluginsFolder = new File( "plugins" );
+    private final File pluginsFolder = new File( System.getProperty( "net.md_5.bungee.plugins", "plugins" ) );
     @Getter
     private final BungeeScheduler scheduler = new BungeeScheduler();
     @Getter


### PR DESCRIPTION
This adds a `net.md_5.bungee.plugins` system property which can be used to set the name of the plugins folder. I have found this feature to be extremely helpful on the Spigot side when testing different plugin setups or no plugins add all simply by using different start files/run configurations

Implementing that functionality with Bungee right now would require moving around folders which gets a bit annoying and is a rather hacky solution imo. Using a system property for that seems cleaner to me.