### PR TITLE
Check if PingHandler PacketWrapper is null and close the channel

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/connection/PingHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/PingHandler.java
@@ -55,8 +55,9 @@ public class PingHandler extends PacketHandler
     @Override
     public void handle(PacketWrapper packet) throws Exception
     {
-        if ( packet.packet == null )
+        if ( packet == null || packet.packet == null )
         {
+            this.channel.close();
             throw new QuietException( "Unexpected packet received during ping process! " + BufUtil.dump( packet.buf, 16 ) );
         }
     }


### PR DESCRIPTION
This fixes some NullPing attacks by closing the channel when the Ping PacketWrapper or the Ping packet is null