### PR TITLE
Optimize packet class construction with LambdaMetafactory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,12 @@
             <version>${lombok.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>animal-sniffer-annotations</artifactId>
+            <version>1.20</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java
@@ -49,6 +49,7 @@ import net.md_5.bungee.protocol.packet.Team;
 import net.md_5.bungee.protocol.packet.Title;
 import net.md_5.bungee.protocol.packet.TitleTimes;
 import net.md_5.bungee.protocol.packet.ViewDistance;
+import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
 
 public enum Protocol
 {
@@ -503,6 +504,7 @@ public enum Protocol
             }
         }
 
+        @IgnoreJRERequirement
         @SuppressWarnings("unchecked")
         private void registerPacket(Class<? extends DefinedPacket> packetClass, ProtocolMapping... mappings)
         {


### PR DESCRIPTION
Use LambdaMetafactory to create Suppliers dynamically which invoke the individual constructors.

According to various online sources like [Exhibit A](https://dzone.com/articles/think-twice-before-using-reflection) or [Exhibit B](https://wttech.blog/blog/2020/method-handles-and-lambda-metafactory/) the use of LambdaMetafactory can reach speed levels near direct method invocations.

Tested as not throwing exceptions quickly with 1.8 client on 1.8 server through bungee.