### PR TITLE
Change connectionsByOfflineUUID Map to use ConcurrentHashMap

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
@@ -38,6 +38,7 @@ import java.util.ResourceBundle;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -132,7 +133,7 @@ public class BungeeCord extends ProxyServer
      */
     private final Map<String, UserConnection> connections = new CaseInsensitiveMap<>();
     // Used to help with packet rewriting
-    private final Map<UUID, UserConnection> connectionsByOfflineUUID = new HashMap<>();
+    private final Map<UUID, UserConnection> connectionsByOfflineUUID = new ConcurrentHashMap<>();
     private final Map<UUID, UserConnection> connectionsByUUID = new HashMap<>();
     private final ReadWriteLock connectionLock = new ReentrantReadWriteLock();
     /**
@@ -602,14 +603,7 @@ public class BungeeCord extends ProxyServer
 
     public UserConnection getPlayerByOfflineUUID(UUID name)
     {
-        connectionLock.readLock().lock();
-        try
-        {
-            return connectionsByOfflineUUID.get( name );
-        } finally
-        {
-            connectionLock.readLock().unlock();
-        }
+        return connectionsByOfflineUUID.get( name );
     }
 
     @Override


### PR DESCRIPTION
Purpose of this change is to avoid having to lock/unlock every single time for such a constantly accessed map. The only usage of this map is get/put/remove

My only concern is a potential de-synchronization issue, but I do not see any cases where that would even be a problem.