### PR TITLE
Make sure packet is always released

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/netty/HandlerBoss.java
+++ b/proxy/src/main/java/net/md_5/bungee/netty/HandlerBoss.java
@@ -96,27 +96,30 @@ public class HandlerBoss extends ChannelInboundHandlerAdapter
                 proxy.release();
             }
             return;
-        }
-
-        if ( handler != null )
+        } else if ( msg instanceof PacketWrapper )
         {
             PacketWrapper packet = (PacketWrapper) msg;
-            boolean sendPacket = handler.shouldHandle( packet );
+            
             try
             {
-                if ( sendPacket && packet.packet != null )
+                if ( handler != null )
                 {
-                    try
+                    boolean sendPacket = handler.shouldHandle( packet );
+                    
+                    if ( sendPacket && packet.packet != null )
                     {
-                        packet.packet.handle( handler );
-                    } catch ( CancelSendSignal ex )
-                    {
-                        sendPacket = false;
+                        try
+                        {
+                            packet.packet.handle( handler );
+                        } catch ( CancelSendSignal ex )
+                        {
+                            sendPacket = false;
+                        }
                     }
-                }
-                if ( sendPacket )
-                {
-                    handler.handle( packet );
+                    if ( sendPacket )
+                    {
+                        handler.handle( packet );
+                    }
                 }
             } finally
             {


### PR DESCRIPTION
Just in case to avoid ram consumption by unreleased bytebufs.