### PR TITLE
Update InitialHandler.java

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -470,14 +470,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
         if ( isOnlineMode() )
         {
             // Check for multiple connections
-            // We have to check for the old name first
-            ProxiedPlayer oldName = bungee.getPlayer( getName() );
-            if ( oldName != null )
-            {
-                // TODO See #1218
-                oldName.disconnect( bungee.getTranslation( "already_connected_proxy" ) );
-            }
-            // And then also for their old UUID
+            // Check for their old UUID
             ProxiedPlayer oldID = bungee.getPlayer( getUniqueId() );
             if ( oldID != null )
             {


### PR DESCRIPTION
Removing the oldName check because it is redundant as UUID is already checked.

Also, this change will allow accounts with the same username to log on the same server. This is also supported by the vanilla server.
See Issue #3002