### PR TITLE
Use a synchronized list for /send command

### DIFF
--- a/module/cmd-send/src/main/java/net/md_5/bungee/module/cmd/send/CommandSend.java
+++ b/module/cmd-send/src/main/java/net/md_5/bungee/module/cmd/send/CommandSend.java
@@ -38,7 +38,7 @@ public class CommandSend extends Command implements TabExecutor
             this.sender = sender;
             for ( ServerConnectRequest.Result result : ServerConnectRequest.Result.values() )
             {
-                results.put( result, new ArrayList<String>() );
+                results.put( result, Collections.synchronizedList( new ArrayList<>() ) );
             }
         }
 


### PR DESCRIPTION
I got the following exception using the "/send all Dev" command.
```21:13:24 [WARNING] An exception was thrown by net.md_5.bungee.UserConnection$4.operationComplete()
java.lang.ArrayIndexOutOfBoundsException: Index 1 out of bounds for length 0
    at java.base/java.util.ArrayList.add(ArrayList.java:455)
    at java.base/java.util.ArrayList.add(ArrayList.java:467)
    at net.md_5.bungee.module.cmd.send.CommandSend$SendCallback$Entry.done(CommandSend.java:80)
    at net.md_5.bungee.module.cmd.send.CommandSend$SendCallback$Entry.done(CommandSend.java:62)
    at net.md_5.bungee.UserConnection$4.operationComplete(UserConnection.java:364)
    at net.md_5.bungee.UserConnection$4.operationComplete(UserConnection.java:357)
    at io.netty.util.concurrent.DefaultPromise.notifyListener0(DefaultPromise.java:590)
    at io.netty.util.concurrent.DefaultPromise.notifyListeners0(DefaultPromise.java:583)
    at io.netty.util.concurrent.DefaultPromise.notifyListenersNow(DefaultPromise.java:559)
    at io.netty.util.concurrent.DefaultPromise.notifyListeners(DefaultPromise.java:492)
    at io.netty.util.concurrent.DefaultPromise.setValue0(DefaultPromise.java:636)
    at io.netty.util.concurrent.DefaultPromise.setSuccess0(DefaultPromise.java:625)
    at io.netty.util.concurrent.DefaultPromise.trySuccess(DefaultPromise.java:105)
    at io.netty.channel.DefaultChannelPromise.trySuccess(DefaultChannelPromise.java:84)
    at io.netty.channel.epoll.AbstractEpollChannel$AbstractEpollUnsafe.fulfillConnectPromise(AbstractEpollChannel.java:653)
    at io.netty.channel.epoll.AbstractEpollChannel$AbstractEpollUnsafe.finishConnect(AbstractEpollChannel.java:691)
    at io.netty.channel.epoll.AbstractEpollChannel$AbstractEpollUnsafe.epollOutReady(AbstractEpollChannel.java:567)
    at io.netty.channel.epoll.EpollEventLoop.processReady(EpollEventLoop.java:499)
    at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:407)
    at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
    at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
    at java.base/java.lang.Thread.run(Thread.java:833)
```
    
synchronizing the map should fix this issue