### PR TITLE
Fix intent issues in InitialHandler 

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -168,7 +168,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
     public void handle(LegacyHandshake legacyHandshake) throws Exception
     {
         Preconditions.checkState( thisState == State.HANDSHAKE, "Not expecting LEGACY HANDSHAKE" );
-        
+
         this.legacy = true;
         ch.close( bungee.getTranslation( "outdated_client", bungee.getGameVersion() ) );
     }

--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -59,7 +59,6 @@ import net.md_5.bungee.protocol.packet.Handshake;
 import net.md_5.bungee.protocol.packet.Kick;
 import net.md_5.bungee.protocol.packet.LegacyHandshake;
 import net.md_5.bungee.protocol.packet.LegacyPing;
-import net.md_5.bungee.protocol.packet.LoginAcknowledged;
 import net.md_5.bungee.protocol.packet.LoginPayloadResponse;
 import net.md_5.bungee.protocol.packet.LoginRequest;
 import net.md_5.bungee.protocol.packet.LoginSuccess;
@@ -123,12 +122,12 @@ public class InitialHandler extends PacketHandler implements PendingConnection
     private enum State
     {
 
-        HANDSHAKE, STATUS, PING_EVENT, PING, USERNAME, ENCRYPT, FINISHING, CONFIGURING
+        HANDSHAKE, STATUS, PING_EVENT, PING, USERNAME, ENCRYPT, FINISHING;
     }
 
     private boolean canSendKickMessage()
     {
-        return thisState == State.USERNAME || thisState == State.ENCRYPT || thisState == State.FINISHING || thisState == State.CONFIGURING;
+        return thisState == State.USERNAME || thisState == State.ENCRYPT || thisState == State.FINISHING;
     }
 
     @Override
@@ -263,10 +262,10 @@ public class InitialHandler extends PacketHandler implements PendingConnection
     {
         Preconditions.checkState( thisState == State.STATUS, "Not expecting STATUS" );
 
-        thisState = State.PING_EVENT;
         ServerInfo forced = AbstractReconnectHandler.getForcedHost( this );
         final String motd = ( forced != null ) ? forced.getMotd() : listener.getMotd();
         final int protocol = ( ProtocolConstants.SUPPORTED_VERSION_IDS.contains( handshake.getProtocolVersion() ) ) ? handshake.getProtocolVersion() : bungee.getProtocolVersion();
+        thisState = State.PING_EVENT;
 
         Callback<ServerPing> pingBack = new Callback<ServerPing>()
         {
@@ -312,7 +311,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
     {
         Preconditions.checkState( thisState == State.PING, "Not expecting PING" );
         unsafe.sendPacket( ping );
-        ch.close();
+        disconnect( "" );
     }
 
     @Override
@@ -603,15 +602,12 @@ public class InitialHandler extends PacketHandler implements PendingConnection
                             userCon = new UserConnection( bungee, ch, getName(), InitialHandler.this );
                             userCon.setCompressionThreshold( BungeeCord.getInstance().config.getCompressionThreshold() );
 
-                            unsafe.sendPacket( new LoginSuccess( getUniqueId(), getName(), ( loginProfile == null ) ? null : loginProfile.getProperties() ) );
-                            if ( getVersion() >= ProtocolConstants.MINECRAFT_1_20_2 )
+                            if ( getVersion() < ProtocolConstants.MINECRAFT_1_20_2 )
                             {
-                                thisState = State.CONFIGURING;
-                            } else
-                            {
+                                unsafe.sendPacket( new LoginSuccess( getUniqueId(), getName(), ( loginProfile == null ) ? null : loginProfile.getProperties() ) );
                                 ch.setProtocol( Protocol.GAME );
-                                finish2();
                             }
+                            finish2();
                         }
                     }
                 } );
@@ -620,15 +616,6 @@ public class InitialHandler extends PacketHandler implements PendingConnection
 
         // fire login event
         bungee.getPluginManager().callEvent( new LoginEvent( InitialHandler.this, complete ) );
-    }
-
-    @Override
-    public void handle(LoginAcknowledged loginAcknowledged) throws Exception
-    {
-        Preconditions.checkState( thisState == State.CONFIGURING, "Not expecting CONFIGURING" );
-
-        ch.setEncodeProtocol( Protocol.CONFIGURATION );
-        finish2();
     }
 
     private void finish2()

--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -128,7 +128,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
 
     private boolean canSendKickMessage()
     {
-        return thisState == State.USERNAME || thisState == State.ENCRYPT || thisState == State.FINISHING || thisState == State.CONFIGURING || thisState == EVENT_LOGIN;
+        return thisState == State.USERNAME || thisState == State.ENCRYPT || thisState == State.FINISHING || thisState == State.CONFIGURING || thisState == State.EVENT_LOGIN;
     }
 
     @Override

--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -121,7 +121,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
 
     private enum State
     {
-        HANDSHAKE, STATUS, PING_EVENT, PING, USERNAME, ENCRYPT, FINISHING;
+        HANDSHAKE, STATUS, PROCESSING_PING, PING, USERNAME, ENCRYPT, FINISHING;
     }
 
     private boolean canSendKickMessage()
@@ -176,7 +176,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
     {
         Preconditions.checkState( thisState == State.HANDSHAKE, "Not expecting LEGACY PING" );
 
-        thisState = State.PING_EVENT;
+        thisState = State.PROCESSING_PING;
         this.legacy = true;
         final boolean v1_5 = ping.isV1_5();
 
@@ -264,7 +264,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
         ServerInfo forced = AbstractReconnectHandler.getForcedHost( this );
         final String motd = ( forced != null ) ? forced.getMotd() : listener.getMotd();
         final int protocol = ( ProtocolConstants.SUPPORTED_VERSION_IDS.contains( handshake.getProtocolVersion() ) ) ? handshake.getProtocolVersion() : bungee.getProtocolVersion();
-        thisState = State.PING_EVENT;
+        thisState = State.PROCESSING_PING;
 
         Callback<ServerPing> pingBack = new Callback<ServerPing>()
         {

--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -123,12 +123,12 @@ public class InitialHandler extends PacketHandler implements PendingConnection
     private enum State
     {
 
-        HANDSHAKE, STATUS, PING, USERNAME, ENCRYPT, FINISHING, CONFIGURING, EVENT_LOGIN, EVENT_PING;
+        HANDSHAKE, STATUS, PING_EVENT, PING, USERNAME, ENCRYPT, FINISHING, CONFIGURING
     }
 
     private boolean canSendKickMessage()
     {
-        return thisState == State.USERNAME || thisState == State.ENCRYPT || thisState == State.FINISHING || thisState == State.CONFIGURING || thisState == State.EVENT_LOGIN;
+        return thisState == State.USERNAME || thisState == State.ENCRYPT || thisState == State.FINISHING || thisState == State.CONFIGURING;
     }
 
     @Override
@@ -178,7 +178,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
     {
         Preconditions.checkState( thisState == State.HANDSHAKE, "Not expecting LEGACY PING" );
 
-        thisState = State.EVENT_PING;
+        thisState = State.PING_EVENT;
         this.legacy = true;
         final boolean v1_5 = ping.isV1_5();
 
@@ -263,7 +263,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
     {
         Preconditions.checkState( thisState == State.STATUS, "Not expecting STATUS" );
 
-        thisState = State.EVENT_PING;
+        thisState = State.PING_EVENT;
         ServerInfo forced = AbstractReconnectHandler.getForcedHost( this );
         final String motd = ( forced != null ) ? forced.getMotd() : listener.getMotd();
         final int protocol = ( ProtocolConstants.SUPPORTED_VERSION_IDS.contains( handshake.getProtocolVersion() ) ) ? handshake.getProtocolVersion() : bungee.getProtocolVersion();
@@ -454,13 +454,12 @@ public class InitialHandler extends PacketHandler implements PendingConnection
                     unsafe().sendPacket( request = EncryptionUtil.encryptRequest() );
                 } else
                 {
-                    thisState = State.FINISHING;
                     finish();
                 }
             }
         };
 
-        thisState = State.EVENT_LOGIN;
+        thisState = State.FINISHING;
         // fire pre login event
         bungee.getPluginManager().callEvent( new PreLoginEvent( InitialHandler.this, callback ) );
     }

--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -178,7 +178,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
     {
         Preconditions.checkState( thisState == State.HANDSHAKE, "Not expecting LEGACY PING" );
 
-        this.thisState = State.EVENT_PING;
+        thisState = State.EVENT_PING;
         this.legacy = true;
         final boolean v1_5 = ping.isV1_5();
 
@@ -460,7 +460,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
             }
         };
 
-        this.thisState = State.EVENT_LOGIN;
+        thisState = State.EVENT_LOGIN;
         // fire pre login event
         bungee.getPluginManager().callEvent( new PreLoginEvent( InitialHandler.this, callback ) );
     }


### PR DESCRIPTION
It is possible to make the server call an infinit amount of events, while an event-callback waits for all Intents to be completed, to change to a new state.

Adding an State for Ping and for Login Events is the simplest way to fix this.

This fixes multiple sending of legacy packets, it is possible to send LegacyPing and while the event call is waiting for all intents to be complete send an Legacy Handshake or a normal handshake and establish a real connection while the legacy ping event is running in the background, because the state is handshake and the channel not closed instanly but waiting for the intents to be completed.

It is also possible to call the PreLoginEvent infinite times, while the first one is waiting for a registered intend, which could potentially crash the server, if exploited.

Also it is possible to send a Ping Packet to the Server befor the server sent the StatusResponse to the client if an intend is registered for the ServerPingEvent. This should not be possible.