### PR TITLE
Add Bungee Chat Spoofing Warning for chat function 

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/connection/ProxiedPlayer.java
+++ b/api/src/main/java/net/md_5/bungee/api/connection/ProxiedPlayer.java
@@ -183,6 +183,7 @@ public interface ProxiedPlayer extends Connection, CommandSender
 
     /**
      * Make this player chat (say something), to the server he is currently on.
+     * WARNING: This function is no longer supported in all versions >= 1.19 and will throw an exception.
      *
      * @param message the message to say
      */


### PR DESCRIPTION
Since Minecraft version 1.19 the proxiedplayer.chat() function no longer works because Mojang removed Bungee Chat Spoofing.
This PR adds a warning in the docs so users know that this function will produce an error when used on servers >= 1.19.

Added Message:
`WARNING: This function is no longer supported in all versions >= 1.19 and will throw an exception.`

closes #3499