### PR TITLE
Legacy ping passthrough

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/AbstractReconnectHandler.java
+++ b/api/src/main/java/net/md_5/bungee/api/AbstractReconnectHandler.java
@@ -28,12 +28,7 @@ public abstract class AbstractReconnectHandler implements ReconnectHandler
 
     public static ServerInfo getForcedHost(PendingConnection con)
     {
-        if ( con.getVirtualHost() == null )
-        {
-            return null;
-        }
-
-        String forced = con.getListener().getForcedHosts().get( con.getVirtualHost().getHostString() );
+        String forced = con.getVirtualHost() == null ? null : con.getListener().getForcedHosts().get( con.getVirtualHost().getHostString() );
 
         if ( forced == null && con.getListener().isForceDefault() )
         {

--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -170,8 +170,6 @@ public class InitialHandler extends PacketHandler implements PendingConnection
     @Override
     public void handle(LegacyPing ping) throws Exception
     {
-        Preconditions.checkState( thisState == State.HANDSHAKE, "Not expecting HANDSHAKE" );
-
         this.legacy = true;
         final boolean v1_5 = ping.isV1_5();
 
@@ -234,8 +232,6 @@ public class InitialHandler extends PacketHandler implements PendingConnection
         {
             pingBack.done( getPingInfo( motd, protocol ), null );
         }
-
-        thisState = State.PING;
     }
 
     private static String getFirstLine(String str)

--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -170,47 +170,72 @@ public class InitialHandler extends PacketHandler implements PendingConnection
     @Override
     public void handle(LegacyPing ping) throws Exception
     {
+        Preconditions.checkState( thisState == State.HANDSHAKE, "Not expecting HANDSHAKE" );
+
         this.legacy = true;
         final boolean v1_5 = ping.isV1_5();
 
-        ServerPing legacy = new ServerPing( new ServerPing.Protocol( bungee.getName() + " " + bungee.getGameVersion(), bungee.getProtocolVersion() ),
-                new ServerPing.Players( listener.getMaxPlayers(), bungee.getOnlineCount(), null ),
-                new TextComponent( TextComponent.fromLegacyText( listener.getMotd() ) ), (Favicon) null );
+        ServerInfo forced = AbstractReconnectHandler.getForcedHost( this );
+        final String motd = ( forced != null ) ? forced.getMotd() : listener.getMotd();
+        final int protocol = bungee.getProtocolVersion();
 
-        Callback<ProxyPingEvent> callback = new Callback<ProxyPingEvent>()
+        Callback<ServerPing> pingBack = new Callback<ServerPing>()
         {
             @Override
-            public void done(ProxyPingEvent result, Throwable error)
+            public void done(ServerPing result, Throwable error)
             {
-                if ( ch.isClosed() )
+                if ( error != null )
                 {
-                    return;
+                    result = getPingInfo( bungee.getTranslation( "ping_cannot_connect" ), protocol );
+                    bungee.getLogger().log( Level.WARNING, "Error pinging remote server", error );
                 }
 
-                ServerPing legacy = result.getResponse();
-                String kickMessage;
-
-                if ( v1_5 )
+                Callback<ProxyPingEvent> callback = new Callback<ProxyPingEvent>()
                 {
-                    kickMessage = ChatColor.DARK_BLUE
-                            + "\00" + 127
-                            + '\00' + legacy.getVersion().getName()
-                            + '\00' + getFirstLine( legacy.getDescription() )
-                            + '\00' + legacy.getPlayers().getOnline()
-                            + '\00' + legacy.getPlayers().getMax();
-                } else
-                {
-                    // Clients <= 1.3 don't support colored motds because the color char is used as delimiter
-                    kickMessage = ChatColor.stripColor( getFirstLine( legacy.getDescription() ) )
-                            + '\u00a7' + legacy.getPlayers().getOnline()
-                            + '\u00a7' + legacy.getPlayers().getMax();
-                }
+                    @Override
+                    public void done(ProxyPingEvent result, Throwable error)
+                    {
+                        if ( ch.isClosed() )
+                        {
+                            return;
+                        }
 
-                ch.close( kickMessage );
+                        ServerPing legacy = result.getResponse();
+                        String kickMessage;
+
+                        if ( v1_5 )
+                        {
+                            kickMessage = ChatColor.DARK_BLUE
+                                    + "\00" + 127
+                                    + '\00' + legacy.getVersion().getName()
+                                    + '\00' + getFirstLine( legacy.getDescription() )
+                                    + '\00' + legacy.getPlayers().getOnline()
+                                    + '\00' + legacy.getPlayers().getMax();
+                        } else
+                        {
+                            // Clients <= 1.3 don't support colored motds because the color char is used as delimiter
+                            kickMessage = ChatColor.stripColor( getFirstLine( legacy.getDescription() ) )
+                                    + '\u00a7' + legacy.getPlayers().getOnline()
+                                    + '\u00a7' + legacy.getPlayers().getMax();
+                        }
+
+                        ch.close( kickMessage );
+                    }
+                };
+
+                bungee.getPluginManager().callEvent( new ProxyPingEvent( InitialHandler.this, result, callback ) );
             }
         };
 
-        bungee.getPluginManager().callEvent( new ProxyPingEvent( this, legacy, callback ) );
+        if ( forced != null && listener.isPingPassthrough() )
+        {
+            ( (BungeeServerInfo) forced ).ping( pingBack, bungee.getProtocolVersion() );
+        } else
+        {
+            pingBack.done( getPingInfo( motd, protocol ), null );
+        }
+
+        thisState = State.PING;
     }
 
     private static String getFirstLine(String str)


### PR DESCRIPTION
Allow ping passthrough for legacy ping, as otherwise the behavior would be unexpected and incorrect, and as long as legacy pinging is still supported it should also be maintained.

It can be tested by starting a Minecraft client (before the Netty rewrite) like 1.5 or 1.4, and adding a server to the server list. And using ping passthrough and force default server in the BungeeCord.