### PR TITLE
[ci skip] Update workflow dependencies

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,9 +14,10 @@ jobs:
     name: Java ${{ matrix.java }}
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-java@v1
+    - uses: actions/checkout@v3
+    - uses: actions/setup-java@v3
       with:
         java-version: ${{ matrix.java }}
+        distribution: 'corretto'
     - run: java -version && mvn --version
     - run: mvn --activate-profiles dist --no-transfer-progress package


### PR DESCRIPTION
This PR only update the version of dependencies in the workflow based in a deprecation announced for a few things used by this actions.
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/