### PR TITLE
Do not fill in LogRecord caller data by default in slf4j wrapper

### DIFF
--- a/slf4j/src/main/java/org/slf4j/impl/JDK14LoggerAdapter.java
+++ b/slf4j/src/main/java/org/slf4j/impl/JDK14LoggerAdapter.java
@@ -585,6 +585,8 @@ public final class JDK14LoggerAdapter extends MarkerIgnoringBase implements Loca
     static String SELF = JDK14LoggerAdapter.class.getName();
     static String SUPER = MarkerIgnoringBase.class.getName();
 
+    private static final boolean FILL_CALLER_DATA = Boolean.getBoolean( "net.md_5.bungee.slf4j-caller-data" );
+
     /**
      * Fill in caller data if possible.
      * 
@@ -592,6 +594,10 @@ public final class JDK14LoggerAdapter extends MarkerIgnoringBase implements Loca
      *          The record to update
      */
     final private void fillCallerData(String callerFQCN, LogRecord record) {
+        if ( !FILL_CALLER_DATA )
+        {
+            return;
+        }
         StackTraceElement[] steArray = new Throwable().getStackTrace();
 
         int selfIndex = -1;


### PR DESCRIPTION
I am no expert with slf4j/java1.4 logging framework, but as bungeecord by default does not use the caller data, it should be safe to not fill it in by default.
Added system property `net.md_5.bungee.slf4j-caller-data` to restore current behaviour in case custom logging requires caller data.

Should slightly improve performance of bungeecord.

Closes #3112
