### PR TITLE
Bump gson to 2.8.6

### DIFF
--- a/chat/pom.xml
+++ b/chat/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.0</version>
+            <version>2.8.6</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/config/pom.xml
+++ b/config/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.0</version>
+            <version>2.8.6</version>
             <scope>compile</scope>
             <optional>true</optional>
         </dependency>


### PR DESCRIPTION
Plugins are restricted to using outdated versions of gson because they default to using this dependency. Update the dependency to allow for the flexibility of more modern libraries.