### PR TITLE
Set encode protocol to CONFIGURATION before connecting downstream

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -622,8 +622,8 @@ public class InitialHandler extends PacketHandler implements PendingConnection
     {
         Preconditions.checkState( thisState == State.CONFIGURING, "Not expecting CONFIGURING" );
 
-        finish2();
         ch.setEncodeProtocol( Protocol.CONFIGURATION );
+        finish2();
     }
 
     private void finish2()


### PR DESCRIPTION
Fixes #3525 

Tested kicks from PostLoginEvent, and whether the client could still join. 