### PR TITLE
Allow event listener methods to be private

### DIFF
--- a/event/src/main/java/net/md_5/bungee/event/EventBus.java
+++ b/event/src/main/java/net/md_5/bungee/event/EventBus.java
@@ -90,6 +90,7 @@ public class EventBus
                 }
                 Map<Byte, Set<Method>> prioritiesMap = handler.computeIfAbsent( params[0], k -> new HashMap<>() );
                 Set<Method> priority = prioritiesMap.computeIfAbsent( annotation.priority(), k -> new HashSet<>() );
+                m.setAccessible(true);
                 priority.add( m );
             }
         }


### PR DESCRIPTION
This is a feature on Spigot, and it annoys me that it doesn't exist on Bungee