### PR TITLE
Add check for '.' and '-' characters in usernames

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/util/AllowedCharacters.java
+++ b/proxy/src/main/java/net/md_5/bungee/util/AllowedCharacters.java
@@ -17,7 +17,7 @@ public final class AllowedCharacters
     {
         if ( onlineMode )
         {
-            return ( c >= 'a' && c <= 'z' ) || ( c >= '0' && c <= '9' ) || ( c >= 'A' && c <= 'Z' ) || c == '_';
+            return ( c >= 'a' && c <= 'z' ) || ( c >= '0' && c <= '9' ) || ( c >= 'A' && c <= 'Z' ) || c == '_' || c == '.' || c == '-';
         } else
         {
             // Don't allow spaces, Yaml config doesn't support them


### PR DESCRIPTION
In this PR we addressed . in names
https://github.com/SpigotMC/BungeeCord/pull/3093

But one of the newer commits added AllowedCharacters class which broke - and . in names, both of which is breaking some of my players ability to join our server.

Here are 2 of our users profiles
https://namemc.com/profile/football-flo.1
https://namemc.com/profile/Mr.Denis.1

Please let me know if anymore information is needed, thanks