### PR TITLE
removed redundant exception handling code

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -136,13 +136,10 @@ public class InitialHandler extends PacketHandler implements PendingConnection
     @Override
     public void exception(Throwable t) throws Exception
     {
-        if ( canSendKickMessage() )
-        {
-            disconnect( ChatColor.RED + Util.exception( t ) );
-        } else
-        {
-            ch.close();
-        }
+        // we only need to mark the channel as closed, the handler boss will close the channel for us
+        // normal disconnecting to send kick message is useless here because the handler boss don't wait like the
+        // delayed close method and a kick packet would never reach the client
+        ch.markClosed();
     }
 
     @Override


### PR DESCRIPTION
checking if its possible to send a kick message and sending it to the client is useless here as it would call the delayed close method that would send the packet 250ms delayed but the handlerboss would close it immediately. Also no need to call the channelwrapper close method here because the handler boss will close as i said and we only need to mark closed