### PR TITLE
Updated deprecated Method "getPackage"

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/plugin/PluginClassloader.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/PluginClassloader.java
@@ -125,7 +125,7 @@ final class PluginClassloader extends URLClassLoader
             if ( dot != -1 )
             {
                 String pkgName = name.substring( 0, dot );
-                if ( getPackage( pkgName ) == null )
+                if ( getDefinedPackage( pkgName ) == null )
                 {
                     try
                     {
@@ -138,7 +138,7 @@ final class PluginClassloader extends URLClassLoader
                         }
                     } catch ( IllegalArgumentException ex )
                     {
-                        if ( getPackage( pkgName ) == null )
+                        if ( getDefinedPackage( pkgName ) == null )
                         {
                             throw new IllegalStateException( "Cannot find package " + pkgName );
                         }


### PR DESCRIPTION
"getPackage" is deprecated since java 9. I updated to the alternative ClassLoader#getDefinedPackage(String).