### PR TITLE
Fix HttpHandler calls done method twice

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/http/HttpHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/http/HttpHandler.java
@@ -26,6 +26,7 @@ public class HttpHandler extends SimpleChannelInboundHandler<HttpObject>
             callback.done( null, cause );
         } finally
         {
+            ctx.channel().pipeline().remove( this );
             ctx.channel().close();
         }
     }
@@ -68,6 +69,7 @@ public class HttpHandler extends SimpleChannelInboundHandler<HttpObject>
             callback.done( buffer.toString(), null );
         } finally
         {
+            ctx.channel().pipeline().remove( this );
             ctx.channel().close();
         }
     }


### PR DESCRIPTION
this happens for example for invalid session. In this case first a DefaultHttpResponse(decodeResult: success, version: HTTP/1.1) had read and that is calling the done method and after that a EmptyLastHttpContent had read which also calls the done method a second time. To fix this we remove the handler after the first done is invoked.