### PR TITLE
Fix sanitized address being not IP but hostname after InetSocketAddress#getHostName()

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/util/AddressUtil.java
+++ b/proxy/src/main/java/net/md_5/bungee/util/AddressUtil.java
@@ -11,7 +11,11 @@ public class AddressUtil
 
     public static String sanitizeAddress(InetSocketAddress addr)
     {
-        String string = addr.getHostString();
+        String string = null;
+        if ( addr.getAddress() != null )
+        {
+            string = addr.getAddress().getHostAddress();
+        }
 
         // Remove IPv6 scope if present
         if ( addr.getAddress() instanceof Inet6Address )


### PR DESCRIPTION
When using `InetSocketAddress#getHostName()` in LoginEvent listener in BungeeCord plugin, BungeeCord send upstream's hostname to Spigot, and then Spigot says "If you wish to use IP forwarding, please enable it in your BungeeCord config as well!".
This is because after `InetSocketAddress#getHostName()` is called, `InetSocketAddress` instance keeps the hostname and `InetSocketAddress#getHostString()` returns not IP but hostname.
By replacing `getHostString()` with `getAddress().getHostAddress()`, it makes sanitized address always IP.