### PR TITLE
SSL on the backend

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/EncryptionUtil.java
+++ b/proxy/src/main/java/net/md_5/bungee/EncryptionUtil.java
@@ -55,6 +55,22 @@ public class EncryptionUtil
         return new EncryptionRequest( hash, pubKey, verify );
     }
 
+    public static EncryptionResponse encryptResponse(EncryptionRequest request, byte[] randomSecret)
+    {
+        try
+        {
+            PublicKey pubkey = getPubkey( request );
+            Cipher cipher = Cipher.getInstance( "RSA" );
+            cipher.init( Cipher.ENCRYPT_MODE, pubkey );
+            byte[] encrypted = cipher.doFinal( request.getVerifyToken() );
+            return new EncryptionResponse( cipher.doFinal( randomSecret ), encrypted );
+        } catch ( GeneralSecurityException e )
+        {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
     public static SecretKey getSecret(EncryptionResponse resp, EncryptionRequest request) throws GeneralSecurityException
     {
         Cipher cipher = Cipher.getInstance( "RSA" );

--- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
+++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
@@ -8,6 +8,9 @@ import java.util.Locale;
 import java.util.Queue;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import net.md_5.bungee.api.ChatColor;
@@ -28,14 +31,19 @@ import net.md_5.bungee.connection.LoginResult;
 import net.md_5.bungee.forge.ForgeConstants;
 import net.md_5.bungee.forge.ForgeServerHandler;
 import net.md_5.bungee.forge.ForgeUtils;
+import net.md_5.bungee.jni.cipher.BungeeCipher;
 import net.md_5.bungee.netty.ChannelWrapper;
 import net.md_5.bungee.netty.HandlerBoss;
 import net.md_5.bungee.netty.PacketHandler;
+import net.md_5.bungee.netty.PipelineUtils;
+import net.md_5.bungee.netty.cipher.CipherDecoder;
+import net.md_5.bungee.netty.cipher.CipherEncoder;
 import net.md_5.bungee.protocol.DefinedPacket;
 import net.md_5.bungee.protocol.PacketWrapper;
 import net.md_5.bungee.protocol.Protocol;
 import net.md_5.bungee.protocol.ProtocolConstants;
 import net.md_5.bungee.protocol.packet.EncryptionRequest;
+import net.md_5.bungee.protocol.packet.EncryptionResponse;
 import net.md_5.bungee.protocol.packet.EntityStatus;
 import net.md_5.bungee.protocol.packet.GameState;
 import net.md_5.bungee.protocol.packet.Handshake;
@@ -325,7 +333,23 @@ public class ServerConnector extends PacketHandler
     @Override
     public void handle(EncryptionRequest encryptionRequest) throws Exception
     {
-        throw new QuietException( "Server is online mode!" );
+        byte[] secret = new byte[16];
+        ThreadLocalRandom.current().nextBytes( secret );
+        EncryptionResponse response = EncryptionUtil.encryptResponse( encryptionRequest, secret );
+        if ( response == null )
+        {
+            throw new IllegalStateException( "unable to generate an encryption key" );
+        }
+        ch.write( response );
+
+
+        SecretKey sharedKey = new SecretKeySpec( secret, "AES" );
+        BungeeCipher decrypt = EncryptionUtil.getCipher( false, sharedKey );
+        ch.addBefore( PipelineUtils.FRAME_DECODER, PipelineUtils.DECRYPT_HANDLER, new CipherDecoder( decrypt ) );
+        BungeeCipher encrypt = EncryptionUtil.getCipher( true, sharedKey );
+        ch.addBefore( PipelineUtils.FRAME_PREPENDER, PipelineUtils.ENCRYPT_HANDLER, new CipherEncoder( encrypt ) );
+        System.out.println( "Server connector is ssl enabled" );
+        thisState = State.LOGIN_SUCCESS;
     }
 
     @Override


### PR DESCRIPTION
I would like to fork this into the main BungeeCord repository because it would protect against network sniffing. I am working on a server patch because even though servers run in offline mode, the client will still send the authentication token, but this currently works with all versions of offline Minecraft ssl-enabled or not.