### PR TITLE
disconnect empty names

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -358,7 +358,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
             disconnect( bungee.getTranslation( "name_empty" ) );
             return;
         }
-        
+
         if ( !AllowedCharacters.isValidName( loginRequest.getData(), onlineMode ) )
         {
             disconnect( bungee.getTranslation( "name_invalid" ) );

--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -353,6 +353,12 @@ public class InitialHandler extends PacketHandler implements PendingConnection
     {
         Preconditions.checkState( thisState == State.USERNAME, "Not expecting USERNAME" );
 
+        if ( loginRequest.getData().isEmpty() )
+        {
+            disconnect( bungee.getTranslation( "name_empty" ) );
+            return;
+        }
+        
         if ( !AllowedCharacters.isValidName( loginRequest.getData(), onlineMode ) )
         {
             disconnect( bungee.getTranslation( "name_invalid" ) );

--- a/proxy/src/main/resources/messages.properties
+++ b/proxy/src/main/resources/messages.properties
@@ -20,6 +20,7 @@ server_list=\u00a76You may connect to the following servers at this time:
 server_went_down=\u00a7cThe server you were previously on went down, you have been connected to a fallback server
 total_players=Total players online: {0}
 name_invalid=Username contains invalid characters.
+name_empty=Username is empty.
 ping_cannot_connect=\u00a7c[Bungee] Can''t connect to server.
 offline_mode_player=Not authenticated with Minecraft.net
 message_needed=\u00a7cYou must supply a message.


### PR DESCRIPTION
it is possible to join with an empty name and send encryption responses with that connection so the bungeecord server would send very weird stuff to the mojang auth server