### PR TITLE
add ability to disable the security manager

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
@@ -189,7 +189,10 @@ public class BungeeCord extends ProxyServer
         // Java uses ! to indicate a resource inside of a jar/zip/other container. Running Bungee from within a directory that has a ! will cause this to muck up.
         Preconditions.checkState( new File( "." ).getAbsolutePath().indexOf( '!' ) == -1, "Cannot use BungeeCord in directory with ! in path." );
 
-        System.setSecurityManager( new BungeeSecurityManager() );
+        if ( !Boolean.getBoolean( "net.md_5.bungee.security.disable" ) )
+        {
+            System.setSecurityManager( new BungeeSecurityManager() );
+        }
 
         try
         {

--- a/proxy/src/main/java/net/md_5/bungee/BungeeSecurityManager.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeSecurityManager.java
@@ -18,30 +18,25 @@ public class BungeeSecurityManager extends SecurityManager
 
     private void checkRestricted(String text)
     {
-        Class[] context = getClassContext();
-        for ( int i = 2; i < context.length; i++ )
+        ClassLoader loader = getClassContext()[0].getClassLoader();
+
+        // Bungee / system can do everything
+        if ( loader == ClassLoader.getSystemClassLoader() || loader == null )
         {
-            ClassLoader loader = context[i].getClassLoader();
+            return;
+        }
 
-            // Bungee / system can do everything
-            if ( loader == ClassLoader.getSystemClassLoader() || loader == null )
-            {
-                break;
-            }
+        AccessControlException ex = new AccessControlException( "Plugin violation: " + text );
+        if ( ENFORCE )
+        {
+            throw ex;
+        }
 
-            AccessControlException ex = new AccessControlException( "Plugin violation: " + text );
-            if ( ENFORCE )
-            {
-                throw ex;
-            }
-
-            StringWriter stack = new StringWriter();
-            ex.printStackTrace( new PrintWriter( stack ) );
-            if ( seen.add( stack.toString() ) )
-            {
-                ProxyServer.getInstance().getLogger().log( Level.WARNING, "Plugin performed restricted action, please inform them to use proper API methods: " + text, ex );
-            }
-            break;
+        StringWriter stack = new StringWriter();
+        ex.printStackTrace( new PrintWriter( stack ) );
+        if ( seen.add( stack.toString() ) )
+        {
+            ProxyServer.getInstance().getLogger().log( Level.WARNING, "Plugin performed restricted action, please inform them to use proper API methods: " + text, ex );
         }
     }
 


### PR DESCRIPTION
Some servers might want disable the security manager and i think it increases a bit performance if the server get flooded because on every incoming connection that has been printed to the console the checkPermission method will be invoked and on every player join the method get called up to 30 times. I know that this is a time of nanoseconds. But it should still be a bit more efficient