### PR TITLE
Fix server list info being cached permanently

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/BungeeServerInfo.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeServerInfo.java
@@ -154,7 +154,7 @@ public class BungeeServerInfo implements ServerInfo
         Preconditions.checkNotNull( callback, "callback" );
 
         int pingCache = ProxyServer.getInstance().getConfig().getRemotePingCache();
-        if ( pingCache > 0 && cachedPing != null && ( lastPing - System.currentTimeMillis() ) > pingCache )
+        if ( pingCache > 0 && cachedPing != null && ( System.currentTimeMillis() - lastPing ) > pingCache )
         {
             cachedPing = null;
         }


### PR DESCRIPTION
The remote_ping_cache doesn't work as expected and it permanently caches `cachedPing`.

`lastPing - System.currentTimeMillis()` is never greater than `0`:
```
( lastPing - System.currentTimeMillis() ) > pingCache
( 1638600000000 - 1638600004000 ) > 1000
```