### PR TITLE
Skip bytes on receiving LegacyPing

### DIFF
--- a/protocol/src/main/java/net/md_5/bungee/protocol/LegacyDecoder.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/LegacyDecoder.java
@@ -14,13 +14,6 @@ public class LegacyDecoder extends ByteToMessageDecoder
     @Override
     protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception
     {
-        // See check in Varint21FrameDecoder for more details
-        if ( !ctx.channel().isActive() )
-        {
-            in.skipBytes( in.readableBytes() );
-            return;
-        }
-
         if ( !in.isReadable() )
         {
             return;
@@ -32,11 +25,12 @@ public class LegacyDecoder extends ByteToMessageDecoder
         if ( packetID == 0xFE )
         {
             out.add( new PacketWrapper( new LegacyPing( in.isReadable() && in.readUnsignedByte() == 0x01 ), Unpooled.EMPTY_BUFFER ) );
+            in.skipBytes( in.readableBytes() );
             return;
         } else if ( packetID == 0x02 && in.isReadable() )
         {
-            in.skipBytes( in.readableBytes() );
             out.add( new PacketWrapper( new LegacyHandshake(), Unpooled.EMPTY_BUFFER ) );
+            in.skipBytes( in.readableBytes() );
             return;
         }
 


### PR DESCRIPTION
We don't need to check for dead connection as in the frame decoder because it is impossible that there are bytes left. In any case this method was executed the ByteBuf is empty on the end or the decoder is removed