### PR TITLE
Default String read limit to 10.000

### DIFF
--- a/protocol/src/main/java/net/md_5/bungee/protocol/DefinedPacket.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/DefinedPacket.java
@@ -33,7 +33,7 @@ public abstract class DefinedPacket
 
     public static String readString(ByteBuf buf)
     {
-        return readString( buf, Short.MAX_VALUE );
+        return readString( buf, 10000 );
     }
 
     public static String readString(ByteBuf buf, int maxLen)


### PR DESCRIPTION
Strings are used to overload servers with packet spam so instead of reading "unrealistic" strings from the client let's limit them.

I had been doing tests in a Survival server for some days and everything seems to work fine.