### PR TITLE
Do not forward cancelled messages or handled commands

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
@@ -190,7 +190,7 @@ public class UpstreamBridge extends PacketHandler
                 return message;
             }
         }
-        return null;
+        throw CancelSendSignal.INSTANCE;
     }
 
     @Override


### PR DESCRIPTION
When a chat message is cancelled or a command was executed on the proxy, that message should not be forwarded to the server.