### PR TITLE
Only accept one brand message

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -691,6 +691,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
             }
         } else if ( input.getTag().equals( "MC|Brand" ) || input.getTag().equals( "minecraft:brand" ) )
         {
+            Preconditions.checkState( brandMessage == null, "Already received brand message" );
             brandMessage = input;
         }
     }


### PR DESCRIPTION
minecraft is only sending a brand one time. The Client should not be able to change the brand while online. The client only responses with an mcbrand by receiving the joingame packet and if the client is receiving it twice it will break the client so checking this is a good way to prevent the client getting broke too