### PR TITLE
Dont throw exceptions for illegal chars and keepalive queue mismatch

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
@@ -150,7 +150,7 @@ public class UpstreamBridge extends PacketHandler
         for ( int index = 0, length = chat.getMessage().length(); index < length; index++ )
         {
             char c = chat.getMessage().charAt( index );
-            if ( c == '\u00A7' || c < ' ' || c == 127 )
+            if ( c == '\u00A7' || c < ' ' || c == 127 ) // Section symbol, control sequences, and delete
             {
                 con.disconnect( "illegal characters in chat" );
                 throw CancelSendSignal.INSTANCE;

--- a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
@@ -1,6 +1,5 @@
 package net.md_5.bungee.connection;
 
-import com.google.common.base.Preconditions;
 import com.mojang.brigadier.context.StringRange;
 import com.mojang.brigadier.suggestion.Suggestion;
 import com.mojang.brigadier.suggestion.Suggestions;
@@ -131,7 +130,7 @@ public class UpstreamBridge extends PacketHandler
 
         if ( keepAliveData != null && alive.getRandomId() == keepAliveData.getId() )
         {
-            if( keepAliveData != con.getServer().getKeepAlives().poll() )
+            if ( keepAliveData != con.getServer().getKeepAlives().poll() )
             {
                 con.disconnect("keepalive queue mismatch");
                 throw CancelSendSignal.INSTANCE;
@@ -151,7 +150,7 @@ public class UpstreamBridge extends PacketHandler
         for ( int index = 0, length = chat.getMessage().length(); index < length; index++ )
         {
             char c = chat.getMessage().charAt( index );
-            if( c == '\u00A7' || c < ' ' || c == 127 )
+            if ( c == '\u00A7' || c < ' ' || c == 127 )
             {
                 con.disconnect( "illegal characters in chat" );
                 throw CancelSendSignal.INSTANCE;

--- a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
@@ -132,7 +132,7 @@ public class UpstreamBridge extends PacketHandler
         {
             if ( keepAliveData != con.getServer().getKeepAlives().poll() )
             {
-                con.disconnect("keepalive queue mismatch");
+                con.disconnect( "keepalive queue mismatch" );
                 throw CancelSendSignal.INSTANCE;
             }
             int newPing = (int) ( System.currentTimeMillis() - keepAliveData.getTime() );

--- a/proxy/src/main/java/net/md_5/bungee/netty/HandlerBoss.java
+++ b/proxy/src/main/java/net/md_5/bungee/netty/HandlerBoss.java
@@ -158,7 +158,7 @@ public class HandlerBoss extends ChannelInboundHandlerAdapter
                             handler, cause.getCause().getMessage()
                         } );
                     }
-                } else if ( cause instanceof IOException || ( cause instanceof IllegalStateException && handler instanceof InitialHandler ) )
+                } else if ( cause instanceof IOException || ( ( cause instanceof IllegalStateException || cause instanceof IllegalArgumentException ) && !( handler instanceof DownstreamBridge ) ) )
                 {
                     ProxyServer.getInstance().getLogger().log( Level.WARNING, "{0} - {1}: {2}", new Object[]
                     {

--- a/proxy/src/main/java/net/md_5/bungee/netty/HandlerBoss.java
+++ b/proxy/src/main/java/net/md_5/bungee/netty/HandlerBoss.java
@@ -12,7 +12,6 @@ import java.net.InetSocketAddress;
 import java.util.logging.Level;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.connection.CancelSendSignal;
-import net.md_5.bungee.connection.DownstreamBridge;
 import net.md_5.bungee.connection.InitialHandler;
 import net.md_5.bungee.connection.PingHandler;
 import net.md_5.bungee.protocol.BadPacketException;
@@ -159,7 +158,7 @@ public class HandlerBoss extends ChannelInboundHandlerAdapter
                             handler, cause.getCause().getMessage()
                         } );
                     }
-                } else if ( cause instanceof IOException || ( ( cause instanceof IllegalStateException || cause instanceof IllegalArgumentException ) && !( handler instanceof DownstreamBridge ) ) )
+                } else if ( cause instanceof IOException || ( cause instanceof IllegalStateException && handler instanceof InitialHandler ) )
                 {
                     ProxyServer.getInstance().getLogger().log( Level.WARNING, "{0} - {1}: {2}", new Object[]
                     {

--- a/proxy/src/main/java/net/md_5/bungee/netty/HandlerBoss.java
+++ b/proxy/src/main/java/net/md_5/bungee/netty/HandlerBoss.java
@@ -12,6 +12,7 @@ import java.net.InetSocketAddress;
 import java.util.logging.Level;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.connection.CancelSendSignal;
+import net.md_5.bungee.connection.DownstreamBridge;
 import net.md_5.bungee.connection.InitialHandler;
 import net.md_5.bungee.connection.PingHandler;
 import net.md_5.bungee.protocol.BadPacketException;


### PR DESCRIPTION
If a player get kicked for illegal chars or keepalive queue mismatch the full stacktrace will be printed