### PR TITLE
Update HandlerBoss.java

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/netty/HandlerBoss.java
+++ b/proxy/src/main/java/net/md_5/bungee/netty/HandlerBoss.java
@@ -28,7 +28,7 @@ public class HandlerBoss extends ChannelInboundHandlerAdapter
 {
 
     private ChannelWrapper channel;
-    private final PacketHandler handler;
+    private PacketHandler handler;
 
     public void setHandler(PacketHandler handler)
     {


### PR DESCRIPTION
Preconditions explicitly tells that handler can't be null.

Make handler final and remove unnecessary null checks.