### PR TITLE
Fixed a protocol implementation issue

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -115,12 +115,12 @@ public class InitialHandler extends PacketHandler implements PendingConnection
     private enum State
     {
 
-        HANDSHAKE, STATUS, PING, USERNAME, ENCRYPT, FINISHED;
+        HANDSHAKE, STATUS, PING, USERNAME, ENCRYPT, FINISHING, FINISHED;
     }
 
     private boolean canSendKickMessage()
     {
-        return thisState == State.USERNAME || thisState == State.ENCRYPT || thisState == State.FINISHED;
+        return thisState == State.USERNAME || thisState == State.ENCRYPT || thisState == State.FINISHING || thisState == State.FINISHED;
     }
 
     @Override
@@ -392,12 +392,13 @@ public class InitialHandler extends PacketHandler implements PendingConnection
                 }
                 if ( onlineMode )
                 {
+                    thisState = State.ENCRYPT;
                     unsafe().sendPacket( request = EncryptionUtil.encryptRequest() );
                 } else
                 {
+                    thisState = State.FINISHING;
                     finish();
                 }
-                thisState = State.ENCRYPT;
             }
         };
 
@@ -455,7 +456,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
                 }
             }
         };
-
+        thisState = State.FINISHING;
         HttpClient.get( authURL, ch.getHandle().eventLoop(), handler );
     }
 

--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -115,12 +115,12 @@ public class InitialHandler extends PacketHandler implements PendingConnection
     private enum State
     {
 
-        HANDSHAKE, STATUS, PING, USERNAME, ENCRYPT, FINISHING, FINISHED;
+        HANDSHAKE, STATUS, PING, USERNAME, ENCRYPT, FINISHING;
     }
 
     private boolean canSendKickMessage()
     {
-        return thisState == State.USERNAME || thisState == State.ENCRYPT || thisState == State.FINISHING || thisState == State.FINISHED;
+        return thisState == State.USERNAME || thisState == State.ENCRYPT || thisState == State.FINISHING;
     }
 
     @Override
@@ -543,8 +543,6 @@ public class InitialHandler extends PacketHandler implements PendingConnection
                             }
 
                             userCon.connect( server, null, true, ServerConnectEvent.Reason.JOIN_PROXY );
-
-                            thisState = State.FINISHED;
                         }
                     }
                 } );


### PR DESCRIPTION
It is possible to send an encription packet to a cracked server and the server will handle it if you send it directly behind the LoginRequest, its also possible to send a second encrypted encription packet directly after the first one befor the mojang server responses to the auth request.

So i added the Finishing state like in vanilla to make sure that this is impossible