### PR TITLE
Linux aarch64 native epoll support

### DIFF
--- a/proxy/pom.xml
+++ b/proxy/pom.xml
@@ -50,6 +50,13 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-epoll</artifactId>
+            <version>${netty.version}</version>
+            <classifier>linux-aarch_64</classifier>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>net.md-5</groupId>
             <artifactId>bungeecord-api</artifactId>
             <version>${project.version}</version>


### PR DESCRIPTION
This allows people using linux aarch64 (arm64) to use Epoll, instead of defaulting to Java NIO.