### PR TITLE
Apply exact vanilla string length limits

### DIFF
--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/TabCompleteRequest.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/TabCompleteRequest.java
@@ -41,7 +41,7 @@ public class TabCompleteRequest extends DefinedPacket
         {
             transactionId = readVarInt( buf );
         }
-        cursor = readString( buf, ( protocolVersion < ProtocolConstants.MINECRAFT_1_13 ? 32767 : ( protocolVersion > ProtocolConstants.MINECRAFT_1_13 ? 32500 : 256 ) ) );
+        cursor = readString( buf, ( protocolVersion > ProtocolConstants.MINECRAFT_1_13 ? 32500 : ( protocolVersion == ProtocolConstants.MINECRAFT_1_13 ? 256 : 32767 ) ) );
 
         if ( protocolVersion < ProtocolConstants.MINECRAFT_1_13 )
         {

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/TabCompleteRequest.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/TabCompleteRequest.java
@@ -41,7 +41,7 @@ public class TabCompleteRequest extends DefinedPacket
         {
             transactionId = readVarInt( buf );
         }
-        cursor = readString( buf, 32500 );
+        cursor = readString( buf, ( protocolVersion < ProtocolConstants.MINECRAFT_1_13 ? 32767 : ( protocolVersion > ProtocolConstants.MINECRAFT_1_13  ? 32500 : 256 ) ) );
 
         if ( protocolVersion < ProtocolConstants.MINECRAFT_1_13 )
         {

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/TabCompleteRequest.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/TabCompleteRequest.java
@@ -41,7 +41,7 @@ public class TabCompleteRequest extends DefinedPacket
         {
             transactionId = readVarInt( buf );
         }
-        cursor = readString( buf, ( protocolVersion < ProtocolConstants.MINECRAFT_1_13 ? 32767 : ( protocolVersion > ProtocolConstants.MINECRAFT_1_13  ? 32500 : 256 ) ) );
+        cursor = readString( buf, ( protocolVersion < ProtocolConstants.MINECRAFT_1_13 ? 32767 : ( protocolVersion > ProtocolConstants.MINECRAFT_1_13 ? 32500 : 256 ) ) );
 
         if ( protocolVersion < ProtocolConstants.MINECRAFT_1_13 )
         {


### PR DESCRIPTION
Limit below 1.13 is 32767 limit above 1.13 is 32500 and the limit in the 1.13 is 256