### PR TITLE
Provide api to get the ChannelWrapper of a Connection

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -44,6 +44,12 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>net.md-5</groupId>
+            <artifactId>bungeecord-proxy</artifactId>
+            <version>${project.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport-native-unix-common</artifactId>
             <version>${netty.version}</version>

--- a/api/src/main/java/net/md_5/bungee/api/connection/Connection.java
+++ b/api/src/main/java/net/md_5/bungee/api/connection/Connection.java
@@ -82,7 +82,7 @@ public interface Connection
         /**
          * Get the ChannelWrapper of this connection.
          *
-         * @param packet the packet to send
+         * @return the ChannelWrapper of the connection
          */
         ChannelWrapper getChannelWrapper();
         

--- a/api/src/main/java/net/md_5/bungee/api/connection/Connection.java
+++ b/api/src/main/java/net/md_5/bungee/api/connection/Connection.java
@@ -3,6 +3,7 @@ package net.md_5.bungee.api.connection;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.netty.ChannelWrapper;
 import net.md_5.bungee.protocol.DefinedPacket;
 
 /**
@@ -78,6 +79,13 @@ public interface Connection
     interface Unsafe
     {
 
+        /**
+         * Get the ChannelWrapper of this connection.
+         *
+         * @param packet the packet to send
+         */
+        ChannelWrapper getChannelWrapper();
+        
         /**
          * Send a packet to this connection.
          *

--- a/proxy/src/main/java/net/md_5/bungee/ServerConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/ServerConnection.java
@@ -38,6 +38,12 @@ public class ServerConnection implements Server
         {
             ch.write( packet );
         }
+        
+        @Override
+        public ChannelWrapper getChannelWrapper()
+        {
+            return ch;
+        }
     };
 
     @Override

--- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
@@ -145,6 +145,12 @@ public final class UserConnection implements ProxiedPlayer
         {
             ch.write( packet );
         }
+        
+        @Override
+        public ChannelWrapper getChannelWrapper()
+        {
+            return ch;
+        }
     };
 
     public void init()


### PR DESCRIPTION
Can be very usefull if you want to get the netty channel of a ProxiedPlayer. Otherwise you need to use reflections to get the channel