### PR TITLE
Fix  possible NPE's in LoginEvent & PreLoginEvent

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -428,7 +428,8 @@ public class InitialHandler extends PacketHandler implements PendingConnection
             {
                 if ( result.isCancelled() )
                 {
-                    disconnect( result.getCancelReasonComponents() );
+                    BaseComponent[] reason = result.getCancelReasonComponents();
+                    disconnect( reason != null ? reason : TextComponent.fromLegacyText( bungee.getTranslation( "kick_message" ) ) );
                     return;
                 }
                 if ( ch.isClosed() )
@@ -551,7 +552,8 @@ public class InitialHandler extends PacketHandler implements PendingConnection
             {
                 if ( result.isCancelled() )
                 {
-                    disconnect( result.getCancelReasonComponents() );
+                    BaseComponent[] reason = result.getCancelReasonComponents();
+                    disconnect( reason != null ? reason : TextComponent.fromLegacyText( bungee.getTranslation( "kick_message" ) ) );
                     return;
                 }
                 if ( ch.isClosed() )


### PR DESCRIPTION
If you cancel an Login or PreLogin event without setting an disconnect message we get an NPE. I added a null check for this and disconnect the player with the kick message if it is null.
This is a fix for #3355 and the same issue for PreLoginEvent.
