### PR TITLE
Force-enable multi-release jar file support for JDK9+ via System property

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/BungeeCordLauncher.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeCordLauncher.java
@@ -21,7 +21,10 @@ public class BungeeCordLauncher
         Security.setProperty( "networkaddress.cache.ttl", "30" );
         Security.setProperty( "networkaddress.cache.negative.ttl", "10" );
         // For JDK9+ we force-enable multi-release jar file support #3087
-        System.setProperty( "jdk.util.jar.enableMultiRelease", "force" );
+        if ( System.getProperty( "jdk.util.jar.enableMultiRelease" ) == null )
+        {
+            System.setProperty( "jdk.util.jar.enableMultiRelease", "force" );
+        }
 
         OptionParser parser = new OptionParser();
         parser.allowsUnrecognizedOptions();

--- a/proxy/src/main/java/net/md_5/bungee/BungeeCordLauncher.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeCordLauncher.java
@@ -20,6 +20,8 @@ public class BungeeCordLauncher
     {
         Security.setProperty( "networkaddress.cache.ttl", "30" );
         Security.setProperty( "networkaddress.cache.negative.ttl", "10" );
+        // For JDK9+ we force-enable multi-release jar file support #3087
+        System.setProperty( "jdk.util.jar.enableMultiRelease", "force" );
 
         OptionParser parser = new OptionParser();
         parser.allowsUnrecognizedOptions();


### PR DESCRIPTION
Fixes SpigotMC/BungeeCord#3087

This way we do not have to fall back to reflection.