### PR TITLE
 Make EventBus use Consumer instead of reflections

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/plugin/PluginClassloader.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/PluginClassloader.java
@@ -38,7 +38,7 @@ final class PluginClassloader extends URLClassLoader
         ClassLoader.registerAsParallelCapable();
     }
 
-    public PluginClassloader(ProxyServer proxy, PluginDescription desc, File file, ClassLoader libraryLoader) throws IOException
+    public PluginClassloader(ProxyServer proxy, PluginDescription desc, File file, ClassLoader libraryLoader) throws IOException, ClassNotFoundException
     {
         super( new URL[]
         {

--- a/api/src/main/java/net/md_5/bungee/api/plugin/PluginClassloader.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/PluginClassloader.java
@@ -54,9 +54,11 @@ final class PluginClassloader extends URLClassLoader
         allLoaders.add( this );
 
         Class<?> lookupClass = EventLookup.class;
-        byte[] classData = ByteStreams.toByteArray( lookupClass.getClassLoader().getResourceAsStream( lookupClass.getName().replace( '.', '/' ) + ".class" ) );
-        // Load the EventLookup class into this PluginClassloader
+        byte[] classData = ByteStreams.toByteArray( lookupClass.getClassLoader().getResourceAsStream( lookupClass.getName().replace( '.', '/' ).concat( ".class" ) ) );
+
+        // Load the EventLookup class into this PluginClassloader and initialize the class
         defineClass( lookupClass.getName(), classData, 0, classData.length );
+        Class.forName( lookupClass.getName(), true, this );
     }
 
     @Override

--- a/api/src/main/java/net/md_5/bungee/api/plugin/PluginClassloader.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/PluginClassloader.java
@@ -16,6 +16,7 @@ import java.util.jar.JarFile;
 import java.util.jar.Manifest;
 import lombok.ToString;
 import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.event.EventLookup;
 
 @ToString(of = "desc")
 final class PluginClassloader extends URLClassLoader
@@ -51,6 +52,11 @@ final class PluginClassloader extends URLClassLoader
         this.libraryLoader = libraryLoader;
 
         allLoaders.add( this );
+
+        Class<?> lookupClass = EventLookup.class;
+        byte[] classData = ByteStreams.toByteArray( lookupClass.getClassLoader().getResourceAsStream( lookupClass.getName().replace( '.', '/' ) + ".class" ) );
+        // Load the EventLookup class into this PluginClassloader
+        defineClass( lookupClass.getName(), classData, 0, classData.length );
     }
 
     @Override

--- a/event/src/main/java/net/md_5/bungee/event/EventBus.java
+++ b/event/src/main/java/net/md_5/bungee/event/EventBus.java
@@ -200,7 +200,7 @@ public class EventBus
     private EventHandlerMethod createEventHandlerMethod(Object listener, Method method) throws Throwable
     {
         // Get the MethodHandles.Lookup created by the PluginClassloader of the listeners Plugin
-        MethodHandles.Lookup lookup = LOOKUPS.get( listener.getClass().getClassLoader() );
+        MethodHandles.Lookup lookup = LOOKUPS.computeIfAbsent( listener.getClass().getClassLoader(), classLoader -> MethodHandles.lookup() );
         Object consumer = LambdaMetafactory.metafactory( lookup,
                 "accept",
                 MethodType.methodType( Consumer.class, listener.getClass() ),

--- a/event/src/main/java/net/md_5/bungee/event/EventBus.java
+++ b/event/src/main/java/net/md_5/bungee/event/EventBus.java
@@ -1,7 +1,9 @@
 package net.md_5.bungee.event;
 
 import com.google.common.collect.ImmutableSet;
-import java.lang.reflect.InvocationTargetException;
+import java.lang.invoke.LambdaMetafactory;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
 import java.lang.reflect.Method;
 import java.text.MessageFormat;
 import java.util.ArrayList;
@@ -13,6 +15,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Consumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -47,15 +50,9 @@ public class EventBus
                 try
                 {
                     method.invoke( event );
-                } catch ( IllegalAccessException ex )
+                } catch ( Throwable ex )
                 {
-                    throw new Error( "Method became inaccessible: " + event, ex );
-                } catch ( IllegalArgumentException ex )
-                {
-                    throw new Error( "Method rejected target/argument: " + event, ex );
-                } catch ( InvocationTargetException ex )
-                {
-                    logger.log( Level.WARNING, MessageFormat.format( "Error dispatching event {0} to listener {1}", event, method.getListener() ), ex.getCause() );
+                    logger.log( Level.WARNING, MessageFormat.format( "Error dispatching event {0} to listener {1}", event, method.getListener() ), ex );
                 }
 
                 long elapsed = System.nanoTime() - start;
@@ -180,8 +177,14 @@ public class EventBus
                     {
                         for ( Method method : listenerHandlers.getValue() )
                         {
-                            EventHandlerMethod ehm = new EventHandlerMethod( listenerHandlers.getKey(), method );
-                            handlersList.add( ehm );
+                            try
+                            {
+                                EventHandlerMethod ehm = createEventHandlerMethod( listenerHandlers.getKey(), method );
+                                handlersList.add( ehm );
+                            } catch ( Throwable ex )
+                            {
+                                logger.log( Level.WARNING, "Can't create EventHandlerMethod", ex );
+                            }
                         }
                     }
                 }
@@ -191,5 +194,22 @@ public class EventBus
         {
             byEventBaked.remove( eventClass );
         }
+    }
+
+    private EventHandlerMethod createEventHandlerMethod(Object listener, Method method) throws Throwable
+    {
+
+        // Get the MethodHandles.Lookup created by the PluginClassloader of the listeners Plugin
+        MethodHandles.Lookup lookup = (MethodHandles.Lookup) listener.getClass().getClassLoader().loadClass( EventLookup.class.getName() ).getFields()[0].get( null );
+
+        Object consumer = LambdaMetafactory.metafactory( lookup,
+                "accept",
+                MethodType.methodType( Consumer.class, listener.getClass() ),
+                MethodType.methodType( void.class, Object.class ),
+                lookup.unreflect( method ),
+                MethodType.methodType( void.class, method.getParameterTypes()[0] ) ).getTarget()
+                .invokeWithArguments( listener );
+
+        return new EventHandlerMethod( listener, (Consumer<Object>) consumer );
     }
 }

--- a/event/src/main/java/net/md_5/bungee/event/EventBus.java
+++ b/event/src/main/java/net/md_5/bungee/event/EventBus.java
@@ -209,6 +209,6 @@ public class EventBus
                 MethodType.methodType( void.class, method.getParameterTypes()[0] ) )
                 .getTarget().invokeWithArguments( listener );
 
-        return new EventHandlerMethod( listener, (Consumer<Object>) consumer);
+        return new EventHandlerMethod( listener, (Consumer<Object>) consumer );
     }
 }

--- a/event/src/main/java/net/md_5/bungee/event/EventHandlerMethod.java
+++ b/event/src/main/java/net/md_5/bungee/event/EventHandlerMethod.java
@@ -1,7 +1,6 @@
 package net.md_5.bungee.event;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
+import java.util.function.Consumer;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -11,11 +10,11 @@ public class EventHandlerMethod
 
     @Getter
     private final Object listener;
-    @Getter
-    private final Method method;
+    private final Consumer<Object> method;
 
-    public void invoke(Object event) throws IllegalAccessException, IllegalArgumentException, InvocationTargetException
+    public void invoke(Object event) throws Throwable
     {
-        method.invoke( listener, event );
+        method.accept( event );
     }
+
 }

--- a/event/src/main/java/net/md_5/bungee/event/EventLookup.java
+++ b/event/src/main/java/net/md_5/bungee/event/EventLookup.java
@@ -1,0 +1,10 @@
+package net.md_5.bungee.event;
+
+import java.lang.invoke.MethodHandles;
+
+public class EventLookup
+{
+
+    public static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
+
+}

--- a/event/src/main/java/net/md_5/bungee/event/EventLookup.java
+++ b/event/src/main/java/net/md_5/bungee/event/EventLookup.java
@@ -5,6 +5,8 @@ import java.lang.invoke.MethodHandles;
 public class EventLookup
 {
 
-    public static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
-
+    static
+    {
+        EventBus.LOOKUPS.put( EventLookup.class.getClassLoader(), MethodHandles.lookup() );
+    }
 }


### PR DESCRIPTION
This pull request changes the way the event system is invoking the event method

My benchmark told me that consumers are up to 11 times faster than reflections

Benchmark                    Mode  Cnt   Score   Error  Units
LambdaConsumerInvoke.invoke  avgt  200   1,098 ± 0,057  ns/op
MethodHandles.invoke         avgt  200   2,941 ± 0,173  ns/op
ReflectionInvoke.invoke      avgt  200  11,026 ± 1,487  ns/op

The method that is invoked is empty, thats why the values are so small and the difference is so big