### PR TITLE
Add chat / command packet to chat event

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/event/ChatEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/ChatEvent.java
@@ -8,6 +8,7 @@ import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.connection.Connection;
 import net.md_5.bungee.api.plugin.Cancellable;
 import net.md_5.bungee.api.plugin.PluginManager;
+import net.md_5.bungee.protocol.DefinedPacket;
 
 /**
  * Event called when a player sends a message to a server.
@@ -26,11 +27,16 @@ public class ChatEvent extends TargetedEvent implements Cancellable
      * Text contained in this chat.
      */
     private String message;
+    /**
+     * The original packet, unchanged.
+     */
+    private DefinedPacket originalPacket;
 
-    public ChatEvent(Connection sender, Connection receiver, String message)
+    public ChatEvent(Connection sender, Connection receiver, String message, DefinedPacket originalPacket)
     {
         super( sender, receiver );
         this.message = message;
+        this.originalPacket = originalPacket;
     }
 
     /**

--- a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
@@ -23,6 +23,7 @@ import net.md_5.bungee.entitymap.EntityMap;
 import net.md_5.bungee.forge.ForgeConstants;
 import net.md_5.bungee.netty.ChannelWrapper;
 import net.md_5.bungee.netty.PacketHandler;
+import net.md_5.bungee.protocol.DefinedPacket;
 import net.md_5.bungee.protocol.PacketWrapper;
 import net.md_5.bungee.protocol.ProtocolConstants;
 import net.md_5.bungee.protocol.packet.Chat;
@@ -147,7 +148,7 @@ public class UpstreamBridge extends PacketHandler
     @Override
     public void handle(Chat chat) throws Exception
     {
-        String message = handleChat( chat.getMessage() );
+        String message = handleChat( chat.getMessage(), chat );
         if ( message != null )
         {
             chat.setMessage( message );
@@ -160,16 +161,16 @@ public class UpstreamBridge extends PacketHandler
     @Override
     public void handle(ClientChat chat) throws Exception
     {
-        handleChat( chat.getMessage() );
+        handleChat( chat.getMessage(), chat );
     }
 
     @Override
     public void handle(ClientCommand command) throws Exception
     {
-        handleChat( "/" + command.getCommand() );
+        handleChat( "/" + command.getCommand(), command );
     }
 
-    private String handleChat(String message)
+    private String handleChat(String message, DefinedPacket originalPacket)
     {
         for ( int index = 0, length = message.length(); index < length; index++ )
         {
@@ -181,7 +182,7 @@ public class UpstreamBridge extends PacketHandler
             }
         }
 
-        ChatEvent chatEvent = new ChatEvent( con, con.getServer(), message );
+        ChatEvent chatEvent = new ChatEvent( con, con.getServer(), message, originalPacket );
         if ( !bungee.getPluginManager().callEvent( chatEvent ).isCancelled() )
         {
             message = chatEvent.getMessage();


### PR DESCRIPTION
Added the original chat packet to the chat event.

Since 1.19, chat packets from the client also include extra info like timestamp, signature, etc. These were not passed through by the event and there was no way to get them from a plugin.

It would have been annoying if the plugin would need to send the message asynchronously to any service backend for things like global chat, global commands, or other similar systems, then forward the message to the server if these systems decided it wasn't needed to process it. Below are examples of code for pre 1.19 and post 1.19 code.

If you see any better way to do that, let me know.

```java
// Pre 1.19
if (event.getSender() instanceof ProxiedPlayer) {
    event.setCancelled(true);

    this.plugin.getProxy().getScheduler().runAsync(this.plugin, () -> {
        try {
            boolean cancelled = this.sendRequestToBackend(event);

            if (!cancelled) {
                event.getReceiver().unsafe().sendPacket(new Chat(event.getMessage()));
            }
        } catch (Exception ex) {
            this.plugin.getLogger().warning(() -> "Failed to handle chat message : " + ex.getMessage());
        }
    });
}
```
```java
if (event.getSender() instanceof ProxiedPlayer) {
    event.setCancelled(true);

    this.plugin.getProxy().getScheduler().runAsync(this.plugin, () -> {
        try {
            boolean cancelled = this.sendRequestToBackend(event);

            if (!cancelled) {
                event.getReceiver().unsafe().sendPacket(event.getOriginalPacket());
            }
        } catch (Exception ex) {
            this.plugin.getLogger().warning(() -> "Failed to handle chat message : " + ex.getMessage());
        }
    });
}
```