### PR TITLE
Remove PluginMessage handling in InitialHandler

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -152,16 +152,6 @@ public class InitialHandler extends PacketHandler implements PendingConnection
     }
 
     @Override
-    public void handle(PluginMessage pluginMessage) throws Exception
-    {
-        // TODO: Unregister?
-        if ( PluginMessage.SHOULD_RELAY.apply( pluginMessage ) )
-        {
-            relayMessages.add( pluginMessage );
-        }
-    }
-
-    @Override
     public void handle(LegacyHandshake legacyHandshake) throws Exception
     {
         this.legacy = true;


### PR DESCRIPTION
Its impossible to send a PluginMessage packet if the state is not GAME and if the state changes in the finish method the handler will be changed too.
So the packet will never be handled in the InitialHandler. And if you send it with clientmods you will be disconnected because the packet is not registered for the state