### PR TITLE
Reset old Title from other server on Upstream initializing

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
@@ -34,6 +34,7 @@ import net.md_5.bungee.protocol.packet.PlayerListItem;
 import net.md_5.bungee.protocol.packet.PluginMessage;
 import net.md_5.bungee.protocol.packet.TabCompleteRequest;
 import net.md_5.bungee.protocol.packet.TabCompleteResponse;
+import net.md_5.bungee.protocol.packet.Title;
 import net.md_5.bungee.util.AllowedCharacters;
 
 public class UpstreamBridge extends PacketHandler
@@ -50,6 +51,7 @@ public class UpstreamBridge extends PacketHandler
         BungeeCord.getInstance().addConnection( con );
         con.getTabListHandler().onConnect();
         con.unsafe().sendPacket( BungeeCord.getInstance().registerChannels( con.getPendingConnection().getVersion() ) );
+        con.unsafe().sendPacket( new Title( Title.Action.RESET ) );
     }
 
     @Override


### PR DESCRIPTION
Some servers are sending titles that do not disapear.
Example: Hypixel, if you are marked as afk a title apears and if you disconnect and join on another server and you have not moved again on hypixel at the time you disconnecting, you will have the same title on the other server and it won't disapear