### PR TITLE
Fix legacy chat conversion losing format reset information.

### DIFF
--- a/chat/src/main/java/net/md_5/bungee/api/chat/BaseComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/BaseComponent.java
@@ -79,6 +79,12 @@ public abstract class BaseComponent
     private HoverEvent hoverEvent;
 
     /**
+     * Whether this component rejects previous formatting
+     */
+    @Getter
+    private transient boolean reset;
+
+    /**
      * Default constructor.
      *
      * @deprecated for use by internal classes only, will be removed.

--- a/chat/src/main/java/net/md_5/bungee/api/chat/ComponentBuilder.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/ComponentBuilder.java
@@ -161,7 +161,7 @@ public final class ComponentBuilder
             previous = dummy;
             dummy = null;
         }
-        if ( previous != null )
+        if ( previous != null && !component.isReset() )
         {
             component.copyFormatting( previous, retention, false );
         }

--- a/chat/src/main/java/net/md_5/bungee/api/chat/TextComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/TextComponent.java
@@ -44,7 +44,7 @@ public final class TextComponent extends BaseComponent
      */
     public static BaseComponent[] fromLegacyText(String message, ChatColor defaultColor)
     {
-        ArrayList<BaseComponent> components = new ArrayList<BaseComponent>();
+        ArrayList<BaseComponent> components = new ArrayList<>();
         StringBuilder builder = new StringBuilder();
         TextComponent component = new TextComponent();
         Matcher matcher = url.matcher( message );
@@ -111,15 +111,15 @@ public final class TextComponent extends BaseComponent
                 } else if ( format == ChatColor.MAGIC )
                 {
                     component.setObfuscated( true );
-                } else if ( format == ChatColor.RESET )
-                {
-                    format = defaultColor;
-                    component = new TextComponent();
-                    component.setColor( format );
                 } else
                 {
+                    if ( format == ChatColor.RESET )
+                    {
+                        format = defaultColor;
+                    }
                     component = new TextComponent();
                     component.setColor( format );
+                    component.setReset( true );
                 }
                 continue;
             }

--- a/chat/src/test/java/net/md_5/bungee/api/chat/ComponentsTest.java
+++ b/chat/src/test/java/net/md_5/bungee/api/chat/ComponentsTest.java
@@ -572,7 +572,37 @@ public class ComponentsTest
         Assert.assertArrayEquals( hexColored, reColored );
     }
 
-    private String fromAndToLegacyText(String legacyText)
+    /**
+     * In legacy chat, colors and reset both reset all formatting.
+     * Make sure it works in combination with ComponentBuilder.
+     */
+    @Test
+    public void testLegacyResetInBuilder()
+    {
+        ComponentBuilder builder = new ComponentBuilder();
+        BaseComponent[] a = TextComponent.fromLegacyText( "§4§n44444§rdd§6§l6666" );
+
+        String expected = "{\"extra\":[{\"underlined\":true,\"color\":\"dark_red\",\"text\":\"44444\"},{\"color\":"
+                + "\"white\",\"text\":\"dd\"},{\"bold\":true,\"color\":\"gold\",\"text\":\"6666\"}],\"text\":\"\"}";
+        Assert.assertEquals( expected, ComponentSerializer.toString( a ) );
+
+        builder.append( a );
+
+        String test1 = ComponentSerializer.toString( builder.create() );
+        Assert.assertEquals( expected, test1 );
+
+        BaseComponent[] b = TextComponent.fromLegacyText( "§rrrrr" );
+        builder.append( b );
+
+        String test2 = ComponentSerializer.toString( builder.create() );
+        Assert.assertEquals(
+                "{\"extra\":[{\"underlined\":true,\"color\":\"dark_red\",\"text\":\"44444\"},"
+                        + "{\"color\":\"white\",\"text\":\"dd\"},{\"bold\":true,\"color\":\"gold\",\"text\":\"6666\"},"
+                        + "{\"color\":\"white\",\"text\":\"rrrr\"}],\"text\":\"\"}",
+                test2 );
+    }
+
+    private static String fromAndToLegacyText(String legacyText)
     {
         return BaseComponent.toLegacyText( TextComponent.fromLegacyText( legacyText ) );
     }


### PR DESCRIPTION
In legacy chat format, colors and reset do not retain any formatting.

In order to prevent this behaviour from creating unnecessary long json containing many redundant `formatting: false`, the original `fromLegacyText(...)` idea was to just override the color to white and handle the format reset just internally.

However eventual previous format rejection (aka reset) information was lost when appending multiple legacy format strings to a `ComponentBuilder`.

With this change we save the "reset wish" in the `BaseComponent` and update `ComponentBuilder`'s append function to not copy over formatting if the component has the reset flag set.


One could have also explicitely set every formatting option to false, but that would create those mentioned long json strings with redundant information. Thats why I chose to add the reset boolean.

See https://www.spigotmc.org/threads/prevent-componentbuilder-format-from-leaking.562014/