### PR TITLE
remove name length check in InitialHandler

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -360,12 +360,6 @@ public class InitialHandler extends PacketHandler implements PendingConnection
             return;
         }
 
-        if ( getName().length() > 16 )
-        {
-            disconnect( bungee.getTranslation( "name_too_long" ) );
-            return;
-        }
-
         int limit = BungeeCord.getInstance().config.getPlayerLimit();
         if ( limit > 0 && bungee.getOnlineCount() >= limit )
         {

--- a/proxy/src/main/resources/messages.properties
+++ b/proxy/src/main/resources/messages.properties
@@ -21,7 +21,6 @@ server_kick=[Kicked]
 server_list=\u00a76You may connect to the following servers at this time: 
 server_went_down=\u00a7cThe server you were previously on went down, you have been connected to a fallback server
 total_players=Total players online: {0}
-name_too_long=Cannot have username longer than 16 characters
 name_invalid=Username contains invalid characters.
 ping_cannot_connect=\u00a7c[Bungee] Can''t connect to server.
 offline_mode_player=Not authenticated with Minecraft.net


### PR DESCRIPTION
This check is not needed. The connection will be closed while reading the LoginRequest packet if the name length is higher than 16