### PR TITLE
Cache MessageFormats for Translation

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
@@ -24,8 +24,8 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
-import java.text.MessageFormat;
 import java.text.Format;
+import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -558,7 +558,7 @@ public class BungeeCord extends ProxyServer
         cacheResourceBundle( cachedFormats, baseBundle );
         messageFormats = cachedFormats;
     }
-    
+
     private void cacheResourceBundle(Map<String, Format> map, ResourceBundle resourceBundle)
     {
         Enumeration<String> keys = resourceBundle.getKeys();

--- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
@@ -564,7 +564,7 @@ public class BungeeCord extends ProxyServer
         Enumeration<String> keys = resourceBundle.getKeys();
         while ( keys.hasMoreElements() )
         {
-            map.computeIfAbsent( keys.nextElement(), ( key ) -> new MessageFormat( resourceBundle.getString( key ) ) );
+            map.computeIfAbsent( keys.nextElement(), (key) -> new MessageFormat( resourceBundle.getString( key ) ) );
         }
     }
 

--- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
@@ -564,11 +564,7 @@ public class BungeeCord extends ProxyServer
         Enumeration<String> keys = resourceBundle.getKeys();
         while ( keys.hasMoreElements() )
         {
-            String key = keys.nextElement();
-            if ( !map.containsKey( key ) )
-            {
-                map.put( key, new MessageFormat( resourceBundle.getString( key ) ) );
-            }
+            map.computeIfAbsent( keys.nextElement(), ( key ) -> new MessageFormat( resourceBundle.getString( key ) ) );
         }
     }
 


### PR DESCRIPTION
The default implementation of java ( MessageFormat.format ) create a new MessageFormat every time its executed. This behavior is wasting much performance as it creates a new Pattern every time with the applyPattern(String) method of the MessageFormat class. To increase the performace of the getTranslation method and make the process way faster I added a simple cache for the MessageFormats so it is not creating a new one every time we want to transalte