### PR TITLE
Reduce string format calls and log statements with parameters to improve performance.

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
@@ -412,7 +412,7 @@ public final class PluginManager
         long elapsed = System.nanoTime() - start;
         if ( elapsed > 250000000 )
         {
-            ProxyServer.getInstance().getLogger().warning( "Event " + event + " took " + elapsed / 1000000 + "ms to process!" );
+            ProxyServer.getInstance().getLogger().log( Level.WARNING, "Event " + event + " took " + elapsed / 1000000 + "ms to process!" );
         }
         return event;
     }

--- a/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
@@ -199,10 +199,7 @@ public final class PluginManager
             {
                 if ( proxy.getConfig().isLogCommands() )
                 {
-                    proxy.getLogger().log( Level.INFO, "{0} executed command: /{1}", new Object[]
-                    {
-                        sender.getName(), commandLine
-                    } );
+                    proxy.getLogger().log( Level.INFO, sender.getName() + " executed command: /" + commandLine );
                 }
                 command.execute( sender, args );
             } else if ( commandLine.contains( " " ) && command instanceof TabExecutor )
@@ -415,10 +412,7 @@ public final class PluginManager
         long elapsed = System.nanoTime() - start;
         if ( elapsed > 250000000 )
         {
-            ProxyServer.getInstance().getLogger().log( Level.WARNING, "Event {0} took {1}ms to process!", new Object[]
-            {
-                event, elapsed / 1000000
-            } );
+            ProxyServer.getInstance().getLogger().warning( "Event " + event + " took " + elapsed / 1000000 + "ms to process!" );
         }
         return event;
     }

--- a/chat/src/main/java/net/md_5/bungee/api/chat/TextComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/TextComponent.java
@@ -230,6 +230,6 @@ public final class TextComponent extends BaseComponent
     @Override
     public String toString()
     {
-        return String.format( "TextComponent{text=%s, %s}", text, super.toString() );
+        return "TextComponent{text=" + text + ", " + super.toString() + '}';
     }
 }

--- a/event/src/main/java/net/md_5/bungee/event/EventBus.java
+++ b/event/src/main/java/net/md_5/bungee/event/EventBus.java
@@ -3,7 +3,6 @@ package net.md_5.bungee.event;
 import com.google.common.collect.ImmutableSet;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -53,7 +52,7 @@ public class EventBus
                     throw new Error( "Method rejected target/argument: " + event, ex );
                 } catch ( InvocationTargetException ex )
                 {
-                    logger.log( Level.WARNING, MessageFormat.format( "Error dispatching event {0} to listener {1}", event, method.getListener() ), ex.getCause() );
+                    logger.log( Level.WARNING, "Error dispatching event " + event + " to listener " + method.getListener(), ex.getCause() );
                 }
             }
         }

--- a/protocol/src/main/java/net/md_5/bungee/protocol/DefinedPacket.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/DefinedPacket.java
@@ -23,7 +23,7 @@ public abstract class DefinedPacket
     {
         if ( s.length() > Short.MAX_VALUE )
         {
-            throw new OverflowPacketException( String.format( "Cannot send string longer than Short.MAX_VALUE (got %s characters)", s.length() ) );
+            throw new OverflowPacketException( "Cannot send string longer than Short.MAX_VALUE (got " + s.length() + " characters)" );
         }
 
         byte[] b = s.getBytes( Charsets.UTF_8 );
@@ -41,7 +41,7 @@ public abstract class DefinedPacket
         int len = readVarInt( buf );
         if ( len > maxLen * 4 )
         {
-            throw new OverflowPacketException( String.format( "Cannot receive string longer than %d (got %d bytes)", maxLen * 4, len ) );
+            throw new OverflowPacketException( "Cannot receive string longer than " + maxLen * 4 + " (got " + len + " bytes)" );
         }
 
         byte[] b = new byte[ len ];
@@ -50,7 +50,7 @@ public abstract class DefinedPacket
         String s = new String( b, Charsets.UTF_8 );
         if ( s.length() > maxLen )
         {
-            throw new OverflowPacketException( String.format( "Cannot receive string longer than %d (got %d characters)", maxLen, s.length() ) );
+            throw new OverflowPacketException( "Cannot receive string longer than " + maxLen + " (got " + s.length() + " characters)" );
         }
 
         return s;
@@ -60,7 +60,7 @@ public abstract class DefinedPacket
     {
         if ( b.length > Short.MAX_VALUE )
         {
-            throw new OverflowPacketException( String.format( "Cannot send byte array longer than Short.MAX_VALUE (got %s bytes)", b.length ) );
+            throw new OverflowPacketException( "Cannot send byte array longer than Short.MAX_VALUE (got " + b.length + " bytes)" );
         }
         writeVarInt( b.length, buf );
         buf.writeBytes( b );
@@ -84,7 +84,7 @@ public abstract class DefinedPacket
         int len = readVarInt( buf );
         if ( len > limit )
         {
-            throw new OverflowPacketException( String.format( "Cannot receive byte array longer than %s (got %s bytes)", limit, len ) );
+            throw new OverflowPacketException( "Cannot receive byte array longer than " + limit + " (got " + len + " bytes)" );
         }
         byte[] ret = new byte[ len ];
         buf.readBytes( ret );

--- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
@@ -407,10 +407,7 @@ public final class UserConnection implements ProxiedPlayer
     {
         if ( !ch.isClosing() )
         {
-            bungee.getLogger().log( Level.INFO, "[{0}] disconnected with: {1}", new Object[]
-            {
-                getName(), BaseComponent.toLegacyText( reason )
-            } );
+            bungee.getLogger().log( Level.INFO, '[' + toString() + "] disconnected with: " + BaseComponent.toLegacyText( reason ) );
 
             ch.close( new Kick( ComponentSerializer.toString( reason ) ) );
 

--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -320,14 +320,14 @@ public class InitialHandler extends PacketHandler implements PendingConnection
                 // Ping
                 if ( bungee.getConfig().isLogPings() )
                 {
-                    bungee.getLogger().info( this + " has pinged" );
+                    bungee.getLogger().log( Level.INFO, this + " has pinged" );
                 }
                 thisState = State.STATUS;
                 ch.setProtocol( Protocol.STATUS );
                 break;
             case 2:
                 // Login
-                bungee.getLogger().info( this + " has connected" );
+                bungee.getLogger().log( Level.INFO, this + " has connected" );
                 thisState = State.USERNAME;
                 ch.setProtocol( Protocol.LOGIN );
 

--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -320,14 +320,14 @@ public class InitialHandler extends PacketHandler implements PendingConnection
                 // Ping
                 if ( bungee.getConfig().isLogPings() )
                 {
-                    bungee.getLogger().log( Level.INFO, "{0} has pinged", this );
+                    bungee.getLogger().info( this + " has pinged" );
                 }
                 thisState = State.STATUS;
                 ch.setProtocol( Protocol.STATUS );
                 break;
             case 2:
                 // Login
-                bungee.getLogger().log( Level.INFO, "{0} has connected", this );
+                bungee.getLogger().info( this + " has connected" );
                 thisState = State.USERNAME;
                 ch.setProtocol( Protocol.LOGIN );
 

--- a/proxy/src/main/java/net/md_5/bungee/netty/HandlerBoss.java
+++ b/proxy/src/main/java/net/md_5/bungee/netty/HandlerBoss.java
@@ -46,7 +46,7 @@ public class HandlerBoss extends ChannelInboundHandlerAdapter
 
             if ( !( handler instanceof InitialHandler || handler instanceof PingHandler ) )
             {
-                ProxyServer.getInstance().getLogger().log( Level.INFO, "{0} has connected", handler );
+                ProxyServer.getInstance().getLogger().info( handler + " has connected" );
             }
         }
     }
@@ -61,7 +61,7 @@ public class HandlerBoss extends ChannelInboundHandlerAdapter
 
             if ( !( handler instanceof InitialHandler || handler instanceof PingHandler ) )
             {
-                ProxyServer.getInstance().getLogger().log( Level.INFO, "{0} has disconnected", handler );
+                ProxyServer.getInstance().getLogger().info( handler + " has disconnected" );
             }
         }
     }
@@ -136,40 +136,25 @@ public class HandlerBoss extends ChannelInboundHandlerAdapter
             {
                 if ( cause instanceof ReadTimeoutException )
                 {
-                    ProxyServer.getInstance().getLogger().log( Level.WARNING, "{0} - read timed out", handler );
+                    ProxyServer.getInstance().getLogger().log( Level.WARNING, handler + " - read timed out" );
                 } else if ( cause instanceof DecoderException )
                 {
                     if ( cause instanceof CorruptedFrameException )
                     {
-                        ProxyServer.getInstance().getLogger().log( Level.WARNING, "{0} - corrupted frame: {1}", new Object[]
-                        {
-                            handler, cause.getMessage()
-                        } );
+                        ProxyServer.getInstance().getLogger().log( Level.WARNING, handler + " - corrupted frame: " + cause.getMessage() );
                     } else if ( cause.getCause() instanceof BadPacketException )
                     {
-                        ProxyServer.getInstance().getLogger().log( Level.WARNING, "{0} - bad packet ID, are mods in use!? {1}", new Object[]
-                        {
-                            handler, cause.getCause().getMessage()
-                        } );
+                        ProxyServer.getInstance().getLogger().log( Level.WARNING, handler + " - bad packet ID, are mods in use!? " + cause.getCause().getMessage() );
                     } else if ( cause.getCause() instanceof OverflowPacketException )
                     {
-                        ProxyServer.getInstance().getLogger().log( Level.WARNING, "{0} - overflow in packet detected! {1}", new Object[]
-                        {
-                            handler, cause.getCause().getMessage()
-                        } );
+                        ProxyServer.getInstance().getLogger().log( Level.WARNING, handler + " - overflow in packet detected! " + cause.getCause().getMessage() );
                     }
                 } else if ( cause instanceof IOException || ( cause instanceof IllegalStateException && handler instanceof InitialHandler ) )
                 {
-                    ProxyServer.getInstance().getLogger().log( Level.WARNING, "{0} - {1}: {2}", new Object[]
-                    {
-                        handler, cause.getClass().getSimpleName(), cause.getMessage()
-                    } );
+                    ProxyServer.getInstance().getLogger().log( Level.WARNING, handler + " - " + cause.getClass().getSimpleName() + ": " + cause.getMessage() );
                 } else if ( cause instanceof QuietException )
                 {
-                    ProxyServer.getInstance().getLogger().log( Level.SEVERE, "{0} - encountered exception: {1}", new Object[]
-                    {
-                        handler, cause
-                    } );
+                    ProxyServer.getInstance().getLogger().log( Level.SEVERE, handler + " - encountered exception: " + cause );
                 } else
                 {
                     ProxyServer.getInstance().getLogger().log( Level.SEVERE, handler + " - encountered exception", cause );

--- a/proxy/src/main/java/net/md_5/bungee/netty/HandlerBoss.java
+++ b/proxy/src/main/java/net/md_5/bungee/netty/HandlerBoss.java
@@ -46,7 +46,7 @@ public class HandlerBoss extends ChannelInboundHandlerAdapter
 
             if ( !( handler instanceof InitialHandler || handler instanceof PingHandler ) )
             {
-                ProxyServer.getInstance().getLogger().info( handler + " has connected" );
+                ProxyServer.getInstance().getLogger().log( Level.INFO, handler + " has connected" );
             }
         }
     }
@@ -61,7 +61,7 @@ public class HandlerBoss extends ChannelInboundHandlerAdapter
 
             if ( !( handler instanceof InitialHandler || handler instanceof PingHandler ) )
             {
-                ProxyServer.getInstance().getLogger().info( handler + " has disconnected" );
+                ProxyServer.getInstance().getLogger().log( Level.INFO, handler + " has disconnected" );
             }
         }
     }

--- a/proxy/src/main/java/net/md_5/bungee/scheduler/BungeeTask.java
+++ b/proxy/src/main/java/net/md_5/bungee/scheduler/BungeeTask.java
@@ -63,7 +63,7 @@ public class BungeeTask implements Runnable, ScheduledTask
                 task.run();
             } catch ( Throwable t )
             {
-                ProxyServer.getInstance().getLogger().log( Level.SEVERE, String.format( "Task %s encountered an exception", this ), t );
+                ProxyServer.getInstance().getLogger().log( Level.SEVERE, "Task " + this + " encountered an exception", t );
             }
 
             // If we have a period of 0 or less, only run once

--- a/query/src/main/java/net/md_5/bungee/query/QueryHandler.java
+++ b/query/src/main/java/net/md_5/bungee/query/QueryHandler.java
@@ -65,7 +65,7 @@ public class QueryHandler extends SimpleChannelInboundHandler<DatagramPacket>
         ByteBuf in = msg.content();
         if ( in.readUnsignedByte() != 0xFE || in.readUnsignedByte() != 0xFD )
         {
-            bungee.getLogger().log( Level.WARNING, "Query - Incorrect magic!: {0}", msg.sender() );
+            bungee.getLogger().log( Level.WARNING, "Query - Incorrect magic!: " + msg.sender() );
             return;
         }
 


### PR DESCRIPTION
Based on #3136 

This has been applied to common messages on severe, warn and info levels where string concatenation after checking logging level is not relevant as most users use info log level.
Simple string concatenation (with StringBuilder internally) is clearly always faster than parsing a format string. As seen in original PR comments, for String.format we get a difference in order of magnitude.

Not handing the handler in HandlerBoss to the logging thread and letting it wait there to get logged and collected after logging should further improve performance (GC) in scenarios of being attacked with log spam.
Its not that easy to test actual performance impact of that though.