### PR TITLE
Update ProxiedPlayer#setDisplayName javadoc to current behaviour

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/connection/ProxiedPlayer.java
+++ b/api/src/main/java/net/md_5/bungee/api/connection/ProxiedPlayer.java
@@ -57,8 +57,7 @@ public interface ProxiedPlayer extends Connection, CommandSender
     String getDisplayName();
 
     /**
-     * Sets this players display name to be used as their nametag and tab list
-     * name.
+     * Sets this players display name to be used by bungeecord commands and plugins.
      *
      * @param name the name to set
      */


### PR DESCRIPTION
Bungeecord does not edits nametags and tab list since years.

Currently the display name is only used by bungeecord command /glist and possibly by other bungeecord plugins.