### PR TITLE
Print all thrown exception

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/netty/HandlerBoss.java
+++ b/proxy/src/main/java/net/md_5/bungee/netty/HandlerBoss.java
@@ -150,7 +150,7 @@ public class HandlerBoss extends ChannelInboundHandlerAdapter
                         } );
                     } else if ( cause.getCause() instanceof BadPacketException )
                     {
-                        ProxyServer.getInstance().getLogger().log( Level.WARNING, "{0} - bad packet ID, are mods in use!? {1}", new Object[]
+                        ProxyServer.getInstance().getLogger().log( Level.WARNING, "{0} - bad packet, are mods in use!? {1}", new Object[]
                         {
                             handler, cause.getCause().getMessage()
                         } );
@@ -159,6 +159,12 @@ public class HandlerBoss extends ChannelInboundHandlerAdapter
                         ProxyServer.getInstance().getLogger().log( Level.WARNING, "{0} - overflow in packet detected! {1}", new Object[]
                         {
                             handler, cause.getCause().getMessage()
+                        } );
+                    } else
+                    {
+                        ProxyServer.getInstance().getLogger().log( Level.WARNING, "{0} - could not decode packet! {1}", new Object[]
+                        {
+                            handler, cause.getCause() != null ? cause.getCause() : cause
                         } );
                     }
                 } else if ( cause instanceof IOException || ( cause instanceof IllegalStateException && handler instanceof InitialHandler ) )


### PR DESCRIPTION
DecoderExceptions that are not a CorruptedFrameException and dont have BadPacketException or OverflowPacketException as cause are not printed.
I also removed the ID message in BadPacketException because bad packet does not mean it has a invalid id the protocol version can also be not valid or the packet was not read to the end and more details are in the message of the exception