### PR TITLE
Fix race condition when 2 players with the same nickname join at the same time

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
@@ -749,11 +749,15 @@ public class BungeeCord extends ProxyServer
         }
     }
 
-    public void addConnection(UserConnection con)
+    public boolean addConnection(UserConnection con)
     {
         connectionLock.writeLock().lock();
         try
         {
+            if ( connections.get( con.getName() ) != null || connectionsByUUID.get( con.getUniqueId() ) != null )
+            {
+                return true;
+            }
             connections.put( con.getName(), con );
             connectionsByUUID.put( con.getUniqueId(), con );
             connectionsByOfflineUUID.put( con.getPendingConnection().getOfflineId(), con );
@@ -761,6 +765,7 @@ public class BungeeCord extends ProxyServer
         {
             connectionLock.writeLock().unlock();
         }
+        return false;
     }
 
     public void removeConnection(UserConnection con)

--- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
@@ -756,7 +756,7 @@ public class BungeeCord extends ProxyServer
         {
             if ( connections.get( con.getName() ) != null || connectionsByUUID.get( con.getUniqueId() ) != null )
             {
-                return true;
+                return false;
             }
             connections.put( con.getName(), con );
             connectionsByUUID.put( con.getUniqueId(), con );
@@ -765,7 +765,7 @@ public class BungeeCord extends ProxyServer
         {
             connectionLock.writeLock().unlock();
         }
-        return false;
+        return true;
     }
 
     public void removeConnection(UserConnection con)

--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -601,7 +601,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
                             ch.setProtocol( Protocol.GAME );
 
                             UpstreamBridge newUpstreamBridge = new UpstreamBridge( bungee, userCon );
-                            if ( newUpstreamBridge.init() )
+                            if ( !newUpstreamBridge.init() )
                             {
                                 disconnect( bungee.getTranslation( "already_connected_proxy" ) );
                                 return;

--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -600,7 +600,14 @@ public class InitialHandler extends PacketHandler implements PendingConnection
                             unsafe.sendPacket( new LoginSuccess( getUniqueId(), getName(), ( loginProfile == null ) ? null : loginProfile.getProperties() ) );
                             ch.setProtocol( Protocol.GAME );
 
-                            ch.getHandle().pipeline().get( HandlerBoss.class ).setHandler( new UpstreamBridge( bungee, userCon ) );
+                            UpstreamBridge newUpstreamBridge = new UpstreamBridge( bungee, userCon );
+                            if ( newUpstreamBridge.init() )
+                            {
+                                disconnect( bungee.getTranslation( "already_connected_proxy" ) );
+                                return;
+                            }
+
+                            ch.getHandle().pipeline().get( HandlerBoss.class ).setHandler( newUpstreamBridge );
                             bungee.getPluginManager().callEvent( new PostLoginEvent( userCon ) );
                             ServerInfo server;
                             if ( bungee.getReconnectHandler() != null )

--- a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
@@ -52,13 +52,13 @@ public class UpstreamBridge extends PacketHandler
 
     public boolean init()
     {
-        if ( BungeeCord.getInstance().addConnection( con ) )
+        if ( !BungeeCord.getInstance().addConnection( con ) )
         {
-            return true;
+            return false;
         }
         con.getTabListHandler().onConnect();
         con.unsafe().sendPacket( BungeeCord.getInstance().registerChannels( con.getPendingConnection().getVersion() ) );
-        return false;
+        return true;
     }
 
     @Override

--- a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
@@ -48,10 +48,17 @@ public class UpstreamBridge extends PacketHandler
     {
         this.bungee = bungee;
         this.con = con;
+    }
 
-        BungeeCord.getInstance().addConnection( con );
+    public boolean init()
+    {
+        if ( BungeeCord.getInstance().addConnection( con ) )
+        {
+            return true;
+        }
         con.getTabListHandler().onConnect();
         con.unsafe().sendPacket( BungeeCord.getInstance().registerChannels( con.getPendingConnection().getVersion() ) );
+        return false;
     }
 
     @Override


### PR DESCRIPTION
This pull request attempts to fix a rare race condition bug where multiple players with the same username try to join the proxy at the same time.
When this behavior occurs, some plugins go crazy, because for the same player by his nickname or sometimes uuid, the login and disconnect event are called several times, causing undefined behavior and also allowing the same player to join the server several times.
This happens because there is no synchronization and verification of existing players anywhere.
Since the getPlayer method only blocks when the collection changes, multiple players with the same name can easily join the proxy at the same time.
My solution is to have the addConnection method return true if the player has already been added to the collection.
Since this is the only place that is always blocked because it modifies the collection, in my opinion this is a great opportunity to check if a player has already been added and return the result.

I tried to keep the old behavior. Since addConnection is always called in the UpstreamBridge constructor, I decided it would be better to create an init method and move some of the methods there.
The only thing I don't like at the moment is that LoginSuccess will always be sent even when the player should be kicked. However, this is a very rare situation and I don't think it's worth changing.

I do not consider this an ideal solution and perhaps I could not take into account something.