### PR TITLE
Command string decoding limit for ClientCommand

### DIFF
--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/ClientCommand.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/ClientCommand.java
@@ -32,7 +32,7 @@ public class ClientCommand extends DefinedPacket
     @Override
     public void read(ByteBuf buf, ProtocolConstants.Direction direction, int protocolVersion)
     {
-        command = readString( buf );
+        command = readString( buf, 256 );
         timestamp = buf.readLong();
         salt = buf.readLong();
 


### PR DESCRIPTION
The ClientChat packet has a chat string decoding limit, but for some reason is missing from the ClientCommand packet.
This pull request fixes this.