### PR TITLE
Handle ExperimentalFeatures packets during server login process for 1.19.3

### DIFF
--- a/protocol/src/main/java/net/md_5/bungee/protocol/AbstractPacketHandler.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/AbstractPacketHandler.java
@@ -11,6 +11,7 @@ import net.md_5.bungee.protocol.packet.Commands;
 import net.md_5.bungee.protocol.packet.EncryptionRequest;
 import net.md_5.bungee.protocol.packet.EncryptionResponse;
 import net.md_5.bungee.protocol.packet.EntityStatus;
+import net.md_5.bungee.protocol.packet.ExperimentalFeatures;
 import net.md_5.bungee.protocol.packet.GameState;
 import net.md_5.bungee.protocol.packet.Handshake;
 import net.md_5.bungee.protocol.packet.KeepAlive;
@@ -221,6 +222,10 @@ public abstract class AbstractPacketHandler
     }
 
     public void handle(ServerData serverData) throws Exception
+    {
+    }
+
+    public void handle(ExperimentalFeatures experimentalFeatures) throws Exception
     {
     }
 }

--- a/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java
@@ -19,6 +19,7 @@ import net.md_5.bungee.protocol.packet.Commands;
 import net.md_5.bungee.protocol.packet.EncryptionRequest;
 import net.md_5.bungee.protocol.packet.EncryptionResponse;
 import net.md_5.bungee.protocol.packet.EntityStatus;
+import net.md_5.bungee.protocol.packet.ExperimentalFeatures;
 import net.md_5.bungee.protocol.packet.GameState;
 import net.md_5.bungee.protocol.packet.Handshake;
 import net.md_5.bungee.protocol.packet.KeepAlive;
@@ -379,7 +380,11 @@ public enum Protocol
                     PlayerListItemUpdate::new,
                     map( ProtocolConstants.MINECRAFT_1_19_3, 0x36 )
             );
-
+            TO_CLIENT.registerPacket(
+                    ExperimentalFeatures.class,
+                    ExperimentalFeatures::new,
+                    map( ProtocolConstants.MINECRAFT_1_19_3, 0x67 )
+            );
             TO_SERVER.registerPacket(
                     KeepAlive.class,
                     KeepAlive::new,

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/ExperimentalFeatures.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/ExperimentalFeatures.java
@@ -1,0 +1,45 @@
+package net.md_5.bungee.protocol.packet;
+
+import io.netty.buffer.ByteBuf;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import net.md_5.bungee.protocol.AbstractPacketHandler;
+import net.md_5.bungee.protocol.DefinedPacket;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = false)
+public class ExperimentalFeatures extends DefinedPacket
+{
+    private List<String> features = new ArrayList<>();
+
+    @Override
+    public void read(ByteBuf buf)
+    {
+        for ( int i = 0; i < readVarInt( buf ); i++ )
+        {
+            features.add( readString( buf ) );
+        }
+    }
+
+    @Override
+    public void write(ByteBuf buf)
+    {
+        writeVarInt( features.size(), buf );
+        for ( String feature : features )
+        {
+            writeString( feature, buf );
+        }
+    }
+
+    @Override
+    public void handle(AbstractPacketHandler handler) throws Exception
+    {
+        handler.handle( this );
+    }
+}


### PR DESCRIPTION
Plugins like ViaVersion always send this packet, although it doesn't seem necessary, we can always process this packet to connect players without problems.
This should fix this issue (which was actually referring to this issue): https://github.com/SpigotMC/BungeeCord/issues/3409