### PR TITLE
Add local maven repo caching to github actions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -18,5 +18,13 @@ jobs:
     - uses: actions/setup-java@v1
       with:
         java-version: ${{ matrix.java }}
+    - uses: actions/cache@v2
+      with:
+        path: |
+          ~/.m2/repository
+          !~/.m2/repository/net/md-5
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
     - run: java -version && mvn --version
     - run: mvn --activate-profiles dist --no-transfer-progress package


### PR DESCRIPTION
Should improve the speed

Unfortunaly using a maven multithreaded (like -T 8) messes with the log output too much for it to be suitable here in my opinion.