### PR TITLE
only verify profile key when on 1.19 or newer

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -381,7 +381,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
             return;
         }
 
-        if ( BungeeCord.getInstance().config.isEnforceSecureProfile() )
+        if ( BungeeCord.getInstance().config.isEnforceSecureProfile() && getVersion() >= ProtocolConstants.MINECRAFT_1_19 )
         {
             PlayerPublicKey publicKey = loginRequest.getPublicKey();
             if ( publicKey == null )


### PR DESCRIPTION
When enabling secure profile enforcement for 1.19, BungeeCord will deny connections of all older versions as there is currently no check if the version a user uses to connect to the proxy actually supports secure profiles.

I've just added that check in order to enforce secure profiles while allowing older versions to connect to the proxy.