### PR TITLE
Eventbus speed improvements

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/plugin/PluginClassloader.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/PluginClassloader.java
@@ -21,7 +21,7 @@ import net.md_5.bungee.api.ProxyServer;
 final class PluginClassloader extends URLClassLoader
 {
 
-    private static final Set<PluginClassloader> allLoaders = new CopyOnWriteArraySet<>();
+    static final Set<PluginClassloader> allLoaders = new CopyOnWriteArraySet<>();
     //
     private final ProxyServer proxy;
     private final PluginDescription desc;

--- a/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
@@ -9,6 +9,7 @@ import com.google.common.graph.Graphs;
 import com.google.common.graph.MutableGraph;
 import java.io.File;
 import java.io.InputStream;
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
 import java.net.URLClassLoader;
 import java.util.Arrays;
@@ -57,11 +58,12 @@ public final class PluginManager
     private Map<String, PluginDescription> toLoad = new HashMap<>();
     private final Multimap<Plugin, Command> commandsByPlugin = ArrayListMultimap.create();
     private final Multimap<Plugin, Listener> listenersByPlugin = ArrayListMultimap.create();
+    private final MethodHandles.Lookup lookup;
 
-    @SuppressWarnings("unchecked")
-    public PluginManager(ProxyServer proxy)
+    public PluginManager(ProxyServer proxy, MethodHandles.Lookup lookup)
     {
         this.proxy = proxy;
+        this.lookup = lookup;
 
         // Ignore unknown entries in the plugin descriptions
         Constructor yamlConstructor = new Constructor();
@@ -438,7 +440,7 @@ public final class PluginManager
             Preconditions.checkArgument( !method.isAnnotationPresent( Subscribe.class ),
                     "Listener %s has registered using deprecated subscribe annotation! Please update to @EventHandler.", listener );
         }
-        eventBus.register( listener );
+        eventBus.register( listener, lookup );
         listenersByPlugin.put( plugin, listener );
     }
 

--- a/event/pom.xml
+++ b/event/pom.xml
@@ -17,4 +17,13 @@
 
     <name>BungeeCord-Event</name>
     <description>Generic java event dispatching API intended for use with BungeeCord</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>animal-sniffer-annotations</artifactId>
+            <version>1.20</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
 </project>

--- a/event/src/main/java/net/md_5/bungee/event/EventBus.java
+++ b/event/src/main/java/net/md_5/bungee/event/EventBus.java
@@ -71,7 +71,7 @@ public class EventBus
                 Class<?>[] params = m.getParameterTypes();
                 if ( params.length != 1 )
                 {
-                    logger.log( Level.INFO, "Method {0} in class {1} annotated with {2} does not have single argument", new Object[]
+                    logger.log( Level.INFO, "Method {0} in class {1} annotated with {2} does not have exactly one argument", new Object[]
                     {
                         m, listener.getClass(), annotation
                     } );

--- a/event/src/main/java/net/md_5/bungee/event/EventBus.java
+++ b/event/src/main/java/net/md_5/bungee/event/EventBus.java
@@ -1,7 +1,9 @@
 package net.md_5.bungee.event;
 
 import com.google.common.collect.ImmutableSet;
-import java.lang.reflect.InvocationTargetException;
+import java.lang.invoke.LambdaMetafactory;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
 import java.lang.reflect.Method;
 import java.text.MessageFormat;
 import java.util.ArrayList;
@@ -13,13 +15,15 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.BiConsumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
 
 public class EventBus
 {
 
-    private final Map<Class<?>, Map<Byte, Map<Object, Method[]>>> byListenerAndPriority = new HashMap<>();
+    private final Map<Class<?>, Map<Byte, Map<Object, BiConsumer<Object, Object>[]>>> byListenerAndPriority = new HashMap<>();
     private final Map<Class<?>, EventHandlerMethod[]> byEventBaked = new ConcurrentHashMap<>();
     private final Lock lock = new ReentrantLock();
     private final Logger logger;
@@ -45,15 +49,9 @@ public class EventBus
                 try
                 {
                     method.invoke( event );
-                } catch ( IllegalAccessException ex )
+                } catch ( Throwable t )
                 {
-                    throw new Error( "Method became inaccessible: " + event, ex );
-                } catch ( IllegalArgumentException ex )
-                {
-                    throw new Error( "Method rejected target/argument: " + event, ex );
-                } catch ( InvocationTargetException ex )
-                {
-                    logger.log( Level.WARNING, MessageFormat.format( "Error dispatching event {0} to listener {1}", event, method.getListener() ), ex.getCause() );
+                    logger.log( Level.WARNING, MessageFormat.format( "Error dispatching event {0} to listener {1}", event, method.getListener() ), t );
                 }
             }
         }
@@ -85,7 +83,36 @@ public class EventBus
         return handler;
     }
 
+    private static final MethodType INVOKED_TYPE = MethodType.methodType( BiConsumer.class );
+    private static final MethodType SAM_METHOD_TYPE = MethodType.methodType( void.class, Object.class, Object.class );
+
+    @IgnoreJRERequirement
+    @SuppressWarnings("unchecked")
+    private BiConsumer<Object, Object> createMethodInvoker(MethodHandles.Lookup lookup, Object listener, Method method)
+    {
+        try
+        {
+            return (BiConsumer<Object, Object>) LambdaMetafactory.metafactory(
+                    lookup,
+                    "accept",
+                    INVOKED_TYPE,
+                    SAM_METHOD_TYPE,
+                    lookup.unreflect( method ),
+                    MethodType.methodType( void.class, listener.getClass(), method.getParameterTypes()[0] )
+            ).getTarget().invokeExact();
+        } catch ( Throwable t )
+        {
+            throw new RuntimeException( "Could not create invoker for method " + method + " of listener " + listener + " (" + listener.getClass() + ")", t );
+        }
+    }
+
     public void register(Object listener)
+    {
+        register( listener, MethodHandles.lookup() );
+    }
+
+    @SuppressWarnings("unchecked")
+    public void register(Object listener, MethodHandles.Lookup lookup)
     {
         Map<Class<?>, Map<Byte, Set<Method>>> handler = findHandlers( listener );
         lock.lock();
@@ -93,11 +120,14 @@ public class EventBus
         {
             for ( Map.Entry<Class<?>, Map<Byte, Set<Method>>> e : handler.entrySet() )
             {
-                Map<Byte, Map<Object, Method[]>> prioritiesMap = byListenerAndPriority.computeIfAbsent( e.getKey(), k -> new HashMap<>() );
+                Map<Byte, Map<Object, BiConsumer<Object, Object>[]>> prioritiesMap = byListenerAndPriority.computeIfAbsent( e.getKey(), k -> new HashMap<>() );
                 for ( Map.Entry<Byte, Set<Method>> entry : e.getValue().entrySet() )
                 {
+                    BiConsumer<Object, Object>[] baked = entry.getValue().stream()
+                            .map( method -> createMethodInvoker( lookup, listener, method ) )
+                            .toArray( BiConsumer[]::new );
                     prioritiesMap.computeIfAbsent( entry.getKey(), k -> new HashMap<>() )
-                            .put( listener, entry.getValue().toArray( new Method[ 0 ] ) );
+                            .put( listener, baked );
                 }
                 bakeHandlers( e.getKey() );
             }
@@ -144,7 +174,7 @@ public class EventBus
      */
     private void bakeHandlers(Class<?> eventClass)
     {
-        Map<Byte, Map<Object, Method[]>> handlersByPriority = byListenerAndPriority.get( eventClass );
+        Map<Byte, Map<Object, BiConsumer<Object, Object>[]>> handlersByPriority = byListenerAndPriority.get( eventClass );
         if ( handlersByPriority != null )
         {
             List<EventHandlerMethod> handlersList = new ArrayList<>( handlersByPriority.size() * 2 );
@@ -154,12 +184,12 @@ public class EventBus
             byte value = Byte.MIN_VALUE;
             do
             {
-                Map<Object, Method[]> handlersByListener = handlersByPriority.get( value );
+                Map<Object, BiConsumer<Object, Object>[]> handlersByListener = handlersByPriority.get( value );
                 if ( handlersByListener != null )
                 {
-                    for ( Map.Entry<Object, Method[]> listenerHandlers : handlersByListener.entrySet() )
+                    for ( Map.Entry<Object, BiConsumer<Object, Object>[]> listenerHandlers : handlersByListener.entrySet() )
                     {
-                        for ( Method method : listenerHandlers.getValue() )
+                        for ( BiConsumer<Object, Object> method : listenerHandlers.getValue() )
                         {
                             EventHandlerMethod ehm = new EventHandlerMethod( listenerHandlers.getKey(), method );
                             handlersList.add( ehm );

--- a/event/src/main/java/net/md_5/bungee/event/EventHandlerMethod.java
+++ b/event/src/main/java/net/md_5/bungee/event/EventHandlerMethod.java
@@ -1,7 +1,6 @@
 package net.md_5.bungee.event;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
+import java.util.function.BiConsumer;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -12,10 +11,10 @@ public class EventHandlerMethod
     @Getter
     private final Object listener;
     @Getter
-    private final Method method;
+    private final BiConsumer<Object, Object> method;
 
-    public void invoke(Object event) throws IllegalAccessException, IllegalArgumentException, InvocationTargetException
+    public void invoke(Object event)
     {
-        method.invoke( listener, event );
+        method.accept( listener, event );
     }
 }

--- a/event/src/test/java/net/md_5/bungee/event/NonVoidReturnTypeTest.java
+++ b/event/src/test/java/net/md_5/bungee/event/NonVoidReturnTypeTest.java
@@ -1,0 +1,44 @@
+package net.md_5.bungee.event;
+
+import java.util.concurrent.CountDownLatch;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class NonVoidReturnTypeTest
+{
+
+    private final EventBus bus = new EventBus();
+    private final CountDownLatch latch = new CountDownLatch( 2 );
+
+    @Test
+    public void test()
+    {
+        bus.register( this );
+        bus.post( new FirstEvent() );
+        Assert.assertEquals( 0, latch.getCount() );
+    }
+
+    @EventHandler
+    public FirstEvent firstListener(FirstEvent event)
+    {
+        bus.post( new SecondEvent() );
+        Assert.assertEquals( 1, latch.getCount() );
+        latch.countDown();
+        return event;
+    }
+
+    @EventHandler
+    public Object secondListener(SecondEvent event)
+    {
+        latch.countDown();
+        return null;
+    }
+
+    public static class FirstEvent
+    {
+    }
+
+    public static class SecondEvent
+    {
+    }
+}

--- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
@@ -65,6 +65,7 @@ import net.md_5.bungee.api.config.ConfigurationAdapter;
 import net.md_5.bungee.api.config.ListenerInfo;
 import net.md_5.bungee.api.config.ServerInfo;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
+import net.md_5.bungee.api.plugin.EventCallerClassLoader;
 import net.md_5.bungee.api.plugin.Plugin;
 import net.md_5.bungee.api.plugin.PluginManager;
 import net.md_5.bungee.chat.ComponentSerializer;
@@ -220,7 +221,7 @@ public class BungeeCord extends ProxyServer
         System.setErr( new PrintStream( new LoggingOutputStream( logger, Level.SEVERE ), true ) );
         System.setOut( new PrintStream( new LoggingOutputStream( logger, Level.INFO ), true ) );
 
-        pluginManager = new PluginManager( this );
+        pluginManager = new PluginManager( this, EventCallerClassLoader.getEventCallerLookup() );
         getPluginManager().registerCommand( null, new CommandReload() );
         getPluginManager().registerCommand( null, new CommandEnd() );
         getPluginManager().registerCommand( null, new CommandIP() );

--- a/proxy/src/main/java/net/md_5/bungee/api/plugin/EventCallerClassLoader.java
+++ b/proxy/src/main/java/net/md_5/bungee/api/plugin/EventCallerClassLoader.java
@@ -1,0 +1,116 @@
+package net.md_5.bungee.api.plugin;
+
+import com.google.common.io.ByteStreams;
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.util.Set;
+
+/**
+ * Class loader which can delegate to all {@linkplain net.md_5.bungee.api.plugin.PluginClassloader PluginClassloader}
+ * so classes loaded by it can access all plugin classes.<br>
+ * <br>
+ * The class is in this package to be able to easily access PluginClassloader.allLoaders
+ */
+public final class EventCallerClassLoader extends ClassLoader
+{
+
+    private static final String EVENT_CALLER_CLASS = "net.md_5.bungee.pluginutil.EventCaller";
+    private static final String EVENT_CALLER_CLASS_PATH = EVENT_CALLER_CLASS.replace( '.', '/' ).concat( ".class" );
+
+    static
+    {
+        ClassLoader.registerAsParallelCapable();
+    }
+
+    private static MethodHandles.Lookup lookup;
+
+    public static synchronized MethodHandles.Lookup getEventCallerLookup()
+    {
+        if ( lookup == null )
+        {
+            try
+            {
+                lookup = (MethodHandles.Lookup) new EventCallerClassLoader().loadEventCallerClass().getDeclaredField( "lookup" ).get( null );
+            } catch ( ReflectiveOperationException ex )
+            {
+                throw new RuntimeException( ex );
+            }
+        }
+        return lookup;
+    }
+
+    private final Set<PluginClassloader> classLoaders;
+    private final ClassLoader appClassLoader;
+
+    private EventCallerClassLoader()
+    {
+        this.classLoaders = PluginClassloader.allLoaders;
+        this.appClassLoader = getClass().getClassLoader();
+    }
+
+    private Class<?> eventCallerClass;
+
+    private Class<?> loadEventCallerClass()
+    {
+        if ( eventCallerClass == null )
+        {
+            try
+            {
+                return eventCallerClass = findClass( EVENT_CALLER_CLASS );
+            } catch ( ClassNotFoundException ex )
+            {
+                throw new RuntimeException( ex );
+            }
+        }
+        return eventCallerClass;
+    }
+
+    @Override
+    protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException
+    {
+        if ( EVENT_CALLER_CLASS.equals( name ) )
+        {
+            synchronized ( getClassLoadingLock( name ) )
+            {
+                Class<?> c = loadEventCallerClass();
+                if ( resolve )
+                {
+                    resolveClass( c );
+                }
+                return c;
+            }
+        }
+        return super.loadClass( name, resolve );
+    }
+
+    @Override
+    protected Class<?> findClass(String name) throws ClassNotFoundException
+    {
+        if ( EVENT_CALLER_CLASS.equals( name ) )
+        {
+            if ( eventCallerClass != null )
+            {
+                return eventCallerClass;
+            }
+            try
+            {
+                byte[] bytes = ByteStreams.toByteArray( appClassLoader.getResource( EVENT_CALLER_CLASS_PATH ).openStream() );
+                // use define class and don't delegate to app classloader so we are the classloader
+                return defineClass( EVENT_CALLER_CLASS, bytes, 0, bytes.length, getClass().getProtectionDomain() );
+            } catch ( NullPointerException | IOException ex )
+            {
+                throw new ClassNotFoundException( EVENT_CALLER_CLASS, ex );
+            }
+        }
+        for ( PluginClassloader classLoader : classLoaders )
+        {
+            try
+            {
+                return classLoader.loadClass( name );
+            } catch ( ClassNotFoundException ignored )
+            {
+            }
+        }
+        return appClassLoader.loadClass( name );
+    }
+}

--- a/proxy/src/main/java/net/md_5/bungee/pluginutil/EventCaller.java
+++ b/proxy/src/main/java/net/md_5/bungee/pluginutil/EventCaller.java
@@ -1,0 +1,18 @@
+package net.md_5.bungee.pluginutil;
+
+import java.lang.invoke.MethodHandles;
+
+/**
+ * Class to be loaded by {@linkplain net.md_5.bungee.api.plugin.EventCallerClassLoader EventCallerClassLoader}, may not
+ * be referenced in other code directly.<br>
+ * <br>
+ * This class is string-referenced in EventCallerClassLoader; renaming or moving requires to update said string in said
+ * class.<br>
+ * The class is alone in this package to not be able to access other package-only
+ * things.
+ */
+public final class EventCaller
+{
+
+    public static final MethodHandles.Lookup lookup = MethodHandles.lookup();
+}


### PR DESCRIPTION
Take 3 on EventBus speed improvements. Earlier attempts in #3104 (and #3098).

Lambda packet class creation was already merged form previous PRs.

**Uses LambdaMetafactory for event BiConsumer creation.**

This time it uses a lookup created by a special class which is loaded by a custom class loader which delegates to all PluginClassloaders.

Other changes:
- Add NonVoidReturnTypeTest (Supported by current EventBus impl, prevents potential regression in the future)
- Improve wording of listener wrong argument length log message
- Use Java 8 lambda map access in EventBus
Improves speed as HashMap doesn't have to calculate hash multiple times.

Testing done:
- Compiles on Java 8 and 16
- Runs on Java 8 and 16 without additional startup parameters
- Listening for events with a basic plugin is working
