### PR TITLE
Enhance permission checking during server connects

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/ProxyConfig.java
+++ b/api/src/main/java/net/md_5/bungee/api/ProxyConfig.java
@@ -87,6 +87,15 @@ public interface ProxyConfig
     int getServerConnectTimeout();
 
     /**
+     * Should all plugin and proxy executed requests for a player to a server require
+     * direct access permission to a server. This is disabled by default, by setting to
+     * true; this will be enabled. This flag can also be toggled in the ServerConnectRequest instance
+     *
+     * @return true if players need authorisation for connections
+     */
+    boolean isRequireAccess();
+
+    /**
      * Time in milliseconds before timing out a ping request from the proxy to a
      * server when attempting to request server list info.
      *

--- a/api/src/main/java/net/md_5/bungee/api/ServerConnectRequest.java
+++ b/api/src/main/java/net/md_5/bungee/api/ServerConnectRequest.java
@@ -40,7 +40,11 @@ public class ServerConnectRequest
         /**
          * Connection failed, error can be accessed from callback method handle.
          */
-        FAIL
+        FAIL,
+        /**
+         * User has no access to this server.
+         */
+        UNAUTHORISED
     }
 
     /**
@@ -68,6 +72,12 @@ public class ServerConnectRequest
      */
     @Setter
     private boolean retry;
+    /**
+     * Disabled by default. Set to true if the the permissions defined in the config
+     * to restrict servers to certain players should be respected for this request.
+     */
+    @Setter
+    private boolean requireAccess;
 
     /**
      * Class that sets default properties/adds methods to the lombok builder
@@ -76,6 +86,7 @@ public class ServerConnectRequest
     public static class Builder
     {
 
+        private boolean requireAccess = ProxyServer.getInstance().getConfig().isRequireAccess();
         private int connectTimeout = ProxyServer.getInstance().getConfig().getServerConnectTimeout();
     }
 }

--- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
@@ -311,6 +311,16 @@ public final class UserConnection implements ProxiedPlayer
             sendMessage( bungee.getTranslation( "already_connecting" ) );
             return;
         }
+        if ( request.isRequireAccess() && !target.canAccess( this ) )
+        {
+            if ( callback != null )
+            {
+                callback.done( ServerConnectRequest.Result.UNAUTHORISED, null );
+            }
+
+            sendMessage( ProxyServer.getInstance().getTranslation( "no_server_permission" ) );
+            return;
+        }
 
         pendingConnects.add( target );
 

--- a/proxy/src/main/java/net/md_5/bungee/conf/Configuration.java
+++ b/proxy/src/main/java/net/md_5/bungee/conf/Configuration.java
@@ -56,6 +56,7 @@ public class Configuration implements ProxyConfig
     private int playerLimit = -1;
     private Collection<String> disabledCommands;
     private int serverConnectTimeout = 5000;
+    private boolean requireAccess = false;
     private int remotePingTimeout = 5000;
     private int throttle = 4000;
     private int throttleLimit = 3;
@@ -91,6 +92,7 @@ public class Configuration implements ProxyConfig
         remotePingCache = adapter.getInt( "remote_ping_cache", remotePingCache );
         playerLimit = adapter.getInt( "player_limit", playerLimit );
         serverConnectTimeout = adapter.getInt( "server_connect_timeout", serverConnectTimeout );
+        requireAccess = adapter.getBoolean( "strict_permissions", requireAccess );
         remotePingTimeout = adapter.getInt( "remote_ping_timeout", remotePingTimeout );
         throttle = adapter.getInt( "connection_throttle", throttle );
         throttleLimit = adapter.getInt( "connection_throttle_limit", throttleLimit );


### PR DESCRIPTION
Previously the only time server permissions were tested was using the /server command.
This left a door for every ProxiedPlayer#connect(ServerInfo) invocation to ignore the ServerInfo#canAccess(ProxiedPlayer) check. This PR implements a few features:
- A config option to always go through the canAccess check during any server connect attempt;
  - I disabled this by default as to retain current behaviour and to not disrupt anyones current setups.
- An option to override whatever setting had been set in the config by directly altering this on the ServerConnectRequest.
- A new ServerConnectRequest REASON field 'UNAUTHORISED'

I feel like this is a feature needed for security purposes as to prevent accidental entrances to hidden servers. If needed of course plugins can bypass the flags.