### PR TITLE
Add CommandEvent to customize command management

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/event/CommandEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/CommandEvent.java
@@ -4,6 +4,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import net.md_5.bungee.api.CommandSender;
+import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.plugin.Cancellable;
 import net.md_5.bungee.api.plugin.Event;
 
@@ -29,17 +30,17 @@ public class CommandEvent extends Event implements Cancellable
     /**
      * Sent to sender when executed command is cancelled.
      */
-    private String cancelledMessage;
+    private BaseComponent cancelledMessage;
 
     /**
      * Sent to the sender when sender has no permission to execute the command.
      */
-    private String notPermittedMessage;
+    private BaseComponent notPermittedMessage;
 
     /**
      * Sent to the sender when executed command is unknown.
      */
-    private String notFoundMessage;
+    private BaseComponent notFoundMessage;
 
     /**
      * If true, no messages will be displayed to the sender.
@@ -92,7 +93,7 @@ public class CommandEvent extends Event implements Cancellable
      *
      * @param cancelledMessage New message that will be sent to the sender if the event is cancelled
      */
-    public void setCancelledMessage(String cancelledMessage)
+    public void setCancelledMessage(BaseComponent cancelledMessage)
     {
         this.cancelledMessage = cancelledMessage;
     }
@@ -102,7 +103,7 @@ public class CommandEvent extends Event implements Cancellable
      *
      * @param notPermittedMessage New message that will be sent to the sender if the sender is not permitted to execute the command.
      */
-    public void setNotPermittedMessage(String notPermittedMessage)
+    public void setNotPermittedMessage(BaseComponent notPermittedMessage)
     {
         this.notPermittedMessage = notPermittedMessage;
     }
@@ -112,7 +113,7 @@ public class CommandEvent extends Event implements Cancellable
      *
      * @param notFoundMessage New message that will be sent to the sender if the command could not be found.
      */
-    public void setNotFoundMessage(String notFoundMessage)
+    public void setNotFoundMessage(BaseComponent notFoundMessage)
     {
         this.notFoundMessage = notFoundMessage;
     }

--- a/api/src/main/java/net/md_5/bungee/api/event/CommandEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/CommandEvent.java
@@ -1,0 +1,119 @@
+package net.md_5.bungee.api.event;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import net.md_5.bungee.api.CommandSender;
+import net.md_5.bungee.api.plugin.Cancellable;
+import net.md_5.bungee.api.plugin.Event;
+
+/**
+ * This event is called when a command is run.
+ */
+@Data
+@ToString
+@EqualsAndHashCode(callSuper = false)
+public class CommandEvent extends Event implements Cancellable
+{
+
+    /**
+     * CommandSender who issued the command.
+     */
+    private final CommandSender commandSender;
+
+    /**
+     * Issued command.
+     */
+    private String command;
+
+    /**
+     * Sent to sender when executed command is cancelled.
+     */
+    private String cancelledMessage;
+
+    /**
+     * Sent to the sender when sender has no permission to execute the command.
+     */
+    private String notPermittedMessage;
+
+    /**
+     * Sent to the sender when executed command is unknown.
+     */
+    private String notFoundMessage;
+
+    /**
+     * If true, no messages will be displayed to the sender.
+     */
+    private boolean suppressMessages = false;
+
+    /**
+     * Cancelled state.
+     */
+    private boolean cancelled = false;
+
+    public CommandEvent(CommandSender commandSender, String command)
+    {
+        this.commandSender = commandSender;
+        this.command = command;
+    }
+
+    /**
+     * Get the command sender.
+     *
+     * @return The sender
+     */
+    public CommandSender getSender()
+    {
+        return this.commandSender;
+    }
+
+    /**
+     * Get the command.
+     *
+     * @return The command
+     */
+    public String getCommand()
+    {
+        return this.command;
+    }
+
+    /**
+     * Sets the command that the server will execute.
+     *
+     * @param command New command that the server will execute
+     */
+    public void setCommand(String command)
+    {
+        this.command = command;
+    }
+
+    /**
+     * Sets the message that will be sent to the sender if the event is cancelled.
+     *
+     * @param cancelledMessage New message that will be sent to the sender if the event is cancelled
+     */
+    public void setCancelledMessage(String cancelledMessage)
+    {
+        this.cancelledMessage = cancelledMessage;
+    }
+
+    /**
+     * Sets the message that will be sent to the sender if the sender is not permitted to execute the command.
+     *
+     * @param notPermittedMessage New message that will be sent to the sender if the sender is not permitted to execute the command.
+     */
+    public void setNotPermittedMessage(String notPermittedMessage)
+    {
+        this.notPermittedMessage = notPermittedMessage;
+    }
+
+    /**
+     * Sets the message that will be sent to the sender if the command could not be found.
+     *
+     * @param notFoundMessage New message that will be sent to the sender if the command could not be found.
+     */
+    public void setNotFoundMessage(String notFoundMessage)
+    {
+        this.notFoundMessage = notFoundMessage;
+    }
+}

--- a/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
@@ -30,6 +30,7 @@ import lombok.RequiredArgsConstructor;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.ComponentBuilder;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.event.CommandEvent;
@@ -199,14 +200,14 @@ public final class PluginManager
             {
                 if ( !commandEvent.isSuppressMessages() )
                 {
-                    String noPermission = commandEvent.getNotPermittedMessage();
+                    BaseComponent noPermission = commandEvent.getNotPermittedMessage();
 
                     if ( noPermission == null )
                     {
-                        noPermission = command.getPermissionMessage() == null ? this.proxy.getTranslation( "no_permission" ) : command.getPermissionMessage();
+                        noPermission = new ComponentBuilder( command.getPermissionMessage() == null ? this.proxy.getTranslation( "no_permission" ) : command.getPermissionMessage() ).getCurrentComponent();
                     }
 
-                    sender.sendMessage( new ComponentBuilder( noPermission ).create() );
+                    sender.sendMessage( noPermission );
                 }
             }
             return true;
@@ -240,13 +241,13 @@ public final class PluginManager
         return true;
     }
 
-    private boolean sendCommandEventMessage(CommandSender sender, CommandEvent commandEvent, String message)
+    private boolean sendCommandEventMessage(CommandSender sender, CommandEvent commandEvent, BaseComponent message)
     {
         if ( !commandEvent.isSuppressMessages() )
         {
             if ( message != null )
             {
-                sender.sendMessage( new ComponentBuilder( message ).create() );
+                sender.sendMessage( message );
                 return true;
             }
         } else

--- a/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
@@ -30,7 +30,9 @@ import lombok.RequiredArgsConstructor;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.chat.ComponentBuilder;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
+import net.md_5.bungee.api.event.CommandEvent;
 import net.md_5.bungee.event.EventBus;
 import net.md_5.bungee.event.EventHandler;
 import org.yaml.snakeyaml.Yaml;
@@ -170,6 +172,14 @@ public final class PluginManager
      */
     public boolean dispatchCommand(CommandSender sender, String commandLine, List<String> tabResults)
     {
+        CommandEvent commandEvent = this.callEvent( new CommandEvent( sender, commandLine ) );
+        commandLine = commandEvent.getCommand();
+
+        if ( commandEvent.isCancelled() )
+        {
+            return this.sendCommandEventMessage( sender, commandEvent, commandEvent.getCancelledMessage() );
+        }
+
         String[] split = commandLine.split( " ", -1 );
         // Check for chat that only contains " "
         if ( split.length == 0 || split[0].isEmpty() )
@@ -180,14 +190,24 @@ public final class PluginManager
         Command command = getCommandIfEnabled( split[0], sender );
         if ( command == null )
         {
-            return false;
+            return this.sendCommandEventMessage( sender, commandEvent, commandEvent.getNotFoundMessage() );
         }
 
         if ( !command.hasPermission( sender ) )
         {
             if ( tabResults == null )
             {
-                sender.sendMessage( ( command.getPermissionMessage() == null ) ? proxy.getTranslation( "no_permission" ) : command.getPermissionMessage() );
+                if ( !commandEvent.isSuppressMessages() )
+                {
+                    String noPermission = commandEvent.getNotPermittedMessage();
+
+                    if ( noPermission == null )
+                    {
+                        noPermission = command.getPermissionMessage() == null ? this.proxy.getTranslation( "no_permission" ) : command.getPermissionMessage();
+                    }
+
+                    sender.sendMessage( new ComponentBuilder( noPermission ).create() );
+                }
             }
             return true;
         }
@@ -218,6 +238,22 @@ public final class PluginManager
             ProxyServer.getInstance().getLogger().log( Level.WARNING, "Error in dispatching command", ex );
         }
         return true;
+    }
+
+    private boolean sendCommandEventMessage(CommandSender sender, CommandEvent commandEvent, String message)
+    {
+        if ( !commandEvent.isSuppressMessages() )
+        {
+            if ( message != null )
+            {
+                sender.sendMessage( new ComponentBuilder( message ).create() );
+                return true;
+            }
+        } else
+        {
+            return true;
+        }
+        return false;
     }
 
     /**


### PR DESCRIPTION
## About

**With this PR**, **users** will now be **able to**
- **listen** for **issued commands** by **players** or by the **console**
- **modify** the issued **command**
- **cancel** a **command**
  - with a **custom** **message**
- **deny** the **execution** of an **unauthorized** **command**
  - with a **custom** **message**
- **set** the **message** **displayed** to the **sender** if the command has **not** been **found**
- **suppress** any **message** (**cancel**, **deny**, **not found**, **default message**) being **sent** to the **sender**

### -> these changes would help anyone wanting to hide specific commands (+ their execution)

## Examples:
![image](https://user-images.githubusercontent.com/54750441/144517339-48a6613e-f73b-4453-8ea0-fad0633d2226.png)
![image](https://user-images.githubusercontent.com/54750441/144517347-0fa05aa5-1cbb-48bd-9d46-4ee886ca4025.png)

