### PR TITLE
Remove KickStringWriter from the Pipeline after Handshake arrives

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -314,6 +314,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
         Preconditions.checkState( thisState == State.HANDSHAKE, "Not expecting HANDSHAKE" );
         this.handshake = handshake;
         ch.setVersion( handshake.getProtocolVersion() );
+        ch.getHandle().pipeline().remove( PipelineUtils.LEGACY_KICKER );
 
         // Starting with FML 1.8, a "\0FML\0" token is appended to the handshake. This interferes
         // with Bungee's IP forwarding, so we detect it, and remove it from the host string, for now.


### PR DESCRIPTION
remove LEGACY_KICKER from pipeline after we receive an Handshake. It is only used for the legacy packets that can't be send to server after an Handshake