### PR TITLE
disconnecting directly on illegal chars

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
@@ -147,7 +147,10 @@ public class UpstreamBridge extends PacketHandler
         for ( int index = 0, length = chat.getMessage().length(); index < length; index++ )
         {
             char c = chat.getMessage().charAt( index );
-            Preconditions.checkArgument( c != '\u00A7' && c >= ' ' && c != 127, "illegal characters in chat" ); // Section symbol, control sequences, and delete
+            if ( c == '\u00A7' || c < ' ' || c == 127 ) { // Section symbol, control sequences, and delete
+                con.disconnect( bungee.getTranslation( "illegal_chat_characters", String.format( "\\u%04x", (int) c ) ) );
+                throw CancelSendSignal.INSTANCE;
+            }
         }
 
         ChatEvent chatEvent = new ChatEvent( con, con.getServer(), chat.getMessage() );

--- a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
@@ -147,7 +147,8 @@ public class UpstreamBridge extends PacketHandler
         for ( int index = 0, length = chat.getMessage().length(); index < length; index++ )
         {
             char c = chat.getMessage().charAt( index );
-            if ( c == '\u00A7' || c < ' ' || c == 127 ) { // Section symbol, control sequences, and delete
+            if ( c == '\u00A7' || c < ' ' || c == 127 ) // Section symbol, control sequences, and delete
+            {
                 con.disconnect( bungee.getTranslation( "illegal_chat_characters", String.format( "\\u%04x", (int) c ) ) );
                 throw CancelSendSignal.INSTANCE;
             }

--- a/proxy/src/main/resources/messages.properties
+++ b/proxy/src/main/resources/messages.properties
@@ -38,3 +38,4 @@ you_got_summoned=\u00a76Summoned to {0} by {1}
 command_perms_groups=\u00a76You have the following groups: {0}
 command_perms_permission=\u00a79- {0}
 command_ip=\u00a79IP of {0} is {1}
+illegal_chat_characters=\u00a7cillegal characters in chat ({0})


### PR DESCRIPTION
I added a translation to make the message changeable. we could do the same for the keepalive queue mismatch but this should never happen and if it happen it would be nice to have a stacktrace to see why