### PR TITLE
Release HAProxyMessage after read

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/netty/HandlerBoss.java
+++ b/proxy/src/main/java/net/md_5/bungee/netty/HandlerBoss.java
@@ -81,14 +81,20 @@ public class HandlerBoss extends ChannelInboundHandlerAdapter
         if ( msg instanceof HAProxyMessage )
         {
             HAProxyMessage proxy = (HAProxyMessage) msg;
-            InetSocketAddress newAddress = new InetSocketAddress( proxy.sourceAddress(), proxy.sourcePort() );
-
-            ProxyServer.getInstance().getLogger().log( Level.FINE, "Set remote address via PROXY {0} -> {1}", new Object[]
+            try
             {
-                channel.getRemoteAddress(), newAddress
-            } );
+                InetSocketAddress newAddress = new InetSocketAddress( proxy.sourceAddress(), proxy.sourcePort() );
 
-            channel.setRemoteAddress( newAddress );
+                ProxyServer.getInstance().getLogger().log( Level.FINE, "Set remote address via PROXY {0} -> {1}", new Object[]
+                {
+                    channel.getRemoteAddress(), newAddress
+                } );
+
+                channel.setRemoteAddress( newAddress );
+            } finally
+            {
+                proxy.release();
+            }
             return;
         }
 


### PR DESCRIPTION
This pull request changes HandlerBoss to release the HAProxyMessage after the read is complete.

Running in production for few weeks and noticed no regression.