### PR TITLE
fix: Set secure chat flag based on proxy config

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import net.md_5.bungee.BungeeCord;
 import net.md_5.bungee.ServerConnection;
 import net.md_5.bungee.ServerConnection.KeepAliveData;
 import net.md_5.bungee.UserConnection;
@@ -684,6 +685,7 @@ public class DownstreamBridge extends PacketHandler
     {
         serverData.setMotd( null );
         serverData.setIcon( null );
+        serverData.setEnforceSecure( BungeeCord.getInstance().config.isEnforceSecureProfile() );
         con.unsafe().sendPacket( serverData );
         throw CancelSendSignal.INSTANCE;
     }


### PR DESCRIPTION
Set the secure chat flag inside the `ServerData` packet based on the configured value inside the proxy config.