### PR TITLE
Right protocol limits for strings in the chat packet

### DIFF
--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/Chat.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/Chat.java
@@ -40,7 +40,7 @@ public class Chat extends DefinedPacket
     @Override
     public void read(ByteBuf buf, ProtocolConstants.Direction direction, int protocolVersion)
     {
-        message = readString( buf, ( direction == ProtocolConstants.Direction.TO_CLIENT ) ? 262144 : ( protocolVersion >= ProtocolConstants.MINECRAFT_1_11 ? 256 : 100 ) );
+        message = readString( buf, ( direction == ProtocolConstants.Direction.TO_CLIENT ) ? ( protocolVersion < ProtocolConstants.MINECRAFT_1_16_4 ? Short.MAX_VALUE : 262144 ) : ( protocolVersion >= ProtocolConstants.MINECRAFT_1_11 ? 256 : 100 ) );
         if ( direction == ProtocolConstants.Direction.TO_CLIENT )
         {
             position = buf.readByte();
@@ -54,7 +54,7 @@ public class Chat extends DefinedPacket
     @Override
     public void write(ByteBuf buf, ProtocolConstants.Direction direction, int protocolVersion)
     {
-        writeString( message, buf, ( direction == ProtocolConstants.Direction.TO_CLIENT ) ? 262144 : ( protocolVersion >= ProtocolConstants.MINECRAFT_1_11 ? 256 : 100 ) );
+        writeString( message, buf, ( direction == ProtocolConstants.Direction.TO_CLIENT ) ? ( protocolVersion < ProtocolConstants.MINECRAFT_1_16_4 ? Short.MAX_VALUE : 262144 ) : ( protocolVersion >= ProtocolConstants.MINECRAFT_1_11 ? 256 : 100 ) );
         if ( direction == ProtocolConstants.Direction.TO_CLIENT )
         {
             buf.writeByte( position );


### PR DESCRIPTION
For version below 1.16.5 the limit is short.max_value, as 1.16.5 and 1.16.4 has the same protocol number we limit below 1.16.4 I made a plugin too printing debug stuff in the chat everything was working on 1.19.3 but on 1.8.9 i got disconnected without an exeption because the error was in the client. So i think we should apply the limit in bungee direktly