### PR TITLE
Fix BungeeLogger queue memory leak

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -320,14 +320,14 @@ public class InitialHandler extends PacketHandler implements PendingConnection
                 // Ping
                 if ( bungee.getConfig().isLogPings() )
                 {
-                    bungee.getLogger().log( Level.INFO, "{0} has pinged", this );
+                    bungee.getLogger().log( Level.INFO, "{0} has pinged", this.toString() );
                 }
                 thisState = State.STATUS;
                 ch.setProtocol( Protocol.STATUS );
                 break;
             case 2:
                 // Login
-                bungee.getLogger().log( Level.INFO, "{0} has connected", this );
+                bungee.getLogger().log( Level.INFO, "{0} has connected", this.toString() );
                 thisState = State.USERNAME;
                 ch.setProtocol( Protocol.LOGIN );
 

--- a/proxy/src/main/java/net/md_5/bungee/netty/HandlerBoss.java
+++ b/proxy/src/main/java/net/md_5/bungee/netty/HandlerBoss.java
@@ -46,7 +46,7 @@ public class HandlerBoss extends ChannelInboundHandlerAdapter
 
             if ( !( handler instanceof InitialHandler || handler instanceof PingHandler ) )
             {
-                ProxyServer.getInstance().getLogger().log( Level.INFO, "{0} has connected", handler );
+                ProxyServer.getInstance().getLogger().log( Level.INFO, "{0} has connected", handler.toString() );
             }
         }
     }
@@ -61,7 +61,7 @@ public class HandlerBoss extends ChannelInboundHandlerAdapter
 
             if ( !( handler instanceof InitialHandler || handler instanceof PingHandler ) )
             {
-                ProxyServer.getInstance().getLogger().log( Level.INFO, "{0} has disconnected", handler );
+                ProxyServer.getInstance().getLogger().log( Level.INFO, "{0} has disconnected", handler.toString() );
             }
         }
     }
@@ -139,49 +139,49 @@ public class HandlerBoss extends ChannelInboundHandlerAdapter
             {
                 if ( cause instanceof ReadTimeoutException )
                 {
-                    ProxyServer.getInstance().getLogger().log( Level.WARNING, "{0} - read timed out", handler );
+                    ProxyServer.getInstance().getLogger().log( Level.WARNING, "{0} - read timed out", handler.toString() );
                 } else if ( cause instanceof DecoderException )
                 {
                     if ( cause instanceof CorruptedFrameException )
                     {
                         ProxyServer.getInstance().getLogger().log( Level.WARNING, "{0} - corrupted frame: {1}", new Object[]
                         {
-                            handler, cause.getMessage()
+                            handler.toString(), cause.getMessage()
                         } );
                     } else if ( cause.getCause() instanceof BadPacketException )
                     {
                         ProxyServer.getInstance().getLogger().log( Level.WARNING, "{0} - bad packet, are mods in use!? {1}", new Object[]
                         {
-                            handler, cause.getCause().getMessage()
+                            handler.toString(), cause.getCause().getMessage()
                         } );
                     } else if ( cause.getCause() instanceof OverflowPacketException )
                     {
                         ProxyServer.getInstance().getLogger().log( Level.WARNING, "{0} - overflow in packet detected! {1}", new Object[]
                         {
-                            handler, cause.getCause().getMessage()
+                            handler.toString(), cause.getCause().getMessage()
                         } );
                     } else
                     {
                         ProxyServer.getInstance().getLogger().log( Level.WARNING, "{0} - could not decode packet! {1}", new Object[]
                         {
-                            handler, cause.getCause() != null ? cause.getCause() : cause
+                            handler.toString(), cause.getCause() != null ? cause.getCause() : cause
                         } );
                     }
                 } else if ( cause instanceof IOException || ( cause instanceof IllegalStateException && handler instanceof InitialHandler ) )
                 {
                     ProxyServer.getInstance().getLogger().log( Level.WARNING, "{0} - {1}: {2}", new Object[]
                     {
-                        handler, cause.getClass().getSimpleName(), cause.getMessage()
+                        handler.toString(), cause.getClass().getSimpleName(), cause.getMessage()
                     } );
                 } else if ( cause instanceof QuietException )
                 {
                     ProxyServer.getInstance().getLogger().log( Level.SEVERE, "{0} - encountered exception: {1}", new Object[]
                     {
-                        handler, cause
+                        handler.toString(), cause
                     } );
                 } else
                 {
-                    ProxyServer.getInstance().getLogger().log( Level.SEVERE, handler + " - encountered exception", cause );
+                    ProxyServer.getInstance().getLogger().log( Level.SEVERE, handler.toString() + " - encountered exception", cause );
                 }
             }
 


### PR DESCRIPTION
High number of connections per second (about 1000+) can cause BungeeLogger will store InitialHandler instances. We should use toString() instead of creating objects, some forks already have this fixed. 