### PR TITLE
Use readRetainedSlice method instead of slice+retain+skip

### DIFF
--- a/protocol/src/main/java/net/md_5/bungee/protocol/Varint21FrameDecoder.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/Varint21FrameDecoder.java
@@ -53,8 +53,7 @@ public class Varint21FrameDecoder extends ByteToMessageDecoder
                 {
                     if ( in.hasMemoryAddress() )
                     {
-                        out.add( in.slice( in.readerIndex(), length ).retain() );
-                        in.skipBytes( length );
+                        out.add( in.readRetainedSlice( length ) );
                     } else
                     {
                         if ( !DIRECT_WARNING )


### PR DESCRIPTION
PooledByteBuf has special implementation for retainedSlice, but neither for slice nor retain.