### PR TITLE
Queue packets of Title api

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/BungeeTitle.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeTitle.java
@@ -172,7 +172,13 @@ public class BungeeTitle implements Title
         {
             if ( player.getPendingConnection().getVersion() >= ProtocolConstants.MINECRAFT_1_17 )
             {
-                player.unsafe().sendPacket( packet.newPacket );
+                if ( player.getPendingConnection().getVersion() >= ProtocolConstants.MINECRAFT_1_20_2 )
+                {
+                    ( (UserConnection) player ).sendPacketQueued( packet.newPacket );
+                } else
+                {
+                    player.unsafe().sendPacket( packet.newPacket );
+                }
             } else
             {
                 player.unsafe().sendPacket( packet.oldPacket );

--- a/proxy/src/main/java/net/md_5/bungee/BungeeTitle.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeTitle.java
@@ -172,13 +172,7 @@ public class BungeeTitle implements Title
         {
             if ( player.getPendingConnection().getVersion() >= ProtocolConstants.MINECRAFT_1_17 )
             {
-                if ( player.getPendingConnection().getVersion() >= ProtocolConstants.MINECRAFT_1_20_2 )
-                {
-                    ( (UserConnection) player ).sendPacketQueued( packet.newPacket );
-                } else
-                {
-                    player.unsafe().sendPacket( packet.newPacket );
-                }
+                ( (UserConnection) player ).sendPacketQueued( packet.newPacket );
             } else
             {
                 player.unsafe().sendPacket( packet.oldPacket );


### PR DESCRIPTION
if sending titles using the api in an PostLoginEvent

Example :

player.sendTitle(new BungeeTitle().title(new TextComponent("Hallo")));

this PR fixes this issue

![image](https://github.com/SpigotMC/BungeeCord/assets/48880402/5f58f434-e320-4cf7-a8b3-48b9c33dc09b)
