### PR TITLE
Made file log level configurable

### DIFF
--- a/log/src/main/java/net/md_5/bungee/log/BungeeLogger.java
+++ b/log/src/main/java/net/md_5/bungee/log/BungeeLogger.java
@@ -26,6 +26,7 @@ public class BungeeLogger extends Logger
         try
         {
             FileHandler fileHandler = new FileHandler( filePattern, 1 << 24, 8, true );
+            fileHandler.setLevel( Level.parse( System.getProperty( "net.md_5.bungee.file-log-level", "FINEST" ) ) );
             fileHandler.setFormatter( new ConciseFormatter( false ) );
             addHandler( fileHandler );
 

--- a/log/src/main/java/net/md_5/bungee/log/BungeeLogger.java
+++ b/log/src/main/java/net/md_5/bungee/log/BungeeLogger.java
@@ -26,7 +26,7 @@ public class BungeeLogger extends Logger
         try
         {
             FileHandler fileHandler = new FileHandler( filePattern, 1 << 24, 8, true );
-            fileHandler.setLevel( Level.parse( System.getProperty( "net.md_5.bungee.file-log-level", "FINEST" ) ) );
+            fileHandler.setLevel( Level.parse( System.getProperty( "net.md_5.bungee.file-log-level", "INFO" ) ) );
             fileHandler.setFormatter( new ConciseFormatter( false ) );
             addHandler( fileHandler );
 


### PR DESCRIPTION
By default, all log entries are written to the log file making it very hard to read log files. I would suggest introducing another environment variable which can be used to control the log level for the log file. The default value is set to `FINEST`.