### PR TITLE
Remove check for . as it isn't breaking. Spaces in names are

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -354,7 +354,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
         Preconditions.checkState( thisState == State.USERNAME, "Not expecting USERNAME" );
         this.loginRequest = loginRequest;
 
-        if ( getName().contains( "." ) )
+        if ( getName().contains( " " ) )
         {
             disconnect( bungee.getTranslation( "name_invalid" ) );
             return;


### PR DESCRIPTION
Player could not play my server due to having a "." in the name. This fixes it, "Periods" in the names do not cause any breaking changes, but a " " (space) in the name will. I don't see any reason to keep the check for "." unless its serving another purpose that I am unaware of.