### PR TITLE
Read only 20 chars for clients below 1.13 in PluginMessages

### DIFF
--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/PluginMessage.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/PluginMessage.java
@@ -68,7 +68,7 @@ public class PluginMessage extends DefinedPacket
     @Override
     public void read(ByteBuf buf, ProtocolConstants.Direction direction, int protocolVersion)
     {
-        tag = ( protocolVersion >= ProtocolConstants.MINECRAFT_1_13 ) ? MODERNISE.apply( readString( buf ) ) : readString( buf );
+        tag = ( protocolVersion >= ProtocolConstants.MINECRAFT_1_13 ) ? MODERNISE.apply( readString( buf ) ) : readString( buf, 20 );
         int maxSize = direction == ProtocolConstants.Direction.TO_SERVER ? Short.MAX_VALUE : 0x100000;
         Preconditions.checkArgument( buf.readableBytes() < maxSize );
         data = new byte[ buf.readableBytes() ];


### PR DESCRIPTION
20 chars is the vanilla limit for all clients below 1.13. We should use this value.