### PR TITLE
Check chatmessages for illegal chars & moved length check into the packet class

### DIFF
--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/Chat.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/Chat.java
@@ -40,7 +40,7 @@ public class Chat extends DefinedPacket
     @Override
     public void read(ByteBuf buf, ProtocolConstants.Direction direction, int protocolVersion)
     {
-        message = readString( buf, ( direction == ProtocolConstants.Direction.TO_CLIENT ) ? 262144 : 256 );
+        message = readString( buf, ( direction == ProtocolConstants.Direction.TO_CLIENT ) ? 262144 : ( protocolVersion >= 315 ? 256 : 100 ) );
         if ( direction == ProtocolConstants.Direction.TO_CLIENT )
         {
             position = buf.readByte();

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/Chat.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/Chat.java
@@ -40,7 +40,7 @@ public class Chat extends DefinedPacket
     @Override
     public void read(ByteBuf buf, ProtocolConstants.Direction direction, int protocolVersion)
     {
-        message = readString( buf, ( direction == ProtocolConstants.Direction.TO_CLIENT ) ? 262144 : ( protocolVersion >= 315 ? 256 : 100 ) );
+        message = readString( buf, ( direction == ProtocolConstants.Direction.TO_CLIENT ) ? 262144 : ( protocolVersion >= ProtocolConstants.MINECRAFT_1_11 ? 256 : 100 ) );
         if ( direction == ProtocolConstants.Direction.TO_CLIENT )
         {
             position = buf.readByte();

--- a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
@@ -144,6 +144,12 @@ public class UpstreamBridge extends PacketHandler
     @Override
     public void handle(Chat chat) throws Exception
     {
+        for(char character : chat.getMessage().toCharArray()) {
+    		/* unprintable control codes */					  		 /* DEL */
+    		if(character < 32 || character == '§' || character == Byte.MAX_VALUE) {    			
+    			throw new IllegalStateException("Illegal characters in chat");
+    		}
+    	}
         ChatEvent chatEvent = new ChatEvent( con, con.getServer(), chat.getMessage() );
         if ( !bungee.getPluginManager().callEvent( chatEvent ).isCancelled() )
         {

--- a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
@@ -144,9 +144,6 @@ public class UpstreamBridge extends PacketHandler
     @Override
     public void handle(Chat chat) throws Exception
     {
-        int maxLength = ( con.getPendingConnection().getVersion() >= ProtocolConstants.MINECRAFT_1_11 ) ? 256 : 100;
-        Preconditions.checkArgument( chat.getMessage().length() <= maxLength, "Chat message too long" ); // Mojang limit, check on updates
-
         ChatEvent chatEvent = new ChatEvent( con, con.getServer(), chat.getMessage() );
         if ( !bungee.getPluginManager().callEvent( chatEvent ).isCancelled() )
         {

--- a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
@@ -146,8 +146,8 @@ public class UpstreamBridge extends PacketHandler
     {
         for( int index = 0; index < chat.getMessage().length(); index++ )
         {
-                char character = chat.getMessage().charAt( index );
-                Preconditions.checkState( character > 31 && character != '§' && character != Byte.MAX_VALUE, "illegal characters in chat" );
+            char character = chat.getMessage().charAt( index );
+            Preconditions.checkState( character > 31 && character != '§' && character != Byte.MAX_VALUE, "illegal characters in chat" );
         }
         
         ChatEvent chatEvent = new ChatEvent( con, con.getServer(), chat.getMessage() );

--- a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
@@ -145,10 +145,10 @@ public class UpstreamBridge extends PacketHandler
     public void handle(Chat chat) throws Exception
     {
         for( int index = 0; index < chat.getMessage().length(); index++ )
-	{
-		char character = chat.getMessage().charAt( index );
-		Preconditions.checkState( character > 31 && character != '§' && character != Byte.MAX_VALUE, "illegal characters in chat" );
-	}
+        {
+                char character = chat.getMessage().charAt( index );
+                Preconditions.checkState( character > 31 && character != '§' && character != Byte.MAX_VALUE, "illegal characters in chat" );
+        }
         
         ChatEvent chatEvent = new ChatEvent( con, con.getServer(), chat.getMessage() );
         if ( !bungee.getPluginManager().callEvent( chatEvent ).isCancelled() )

--- a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
@@ -144,12 +144,12 @@ public class UpstreamBridge extends PacketHandler
     @Override
     public void handle(Chat chat) throws Exception
     {
-        for(char character : chat.getMessage().toCharArray()) {
-    		/* unprintable control codes */
-    		if(character < 32 || character == '§' || character == Byte.MAX_VALUE) {    			
-    			throw new IllegalStateException("Illegal characters in chat");
-    		}
-    	}
+        for( int index = 0; index < chat.getMessage().length(); index++ )
+		{
+			char character = chat.getMessage().charAt( index );
+			Preconditions.checkState( character > 31 && character != '§' && character != Byte.MAX_VALUE, "illegal characters in chat" );
+		}
+        
         ChatEvent chatEvent = new ChatEvent( con, con.getServer(), chat.getMessage() );
         if ( !bungee.getPluginManager().callEvent( chatEvent ).isCancelled() )
         {

--- a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
@@ -145,10 +145,10 @@ public class UpstreamBridge extends PacketHandler
     public void handle(Chat chat) throws Exception
     {
         for( int index = 0; index < chat.getMessage().length(); index++ )
-		{
-			char character = chat.getMessage().charAt( index );
-			Preconditions.checkState( character > 31 && character != '§' && character != Byte.MAX_VALUE, "illegal characters in chat" );
-		}
+	{
+		char character = chat.getMessage().charAt( index );
+		Preconditions.checkState( character > 31 && character != '§' && character != Byte.MAX_VALUE, "illegal characters in chat" );
+	}
         
         ChatEvent chatEvent = new ChatEvent( con, con.getServer(), chat.getMessage() );
         if ( !bungee.getPluginManager().callEvent( chatEvent ).isCancelled() )

--- a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
@@ -144,7 +144,7 @@ public class UpstreamBridge extends PacketHandler
     @Override
     public void handle(Chat chat) throws Exception
     {
-        for( int index = 0; index < chat.getMessage().length(); index++ )
+        for( int index = 0, length = chat.getMessage().length(); index < length; index++ )
         {
             char character = chat.getMessage().charAt( index );
             Preconditions.checkState( character > 31 && character != '§' && character != Byte.MAX_VALUE, "illegal characters in chat" );

--- a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
@@ -145,7 +145,7 @@ public class UpstreamBridge extends PacketHandler
     public void handle(Chat chat) throws Exception
     {
         for(char character : chat.getMessage().toCharArray()) {
-    		/* unprintable control codes */					  		 /* DEL */
+    		/* unprintable control codes */
     		if(character < 32 || character == '§' || character == Byte.MAX_VALUE) {    			
     			throw new IllegalStateException("Illegal characters in chat");
     		}


### PR DESCRIPTION
If command logging is enabled the control chars could break the console and we fix the issue that hack client could use \n and color codes in commands