### PR TITLE
Issue #3374: improve log handling of normal java.util Logger usage

### DIFF
--- a/log/src/main/java/net/md_5/bungee/log/BungeeLogger.java
+++ b/log/src/main/java/net/md_5/bungee/log/BungeeLogger.java
@@ -24,6 +24,7 @@ public class BungeeLogger extends Logger
     {
         super( loggerName, null );
         setLevel( Level.ALL );
+        setUseParentHandlers( false );
 
         try
         {

--- a/log/src/main/java/net/md_5/bungee/log/LoggingForwardHandler.java
+++ b/log/src/main/java/net/md_5/bungee/log/LoggingForwardHandler.java
@@ -1,0 +1,26 @@
+package net.md_5.bungee.log;
+
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class LoggingForwardHandler extends Handler
+{
+    private final Logger logger;
+
+    @Override
+    public void publish(LogRecord record)
+    {
+        logger.log( record );
+    }
+    @Override
+    public void flush()
+    {
+    }
+    @Override
+    public void close() throws SecurityException
+    {
+    }
+}


### PR DESCRIPTION
 by forwarding them directly to the BungeeLogger instead of to the err stream.