### PR TITLE
Respond to login query requests in a way that matches the Vanilla client

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
+++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
@@ -41,6 +41,8 @@ import net.md_5.bungee.protocol.packet.GameState;
 import net.md_5.bungee.protocol.packet.Handshake;
 import net.md_5.bungee.protocol.packet.Kick;
 import net.md_5.bungee.protocol.packet.Login;
+import net.md_5.bungee.protocol.packet.LoginPayloadRequest;
+import net.md_5.bungee.protocol.packet.LoginPayloadResponse;
 import net.md_5.bungee.protocol.packet.LoginRequest;
 import net.md_5.bungee.protocol.packet.LoginSuccess;
 import net.md_5.bungee.protocol.packet.PluginMessage;
@@ -404,6 +406,12 @@ public class ServerConnector extends PacketHandler
         // We have to forward these to the user, especially with Forge as stuff might break
         // This includes any REGISTER messages we intercepted earlier.
         user.unsafe().sendPacket( pluginMessage );
+    }
+
+    @Override
+    public void handle(LoginPayloadRequest loginPayloadRequest)
+    {
+        ch.write( new LoginPayloadResponse( loginPayloadRequest.getId(), null ) );
     }
 
     @Override


### PR DESCRIPTION
This is a minimal fix to bring Bungee's output in line with the Vanilla spec for login queries in 1.13+.

This change improves compatibility with servers that may use login queries, without binding BungeeCord to any specific modding platform. In an ideal world, someone with a more complete understanding of the problem space would come along and build off this to provide API for plugins to respond to queries, similarly to how plugin channels are currently supported, but that is not something I have the time to appropriately design or implement at the moment.