### PR TITLE
Fix text messages sending as ActionBars in 1.19 still

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
@@ -479,13 +479,15 @@ public final class UserConnection implements ProxiedPlayer
     {
         if ( getPendingConnection().getVersion() >= ProtocolConstants.MINECRAFT_1_19 )
         {
-            // Align with Spigot and remove client side formatting for now
-            if ( position == ChatMessageType.CHAT )
+            //"CHAT" doesn't exist for 1.19 - therefor the ordinal will be off by 1.
+            // Decrement by 1 to fix for now
+            if ( messagePosition > 0 )
             {
-                position = ChatMessageType.SYSTEM;
+                --messagePosition;
             }
 
-            unsafe().sendPacket( new SystemChat( message, position.ordinal() ) );
+            unsafe().sendPacket( new SystemChat( message, messagePosition ) );
+
         } else
         {
             unsafe().sendPacket( new Chat( message, (byte) position.ordinal(), sender ) );

--- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
@@ -479,6 +479,9 @@ public final class UserConnection implements ProxiedPlayer
     {
         if ( getPendingConnection().getVersion() >= ProtocolConstants.MINECRAFT_1_19 )
         {
+
+           int messagePosition = position.ordinal();
+
             //"CHAT" doesn't exist for 1.19 - therefor the ordinal will be off by 1.
             // Decrement by 1 to fix for now
             if ( messagePosition > 0 )

--- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
@@ -480,7 +480,7 @@ public final class UserConnection implements ProxiedPlayer
         if ( getPendingConnection().getVersion() >= ProtocolConstants.MINECRAFT_1_19 )
         {
 
-           int messagePosition = position.ordinal();
+            int messagePosition = position.ordinal();
 
             //"CHAT" doesn't exist for 1.19 - therefor the ordinal will be off by 1.
             // Decrement by 1 to fix for now


### PR DESCRIPTION
"CHAT" doesn't exist for 1.19 - therefor the ordinal will be off by 1 and result in the wrong message type being displayed.
