### PR TITLE
Remove redundant protocol version check in the TabCompleteResponse packet

### DIFF
--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/TabCompleteResponse.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/TabCompleteResponse.java
@@ -57,9 +57,7 @@ public class TabCompleteResponse extends DefinedPacket
             }
 
             suggestions = new Suggestions( range, matches );
-        }
-
-        if ( protocolVersion < ProtocolConstants.MINECRAFT_1_13 )
+        } else
         {
             commands = readStringArray( buf );
         }
@@ -84,9 +82,7 @@ public class TabCompleteResponse extends DefinedPacket
                     writeString( suggestion.getTooltip().getString(), buf );
                 }
             }
-        }
-
-        if ( protocolVersion < ProtocolConstants.MINECRAFT_1_13 )
+        } else
         {
             writeStringArray( commands, buf );
         }


### PR DESCRIPTION
No need for the second if in the read and write method. Use a else instead.