### PR TITLE
Fix regression preventing child classloaders delegating to a PluginClassloader

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/plugin/PluginClassloader.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/PluginClassloader.java
@@ -54,16 +54,16 @@ final class PluginClassloader extends URLClassLoader
     }
 
     @Override
-    public Class<?> loadClass(String name) throws ClassNotFoundException
+    protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException
     {
-        return loadClass0( name, true, true );
+        return loadClass0( name, resolve, true, true );
     }
 
-    private Class<?> loadClass0(String name, boolean checkOther, boolean checkLibraries) throws ClassNotFoundException
+    private Class<?> loadClass0(String name, boolean resolve, boolean checkOther, boolean checkLibraries) throws ClassNotFoundException
     {
         try
         {
-            return super.loadClass( name );
+            return super.loadClass( name, resolve );
         } catch ( ClassNotFoundException ex )
         {
         }
@@ -86,7 +86,7 @@ final class PluginClassloader extends URLClassLoader
                 {
                     try
                     {
-                        return loader.loadClass0( name, false, proxy.getPluginManager().isTransitiveDepend( desc, loader.desc ) );
+                        return loader.loadClass0( name, resolve, false, proxy.getPluginManager().isTransitiveDepend( desc, loader.desc ) );
                     } catch ( ClassNotFoundException ex )
                     {
                     }


### PR DESCRIPTION
A regression was introduced in 425dd4510989834c52d21d38e239ba0c7a4b02d2 which breaks the behaviour of classloaders delegating to their parents.

`java.lang.ClassLoader` uses the `loadClass(String, boolean)` when delegating - by failing to overload this, child classloaders are unable to access classes in other plugins or from the new library loader.

This fixes https://github.com/lucko/LuckPerms/issues/2981 (although my initial diagnosis in that issue was totally incorrect, oops)

I've tested to confirm it works.

Thanks :)

