### PR TITLE
Chat message sender API

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/connection/ProxiedPlayer.java
+++ b/api/src/main/java/net/md_5/bungee/api/connection/ProxiedPlayer.java
@@ -81,6 +81,22 @@ public interface ProxiedPlayer extends Connection, CommandSender
     public void sendMessage(ChatMessageType position, BaseComponent message);
 
     /**
+     * Send a message to of this player.
+     *
+     * @param sender the sender of the message
+     * @param message the message to send
+     */
+    public void sendMessage(UUID sender, BaseComponent... message);
+
+    /**
+     * Send a message to this player.
+     *
+     * @param sender the sender of the message
+     * @param message the message to send
+     */
+    public void sendMessage(UUID sender, BaseComponent message);
+
+    /**
      * Connects / transfers this user to the specified connection, gracefully
      * closing the current one. Depending on the implementation, this method
      * might return before the user has been connected.

--- a/api/src/main/java/net/md_5/bungee/api/connection/ProxiedPlayer.java
+++ b/api/src/main/java/net/md_5/bungee/api/connection/ProxiedPlayer.java
@@ -81,7 +81,7 @@ public interface ProxiedPlayer extends Connection, CommandSender
     public void sendMessage(ChatMessageType position, BaseComponent message);
 
     /**
-     * Send a message to of this player.
+     * Send a message to this player.
      *
      * @param sender the sender of the message
      * @param message the message to send

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/Chat.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/Chat.java
@@ -2,7 +2,6 @@ package net.md_5.bungee.protocol.packet;
 
 import io.netty.buffer.ByteBuf;
 import java.util.UUID;
-import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/Chat.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/Chat.java
@@ -12,7 +12,6 @@ import net.md_5.bungee.protocol.ProtocolConstants;
 
 @Data
 @NoArgsConstructor
-@AllArgsConstructor
 @EqualsAndHashCode(callSuper = false)
 public class Chat extends DefinedPacket
 {
@@ -30,6 +29,13 @@ public class Chat extends DefinedPacket
     public Chat(String message, byte position)
     {
         this( message, position, EMPTY_UUID );
+    }
+
+    public Chat(String message, byte position, UUID sender)
+    {
+        this.message = message;
+        this.position = position;
+        this.sender = sender == null ? EMPTY_UUID : sender;
     }
 
     @Override

--- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
@@ -441,13 +441,36 @@ public final class UserConnection implements ProxiedPlayer
         sendMessage( ChatMessageType.SYSTEM, message );
     }
 
-    private void sendMessage(ChatMessageType position, String message)
+    @Override
+    public void sendMessage(ChatMessageType position, BaseComponent... message)
     {
-        unsafe().sendPacket( new Chat( message, (byte) position.ordinal() ) );
+        sendMessage( position, null, message );
     }
 
     @Override
-    public void sendMessage(ChatMessageType position, BaseComponent... message)
+    public void sendMessage(ChatMessageType position, BaseComponent message)
+    {
+        sendMessage( position, (UUID) null, message );
+    }
+
+    @Override
+    public void sendMessage(UUID sender, BaseComponent... message)
+    {
+        sendMessage( ChatMessageType.CHAT, sender, message );
+    }
+
+    @Override
+    public void sendMessage(UUID sender, BaseComponent message)
+    {
+        sendMessage( ChatMessageType.CHAT, sender, message );
+    }
+
+    private void sendMessage(ChatMessageType position, UUID sender, String message)
+    {
+        unsafe().sendPacket( new Chat( message, (byte) position.ordinal(), sender ) );
+    }
+
+    private void sendMessage(ChatMessageType position, UUID sender, BaseComponent... message)
     {
         // transform score components
         message = ChatComponentTransformer.getInstance().transform( this, true, message );
@@ -458,7 +481,7 @@ public final class UserConnection implements ProxiedPlayer
             // Fix by converting to a legacy message, see https://bugs.mojang.com/browse/MC-119145
             if ( getPendingConnection().getVersion() <= ProtocolConstants.MINECRAFT_1_10 )
             {
-                sendMessage( position, ComponentSerializer.toString( new TextComponent( BaseComponent.toLegacyText( message ) ) ) );
+                sendMessage( position, sender, ComponentSerializer.toString( new TextComponent( BaseComponent.toLegacyText( message ) ) ) );
             } else
             {
                 net.md_5.bungee.protocol.packet.Title title = new net.md_5.bungee.protocol.packet.Title();
@@ -468,22 +491,7 @@ public final class UserConnection implements ProxiedPlayer
             }
         } else
         {
-            sendMessage( position, ComponentSerializer.toString( message ) );
-        }
-    }
-
-    @Override
-    public void sendMessage(ChatMessageType position, BaseComponent message)
-    {
-        message = ChatComponentTransformer.getInstance().transform( this, true, message )[0];
-
-        // Action bar doesn't display the new JSON formattings, legacy works - send it using this for now
-        if ( position == ChatMessageType.ACTION_BAR )
-        {
-            sendMessage( position, ComponentSerializer.toString( new TextComponent( BaseComponent.toLegacyText( message ) ) ) );
-        } else
-        {
-            sendMessage( position, ComponentSerializer.toString( message ) );
+            sendMessage( position, sender, ComponentSerializer.toString( message ) );
         }
     }
 


### PR DESCRIPTION
Adds API methods to send messages with a sender UUID. In 1.16.4 players will be able to block other players in their client. The added API methods will make it possible to fully support this feature.
1.16.4-pre1 update post:
https://www.minecraft.net/en-us/article/minecraft-1-16-4-pre-release-1