### PR TITLE
Check the username in the LoginRequest

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -353,13 +353,13 @@ public class InitialHandler extends PacketHandler implements PendingConnection
     public void handle(LoginRequest loginRequest) throws Exception
     {
         Preconditions.checkState( thisState == State.USERNAME, "Not expecting USERNAME" );
-        
+
         if ( !PlayerNameUtil.isValid( onlineMode, getName() ) )
         {
             disconnect( bungee.getTranslation( "name_invalid" ) );
             return;
         }
-        
+
         this.loginRequest = loginRequest;
 
         int limit = BungeeCord.getInstance().config.getPlayerLimit();

--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -64,6 +64,7 @@ import net.md_5.bungee.protocol.packet.StatusRequest;
 import net.md_5.bungee.protocol.packet.StatusResponse;
 import net.md_5.bungee.util.BoundedArrayList;
 import net.md_5.bungee.util.BufUtil;
+import net.md_5.bungee.util.PlayerNameUtil;
 import net.md_5.bungee.util.QuietException;
 
 @RequiredArgsConstructor
@@ -354,7 +355,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
         Preconditions.checkState( thisState == State.USERNAME, "Not expecting USERNAME" );
         this.loginRequest = loginRequest;
 
-        if ( getName().contains( " " ) )
+        if ( !PlayerNameUtil.isValid( onlineMode, getName() ) )
         {
             disconnect( bungee.getTranslation( "name_invalid" ) );
             return;

--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -353,13 +353,14 @@ public class InitialHandler extends PacketHandler implements PendingConnection
     public void handle(LoginRequest loginRequest) throws Exception
     {
         Preconditions.checkState( thisState == State.USERNAME, "Not expecting USERNAME" );
-        this.loginRequest = loginRequest;
-
+        
         if ( !PlayerNameUtil.isValid( onlineMode, getName() ) )
         {
             disconnect( bungee.getTranslation( "name_invalid" ) );
             return;
         }
+        
+        this.loginRequest = loginRequest;
 
         int limit = BungeeCord.getInstance().config.getPlayerLimit();
         if ( limit > 0 && bungee.getOnlineCount() >= limit )

--- a/proxy/src/main/java/net/md_5/bungee/util/PlayerNameUtil.java
+++ b/proxy/src/main/java/net/md_5/bungee/util/PlayerNameUtil.java
@@ -1,0 +1,37 @@
+package net.md_5.bungee.util;
+
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+public class PlayerNameUtil
+{
+
+    public static boolean isValid(boolean onlineMode, String name)
+    {
+        if ( onlineMode )
+        {
+            for ( int i = 0; i < name.length(); i++ )
+            {
+                char c = name.charAt( i );
+                if ( ( c >= '0' && c <= '9' ) || ( c >= 'A' && c <= 'Z' ) || ( c >= 'a' && c <= 'z' ) || c == '_' )
+                {
+                    continue;
+                }
+                return false;
+            }
+        } else
+        {
+            for ( int i = 0; i < name.length(); i++ )
+            {
+                char c = name.charAt( i );
+                // Section symbol, control sequences & space, and delete
+                if ( c == '\u00A7' || c <= ' ' || c == 127 )
+                {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+}


### PR DESCRIPTION
This prevents abusing illegal chars in names on cracked server and clients sending weird sessions on premium servers
I moved down the initializing of the loginRequest for the reason that if something causes an exception in the same moment the username will be printed to the console because the channel close will be called with 250ms delay and we don't want § or control chars in our consoles