### PR TITLE
Speed up writing of Varint21

### DIFF
--- a/protocol/src/main/java/net/md_5/bungee/protocol/DefinedPacket.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/DefinedPacket.java
@@ -168,23 +168,47 @@ public abstract class DefinedPacket
 
     public static void writeVarInt(int value, ByteBuf output)
     {
-        int part;
-        while ( true )
+        if ( ( value & 0xFFFFFF80 ) == 0 )
         {
-            part = value & 0x7F;
+            output.writeByte( value );
+        } else if ( ( value & 0xFFFFC000 ) == 0 )
+        {
+            output.writeShort( ( value & 0x7F | 0x80 ) << 8 | ( value >>> 7 & 0x7F ) );
+        } else if ( ( value & 0xFFE00000 ) == 0 )
+        {
+            output.writeMedium( ( value & 0x7F | 0x80 ) << 16 | ( value >>> 7 & 0x7F | 0x80 ) << 8 | ( value >>> 14 & 0x7F ) );
+        } else if ( ( value & 0xF0000000 ) == 0 )
+        {
+            output.writeInt( ( value & 0x7F | 0x80 ) << 24 | ( value >>> 7 & 0x7F | 0x80 ) << 16 | ( value >>> 14 & 0x7F | 0x80 ) << 8 | ( value >>> 21 & 0x7F ) );
+        } else
+        {
+            output.writeInt( ( value & 0x7F | 0x80 ) << 24 | ( value >>> 7 & 0x7F | 0x80 ) << 16 | ( value >>> 14 & 0x7F | 0x80 ) << 8 | ( value >>> 21 & 0x7F | 0x80 ) );
+            output.writeByte( value >>> 28 );
+        }
+    }
 
-            value >>>= 7;
-            if ( value != 0 )
-            {
-                part |= 0x80;
-            }
-
-            output.writeByte( part );
-
-            if ( value == 0 )
-            {
+    public static void writeVarInt(int value, ByteBuf output, int len)
+    {
+        switch ( len )
+        {
+            case 1:
+                output.writeByte( value );
                 break;
-            }
+            case 2:
+                output.writeShort( ( value & 0x7F | 0x80 ) << 8 | ( value >>> 7 & 0x7F ) );
+                break;
+            case 3:
+                output.writeMedium( ( value & 0x7F | 0x80 ) << 16 | ( value >>> 7 & 0x7F | 0x80 ) << 8 | ( value >>> 14 & 0x7F ) );
+                break;
+            case 4:
+                output.writeInt( ( value & 0x7F | 0x80 ) << 24 | ( value >>> 7 & 0x7F | 0x80 ) << 16 | ( value >>> 14 & 0x7F | 0x80 ) << 8 | ( value >>> 21 & 0x7F ) );
+                break;
+            case 5:
+                output.writeInt( ( value & 0x7F | 0x80 ) << 24 | ( value >>> 7 & 0x7F | 0x80 ) << 16 | ( value >>> 14 & 0x7F | 0x80 ) << 8 | ( value >>> 21 & 0x7F | 0x80 ) );
+                output.writeByte( value >>> 28 );
+                break;
+            default:
+                throw new IllegalArgumentException( "Invalid varint len: " + len );
         }
     }
 

--- a/protocol/src/main/java/net/md_5/bungee/protocol/Varint21LengthFieldExtraBufPrepender.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/Varint21LengthFieldExtraBufPrepender.java
@@ -17,8 +17,9 @@ public class Varint21LengthFieldExtraBufPrepender extends MessageToMessageEncode
     protected void encode(ChannelHandlerContext ctx, ByteBuf msg, List<Object> out) throws Exception
     {
         int bodyLen = msg.readableBytes();
-        ByteBuf lenBuf = ctx.alloc().ioBuffer( Varint21LengthFieldPrepender.varintSize( bodyLen ) );
-        DefinedPacket.writeVarInt( bodyLen, lenBuf );
+        int headerLen = Varint21LengthFieldPrepender.varintSize( bodyLen );
+        ByteBuf lenBuf = ctx.alloc().ioBuffer( headerLen );
+        DefinedPacket.writeVarInt( bodyLen, lenBuf, headerLen );
         out.add( lenBuf );
         out.add( msg.retain() );
     }

--- a/protocol/src/main/java/net/md_5/bungee/protocol/Varint21LengthFieldPrepender.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/Varint21LengthFieldPrepender.java
@@ -19,7 +19,7 @@ public class Varint21LengthFieldPrepender extends MessageToByteEncoder<ByteBuf>
         int headerLen = varintSize( bodyLen );
         out.ensureWritable( headerLen + bodyLen );
 
-        DefinedPacket.writeVarInt( bodyLen, out );
+        DefinedPacket.writeVarInt( bodyLen, out, headerLen );
         out.writeBytes( msg );
     }
 

--- a/protocol/src/test/java/net/md_5/bungee/protocol/VarintWriteTest.java
+++ b/protocol/src/test/java/net/md_5/bungee/protocol/VarintWriteTest.java
@@ -1,0 +1,70 @@
+package net.md_5.bungee.protocol;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import java.util.Random;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class VarintWriteTest
+{
+    private final int[] ints = new Random( 8132264708911581L ).ints( 4096 ).toArray();
+
+    private static void originalVarintWrite(int value, ByteBuf output)
+    {
+        int part;
+        while ( true )
+        {
+            part = value & 0x7F;
+
+            value >>>= 7;
+            if ( value != 0 )
+            {
+                part |= 0x80;
+            }
+
+            output.writeByte( part );
+
+            if ( value == 0 )
+            {
+                break;
+            }
+        }
+    }
+
+    @Test
+    public void testWriteVarint()
+    {
+        for ( int i : ints )
+        {
+            ByteBuf expected = Unpooled.buffer( 5 );
+            originalVarintWrite( i, expected );
+
+            ByteBuf actual = Unpooled.buffer( 5 );
+            DefinedPacket.writeVarInt( i, actual );
+
+            Assert.assertArrayEquals( "Number " + i, expected.array(), actual.array() );
+
+            expected.release();
+            actual.release();
+        }
+    }
+
+    @Test
+    public void testWriteVarintWithLen()
+    {
+        for ( int i : ints )
+        {
+            ByteBuf expected = Unpooled.buffer( 5 );
+            originalVarintWrite( i, expected );
+
+            ByteBuf actual = Unpooled.buffer( 5 );
+            DefinedPacket.writeVarInt( i, actual, Varint21LengthFieldPrepender.varintSize( i ) );
+
+            Assert.assertArrayEquals( "Number " + i, expected.array(), actual.array() );
+
+            expected.release();
+            actual.release();
+        }
+    }
+}


### PR DESCRIPTION
Benchmarks indicate this is 20-50% faster (higher when writing longer varints).

See
https://github.com/SpigotMC/BungeeCord/pull/3451#issuecomment-1485796424
https://steinborn.me/posts/performance/how-fast-can-you-write-a-varint/

With just a being few nanoseconds per operation this is likely just a small to not noticable difference overall.

As we just rarely have to touch that part of the code, I think it is okay to have this optimized, unrolled loop and condensed write calls here.

In further benchmarks I made there was no significant difference leaving out the 0x7F mask for the uppermost bit, so I added it to be similar to the code of the blog post.

The varint writing speedup in the benchmark is lower on java 19 (just ~10% faster) compared to java 16/17 (~30% faster), original code speed is similar. For the benchmark 2048 random short numbers were used, the speedup stays similar using other batch sizes (like 4096 or 1024) / random seeds.
I don't want to spend time looking whether this is tunable with jvm flags or what exactly is going on there tho, also because benchmarks are never identical to thereal workload..