### PR TITLE
Optimize channel closing

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/netty/ChannelWrapper.java
+++ b/proxy/src/main/java/net/md_5/bungee/netty/ChannelWrapper.java
@@ -69,7 +69,7 @@ public class ChannelWrapper
         {
             return;
         }
-        
+
         closed = closing = true;
         stopReading();
     }

--- a/proxy/src/main/java/net/md_5/bungee/netty/ChannelWrapper.java
+++ b/proxy/src/main/java/net/md_5/bungee/netty/ChannelWrapper.java
@@ -129,10 +129,13 @@ public class ChannelWrapper
             {
                 ch.config().setOption( ChannelOption.AUTO_READ, false );
 
-                // we need to remove the frame and legacy decoder here, otherwise it will
-                // automatically call the channel read because it's an ByteToMessageDecoder
-                // and the auto read disabling would not work
+                // we need to remove all handlers in reverse order because each would pass the data to the next one
+                // and this would cause that a connection causes multiple exceptions
+                removeChannelHandler( PipelineUtils.BOSS_HANDLER );
+                removeChannelHandler( PipelineUtils.PACKET_DECODER );
+                removeChannelHandler( "decompress" );
                 removeChannelHandler( PipelineUtils.FRAME_DECODER );
+                removeChannelHandler( PipelineUtils.DECRYPT_HANDLER );
                 removeChannelHandler( PipelineUtils.LEGACY_DECODER );
             }
         };

--- a/proxy/src/main/java/net/md_5/bungee/netty/ChannelWrapper.java
+++ b/proxy/src/main/java/net/md_5/bungee/netty/ChannelWrapper.java
@@ -118,8 +118,7 @@ public class ChannelWrapper
 
     private void stopReading()
     {
-        Preconditions.checkState( ch.eventLoop().inEventLoop(), "cannot stop reading outside of event loop" );
-        if ( ch.config().getOption( ChannelOption.AUTO_READ ) )
+        if ( ch.eventLoop().inEventLoop() && ch.config().getOption( ChannelOption.AUTO_READ ) )
         {
             ch.config().setOption( ChannelOption.AUTO_READ, false );
 


### PR DESCRIPTION
If an login inital handler connection gets disconnected the delayed close method is called. This method closes the connection with 250ms delay. While the connection is not closed its possible to flood the server with packets that don't get handled but serialized. With this pull request we make it impossible to let the server serialize tons of packets while wait to close the connection. We do that by setting auto read to false