### PR TITLE
Add Chat Preview API

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/connection/ProxiedPlayer.java
+++ b/api/src/main/java/net/md_5/bungee/api/connection/ProxiedPlayer.java
@@ -336,4 +336,11 @@ public interface ProxiedPlayer extends Connection, CommandSender
      * @return this player's {@link Scoreboard}
      */
     Scoreboard getScoreboard();
+
+    /**
+     * Tell the client whether or not we handle chat preview requests.
+     *
+     * @param enabled true if we handle chat preview requests.
+     */
+    void setHandlingChatPreview(boolean enabled);
 }

--- a/api/src/main/java/net/md_5/bungee/api/event/ChatPreviewRequestEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/ChatPreviewRequestEvent.java
@@ -1,0 +1,33 @@
+package net.md_5.bungee.api.event;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.api.connection.ProxiedPlayer;
+import net.md_5.bungee.api.plugin.Event;
+
+/**
+ * Called when the client is requesting a chat preview as a player is preparing a chat message.
+ */
+@Data
+@ToString(callSuper = false)
+@EqualsAndHashCode(callSuper = false)
+public class ChatPreviewRequestEvent extends Event
+{
+
+    /**
+     * The player that is typing a chat message.
+     */
+    private final ProxiedPlayer player;
+
+    /**
+     * The message the player has typed so far.
+     */
+    private final String message;
+
+    /**
+     * The preview message. If left as null, the request will be forwarded to the backend server.
+     */
+    private BaseComponent preview;
+}

--- a/protocol/src/main/java/net/md_5/bungee/protocol/AbstractPacketHandler.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/AbstractPacketHandler.java
@@ -2,6 +2,8 @@ package net.md_5.bungee.protocol;
 
 import net.md_5.bungee.protocol.packet.BossBar;
 import net.md_5.bungee.protocol.packet.Chat;
+import net.md_5.bungee.protocol.packet.ChatPreviewRequest;
+import net.md_5.bungee.protocol.packet.ChatPreviewResponse;
 import net.md_5.bungee.protocol.packet.ClearTitles;
 import net.md_5.bungee.protocol.packet.ClientChat;
 import net.md_5.bungee.protocol.packet.ClientCommand;
@@ -31,7 +33,9 @@ import net.md_5.bungee.protocol.packet.Respawn;
 import net.md_5.bungee.protocol.packet.ScoreboardDisplay;
 import net.md_5.bungee.protocol.packet.ScoreboardObjective;
 import net.md_5.bungee.protocol.packet.ScoreboardScore;
+import net.md_5.bungee.protocol.packet.ServerData;
 import net.md_5.bungee.protocol.packet.SetCompression;
+import net.md_5.bungee.protocol.packet.SetDisplayChatPreview;
 import net.md_5.bungee.protocol.packet.StatusRequest;
 import net.md_5.bungee.protocol.packet.StatusResponse;
 import net.md_5.bungee.protocol.packet.Subtitle;
@@ -211,6 +215,22 @@ public abstract class AbstractPacketHandler
     }
 
     public void handle(GameState gameState) throws Exception
+    {
+    }
+
+    public void handle(ServerData serverData) throws Exception
+    {
+    }
+
+    public void handle(SetDisplayChatPreview setDisplayChatPreview) throws Exception
+    {
+    }
+
+    public void handle(ChatPreviewRequest chatPreviewRequest) throws Exception
+    {
+    }
+
+    public void handle(ChatPreviewResponse chatPreviewResponse) throws Exception
     {
     }
 }

--- a/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java
@@ -11,6 +11,8 @@ import lombok.Data;
 import lombok.Getter;
 import net.md_5.bungee.protocol.packet.BossBar;
 import net.md_5.bungee.protocol.packet.Chat;
+import net.md_5.bungee.protocol.packet.ChatPreviewRequest;
+import net.md_5.bungee.protocol.packet.ChatPreviewResponse;
 import net.md_5.bungee.protocol.packet.ClearTitles;
 import net.md_5.bungee.protocol.packet.ClientChat;
 import net.md_5.bungee.protocol.packet.ClientCommand;
@@ -37,7 +39,9 @@ import net.md_5.bungee.protocol.packet.Respawn;
 import net.md_5.bungee.protocol.packet.ScoreboardDisplay;
 import net.md_5.bungee.protocol.packet.ScoreboardObjective;
 import net.md_5.bungee.protocol.packet.ScoreboardScore;
+import net.md_5.bungee.protocol.packet.ServerData;
 import net.md_5.bungee.protocol.packet.SetCompression;
+import net.md_5.bungee.protocol.packet.SetDisplayChatPreview;
 import net.md_5.bungee.protocol.packet.StatusRequest;
 import net.md_5.bungee.protocol.packet.StatusResponse;
 import net.md_5.bungee.protocol.packet.Subtitle;
@@ -326,6 +330,21 @@ public enum Protocol
                     map( ProtocolConstants.MINECRAFT_1_17, 0x4A ),
                     map( ProtocolConstants.MINECRAFT_1_19, 0x49 )
             );
+            TO_CLIENT.registerPacket(
+                    SetDisplayChatPreview.class,
+                    SetDisplayChatPreview::new,
+                    map( ProtocolConstants.MINECRAFT_1_19, 0x4B )
+            );
+            TO_CLIENT.registerPacket(
+                    ChatPreviewResponse.class,
+                    ChatPreviewResponse::new,
+                    map( ProtocolConstants.MINECRAFT_1_19, 0x0C )
+            );
+            TO_CLIENT.registerPacket(
+                    ServerData.class,
+                    ServerData::new,
+                    map( ProtocolConstants.MINECRAFT_1_19, 0x3F )
+            );
 
             TO_SERVER.registerPacket(
                     KeepAlive.class,
@@ -358,6 +377,11 @@ public enum Protocol
                     ClientChat.class,
                     ClientChat::new,
                     map( ProtocolConstants.MINECRAFT_1_19, 0x04 )
+            );
+            TO_SERVER.registerPacket(
+                    ChatPreviewRequest.class,
+                    ChatPreviewRequest::new,
+                    map( ProtocolConstants.MINECRAFT_1_19, 0x05 )
             );
             TO_SERVER.registerPacket(
                     TabCompleteRequest.class,

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/ChatPreviewRequest.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/ChatPreviewRequest.java
@@ -1,0 +1,41 @@
+package net.md_5.bungee.protocol.packet;
+
+import io.netty.buffer.ByteBuf;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import net.md_5.bungee.protocol.AbstractPacketHandler;
+import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.protocol.ProtocolConstants;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
+public class ChatPreviewRequest extends DefinedPacket
+{
+
+    private int queryId;
+    private String message;
+
+    @Override
+    public void read(ByteBuf buf, ProtocolConstants.Direction direction, int protocolVersion)
+    {
+        queryId = buf.readInt();
+        message = readString( buf, 256 );
+    }
+
+    @Override
+    public void write(ByteBuf buf, ProtocolConstants.Direction direction, int protocolVersion)
+    {
+        buf.writeInt( queryId );
+        writeString( message, buf );
+    }
+
+    @Override
+    public void handle(AbstractPacketHandler handler) throws Exception
+    {
+        handler.handle( this );
+    }
+}

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/ChatPreviewResponse.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/ChatPreviewResponse.java
@@ -1,0 +1,51 @@
+package net.md_5.bungee.protocol.packet;
+
+import io.netty.buffer.ByteBuf;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import net.md_5.bungee.protocol.AbstractPacketHandler;
+import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.protocol.ProtocolConstants;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
+public class ChatPreviewResponse extends DefinedPacket
+{
+
+    private int queryId;
+    private String message; // nullable
+
+    @Override
+    public void read(ByteBuf buf, ProtocolConstants.Direction direction, int protocolVersion)
+    {
+        queryId = buf.readInt();
+        if ( buf.readBoolean() )
+        {
+            message = readString( buf, 262144 );
+        }
+    }
+
+    @Override
+    public void write(ByteBuf buf, ProtocolConstants.Direction direction, int protocolVersion)
+    {
+        buf.writeInt( queryId );
+        if ( message != null )
+        {
+            buf.writeBoolean( true );
+            writeString( message, buf );
+        } else
+        {
+            buf.writeBoolean( false );
+        }
+    }
+
+    @Override
+    public void handle(AbstractPacketHandler handler) throws Exception
+    {
+        handler.handle( this );
+    }
+}

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/ServerData.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/ServerData.java
@@ -1,0 +1,64 @@
+package net.md_5.bungee.protocol.packet;
+
+import io.netty.buffer.ByteBuf;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import net.md_5.bungee.protocol.AbstractPacketHandler;
+import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.protocol.ProtocolConstants;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
+public class ServerData extends DefinedPacket
+{
+
+    private String motd; // nullable
+    private String iconBase64; // nullable
+    private boolean previewsChat;
+
+    @Override
+    public void read(ByteBuf buf, ProtocolConstants.Direction direction, int protocolVersion)
+    {
+        if ( buf.readBoolean() )
+        {
+            motd = readString( buf, 262144 );
+        }
+        if ( buf.readBoolean() )
+        {
+            iconBase64 = readString( buf, 32767 );
+        }
+        previewsChat = buf.readBoolean();
+    }
+
+    @Override
+    public void write(ByteBuf buf, ProtocolConstants.Direction direction, int protocolVersion)
+    {
+        if ( motd != null )
+        {
+            buf.writeBoolean( true );
+            writeString( motd, buf );
+        } else
+        {
+            buf.writeBoolean( false );
+        }
+        if ( iconBase64 != null )
+        {
+            buf.writeBoolean( true );
+            writeString( iconBase64, buf );
+        } else
+        {
+            buf.writeBoolean( false );
+        }
+        buf.writeBoolean( previewsChat );
+    }
+
+    @Override
+    public void handle(AbstractPacketHandler handler) throws Exception
+    {
+        handler.handle( this );
+    }
+}

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/SetDisplayChatPreview.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/SetDisplayChatPreview.java
@@ -1,0 +1,38 @@
+package net.md_5.bungee.protocol.packet;
+
+import io.netty.buffer.ByteBuf;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import net.md_5.bungee.protocol.AbstractPacketHandler;
+import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.protocol.ProtocolConstants;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
+public class SetDisplayChatPreview extends DefinedPacket
+{
+
+    private boolean enabled;
+
+    @Override
+    public void read(ByteBuf buf, ProtocolConstants.Direction direction, int protocolVersion)
+    {
+        enabled = buf.readBoolean();
+    }
+
+    @Override
+    public void write(ByteBuf buf, ProtocolConstants.Direction direction, int protocolVersion)
+    {
+        buf.writeBoolean( enabled );
+    }
+
+    @Override
+    public void handle(AbstractPacketHandler handler) throws Exception
+    {
+        handler.handle( this );
+    }
+}

--- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
+++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
@@ -322,6 +322,7 @@ public class ServerConnector extends PacketHandler
         user.getPendingConnects().remove( target );
         user.setServerJoinQueue( null );
         user.setDimensionChange( false );
+        user.setBackendHandlingChatPreview( false );
 
         ServerInfo from = ( user.getServer() == null ) ? null : user.getServer().getInfo();
         user.setServer( server );

--- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
@@ -59,7 +59,9 @@ import net.md_5.bungee.protocol.packet.Respawn;
 import net.md_5.bungee.protocol.packet.ScoreboardDisplay;
 import net.md_5.bungee.protocol.packet.ScoreboardObjective;
 import net.md_5.bungee.protocol.packet.ScoreboardScore;
+import net.md_5.bungee.protocol.packet.ServerData;
 import net.md_5.bungee.protocol.packet.SetCompression;
+import net.md_5.bungee.protocol.packet.SetDisplayChatPreview;
 import net.md_5.bungee.protocol.packet.TabCompleteResponse;
 import net.md_5.bungee.tab.TabList;
 
@@ -676,6 +678,23 @@ public class DownstreamBridge extends PacketHandler
             con.unsafe().sendPacket( commands );
             throw CancelSendSignal.INSTANCE;
         }
+    }
+
+    @Override
+    public void handle(ServerData serverData) throws Exception
+    {
+        if ( con.isHandlingChatPreview() && !serverData.isPreviewsChat() )
+        {
+            con.unsafe().sendPacket( new ServerData( serverData.getMotd(), serverData.getIconBase64(), true ) );
+            throw CancelSendSignal.INSTANCE;
+        }
+    }
+
+    @Override
+    public void handle(SetDisplayChatPreview setDisplayChatPreview) throws Exception
+    {
+        con.setBackendHandlingChatPreview( setDisplayChatPreview.isEnabled() );
+        throw CancelSendSignal.INSTANCE;
     }
 
     @Override


### PR DESCRIPTION
Add Chat Preview API so servers that handle chat in BungeeCord can make use of the Chat Preview functionality in Minecraft 1.19.