### PR TITLE
Add TextComponent#fromLegacy() as compact alternative to #fromLegacyText()

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/ServerPing.java
+++ b/api/src/main/java/net/md_5/bungee/api/ServerPing.java
@@ -105,13 +105,13 @@ public class ServerPing
     @Deprecated
     public ServerPing(Protocol version, Players players, String description, String favicon)
     {
-        this( version, players, new TextComponent( TextComponent.fromLegacyText( description ) ), favicon == null ? null : Favicon.create( favicon ) );
+        this( version, players, TextComponent.fromLegacy( description ), favicon == null ? null : Favicon.create( favicon ) );
     }
 
     @Deprecated
     public ServerPing(Protocol version, Players players, String description, Favicon favicon)
     {
-        this( version, players, new TextComponent( TextComponent.fromLegacyText( description ) ), favicon );
+        this( version, players, TextComponent.fromLegacy( description ), favicon );
     }
 
     @Deprecated
@@ -139,7 +139,7 @@ public class ServerPing
     @Deprecated
     public void setDescription(String description)
     {
-        this.description = new TextComponent( TextComponent.fromLegacyText( description ) );
+        this.description = TextComponent.fromLegacy( description );
     }
 
     @Deprecated

--- a/api/src/main/java/net/md_5/bungee/api/event/LoginEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/LoginEvent.java
@@ -40,7 +40,7 @@ public class LoginEvent extends AsyncEvent<LoginEvent> implements Cancellable
 
     /**
      * @return reason to be displayed
-     * @deprecated Use {@link #getReason()} instead
+     * @deprecated Use component methods instead
      */
     @Deprecated
     public String getCancelReason()
@@ -50,7 +50,7 @@ public class LoginEvent extends AsyncEvent<LoginEvent> implements Cancellable
 
     /**
      * @param cancelReason reason to be displayed
-     * @deprecated Use {@link #setReason(BaseComponent)} instead
+     * @deprecated Use component methods instead
      */
     @Deprecated
     public void setCancelReason(String cancelReason)
@@ -60,7 +60,7 @@ public class LoginEvent extends AsyncEvent<LoginEvent> implements Cancellable
 
     /**
      * @return the cancel reason
-     * @deprecated Use {@link #getCancelReason()} instead.
+     * @deprecated Use component methods instead.
      */
     @Deprecated
     public BaseComponent[] getCancelReasonComponents()
@@ -70,7 +70,7 @@ public class LoginEvent extends AsyncEvent<LoginEvent> implements Cancellable
 
     /**
      * @param cancelReason the cancel reason
-     * @deprecated Use {@link #setReason(BaseComponent)} instead
+     * @deprecated Use component methods instead
      */
     @Deprecated
     public void setCancelReason(BaseComponent... cancelReason)

--- a/api/src/main/java/net/md_5/bungee/api/event/LoginEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/LoginEvent.java
@@ -1,12 +1,11 @@
 package net.md_5.bungee.api.event;
 
-import lombok.AccessLevel;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import lombok.Setter;
 import lombok.ToString;
 import net.md_5.bungee.api.Callback;
 import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.api.chat.ComponentBuilder;
 import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.api.connection.PendingConnection;
 import net.md_5.bungee.api.plugin.Cancellable;
@@ -27,8 +26,7 @@ public class LoginEvent extends AsyncEvent<LoginEvent> implements Cancellable
     /**
      * Message to use when kicking if this event is canceled.
      */
-    @Setter(AccessLevel.NONE)
-    private BaseComponent[] cancelReasonComponents;
+    private BaseComponent reason;
     /**
      * Connection attempting to login.
      */
@@ -42,28 +40,41 @@ public class LoginEvent extends AsyncEvent<LoginEvent> implements Cancellable
 
     /**
      * @return reason to be displayed
-     * @deprecated Use component methods instead.
+     * @deprecated Use {@link #getReason()} instead
      */
     @Deprecated
     public String getCancelReason()
     {
-        return BaseComponent.toLegacyText( getCancelReasonComponents() );
+        return TextComponent.toLegacyText( getReason() );
     }
 
     /**
      * @param cancelReason reason to be displayed
-     * @deprecated Use
-     * {@link #setCancelReason(net.md_5.bungee.api.chat.BaseComponent...)}
-     * instead.
+     * @deprecated Use {@link #setReason(BaseComponent)} instead
      */
     @Deprecated
     public void setCancelReason(String cancelReason)
     {
-        setCancelReason( TextComponent.fromLegacyText( cancelReason ) );
+        setReason( TextComponent.fromLegacy( cancelReason ) );
     }
 
+    /**
+     * @return the cancel reason
+     * @deprecated Use {@link #getCancelReason()} instead.
+     */
+    @Deprecated
+    public BaseComponent[] getCancelReasonComponents()
+    {
+        return new BaseComponent[] {getReason()};
+    }
+
+    /**
+     * @param cancelReason the cancel reason
+     * @deprecated Use {@link #setReason(BaseComponent)} instead
+     */
+    @Deprecated
     public void setCancelReason(BaseComponent... cancelReason)
     {
-        this.cancelReasonComponents = cancelReason;
+        setReason( new ComponentBuilder().append( cancelReason ).build() );
     }
 }

--- a/api/src/main/java/net/md_5/bungee/api/event/PreLoginEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/PreLoginEvent.java
@@ -45,7 +45,7 @@ public class PreLoginEvent extends AsyncEvent<PreLoginEvent> implements Cancella
 
     /**
      * @return reason to be displayed
-     * @deprecated use {@link #getReason()} instead
+     * @deprecated use component methods instead
      */
     @Deprecated
     public String getCancelReason()
@@ -55,7 +55,7 @@ public class PreLoginEvent extends AsyncEvent<PreLoginEvent> implements Cancella
 
     /**
      * @param cancelReason reason to be displayed
-     * @deprecated Use {@link #setReason(BaseComponent)} instead
+     * @deprecated Use component methods instead
      */
     @Deprecated
     public void setCancelReason(String cancelReason)
@@ -65,7 +65,7 @@ public class PreLoginEvent extends AsyncEvent<PreLoginEvent> implements Cancella
 
     /**
      * @return the cancel reason
-     * @deprecated Use {@link #getReason()} instead
+     * @deprecated Use component methods instead
      */
     @Deprecated
     public BaseComponent[] getCancelReasonComponents()
@@ -75,7 +75,7 @@ public class PreLoginEvent extends AsyncEvent<PreLoginEvent> implements Cancella
 
     /**
      * @param cancelReason the cancel reason
-     * @deprecated Use {@link #setReason(BaseComponent)} instead
+     * @deprecated Use component methods instead
      */
     @Deprecated
     public void setCancelReason(BaseComponent... cancelReason)

--- a/api/src/main/java/net/md_5/bungee/api/event/PreLoginEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/PreLoginEvent.java
@@ -1,12 +1,11 @@
 package net.md_5.bungee.api.event;
 
-import lombok.AccessLevel;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import lombok.Setter;
 import lombok.ToString;
 import net.md_5.bungee.api.Callback;
 import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.api.chat.ComponentBuilder;
 import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.api.connection.PendingConnection;
 import net.md_5.bungee.api.plugin.Cancellable;
@@ -32,8 +31,7 @@ public class PreLoginEvent extends AsyncEvent<PreLoginEvent> implements Cancella
     /**
      * Message to use when kicking if this event is canceled.
      */
-    @Setter(AccessLevel.NONE)
-    private BaseComponent[] cancelReasonComponents;
+    private BaseComponent reason;
     /**
      * Connection attempting to login.
      */
@@ -47,28 +45,41 @@ public class PreLoginEvent extends AsyncEvent<PreLoginEvent> implements Cancella
 
     /**
      * @return reason to be displayed
-     * @deprecated Use component methods instead.
+     * @deprecated use {@link #getReason()} instead
      */
     @Deprecated
     public String getCancelReason()
     {
-        return BaseComponent.toLegacyText( getCancelReasonComponents() );
+        return BaseComponent.toLegacyText( getReason() );
     }
 
     /**
      * @param cancelReason reason to be displayed
-     * @deprecated Use
-     * {@link #setCancelReason(net.md_5.bungee.api.chat.BaseComponent...)}
-     * instead.
+     * @deprecated Use {@link #setReason(BaseComponent)} instead
      */
     @Deprecated
     public void setCancelReason(String cancelReason)
     {
-        setCancelReason( TextComponent.fromLegacyText( cancelReason ) );
+        setReason( TextComponent.fromLegacy( cancelReason ) );
     }
 
+    /**
+     * @return the cancel reason
+     * @deprecated Use {@link #getReason()} instead
+     */
+    @Deprecated
+    public BaseComponent[] getCancelReasonComponents()
+    {
+        return new BaseComponent[] {getReason()};
+    }
+
+    /**
+     * @param cancelReason the cancel reason
+     * @deprecated Use {@link #setReason(BaseComponent)} instead
+     */
+    @Deprecated
     public void setCancelReason(BaseComponent... cancelReason)
     {
-        this.cancelReasonComponents = cancelReason;
+        setReason( new ComponentBuilder().append( cancelReason ).build() );
     }
 }

--- a/api/src/main/java/net/md_5/bungee/api/event/ServerKickEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/ServerKickEvent.java
@@ -4,6 +4,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.api.chat.ComponentBuilder;
 import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.api.config.ServerInfo;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
@@ -35,7 +36,7 @@ public class ServerKickEvent extends Event implements Cancellable
     /**
      * Kick reason.
      */
-    private BaseComponent[] kickReasonComponent;
+    private BaseComponent reason;
     /**
      * Server to send player to if this event is cancelled.
      */
@@ -63,24 +64,58 @@ public class ServerKickEvent extends Event implements Cancellable
         this( player, player.getServer().getInfo(), kickReasonComponent, cancelServer, state );
     }
 
+    @Deprecated
     public ServerKickEvent(ProxiedPlayer player, ServerInfo kickedFrom, BaseComponent[] kickReasonComponent, ServerInfo cancelServer, State state)
+    {
+        this( player, kickedFrom, new ComponentBuilder().append( kickReasonComponent ).build(), cancelServer, state );
+    }
+
+    public ServerKickEvent(ProxiedPlayer player, ServerInfo kickedFrom, BaseComponent reason, ServerInfo cancelServer, State state)
     {
         this.player = player;
         this.kickedFrom = kickedFrom;
-        this.kickReasonComponent = kickReasonComponent;
+        this.reason = reason;
         this.cancelServer = cancelServer;
         this.state = state;
     }
 
+    /**
+     * @return the kick reason
+     * @deprecated Use {@link #getReason()} instead
+     */
     @Deprecated
     public String getKickReason()
     {
-        return BaseComponent.toLegacyText( kickReasonComponent );
+        return BaseComponent.toLegacyText( getReason() );
     }
 
+    /**
+     * @param reason the kick reason
+     * @deprecated Use {@link #setReason(BaseComponent)} instead
+     */
     @Deprecated
     public void setKickReason(String reason)
     {
-        kickReasonComponent = TextComponent.fromLegacyText( reason );
+        this.setReason( TextComponent.fromLegacy( reason ) );
+    }
+
+    /**
+     * @return the kick reason
+     * @deprecated Use {@link #getReason()} instead
+     */
+    @Deprecated
+    public BaseComponent[] getKickReasonComponent()
+    {
+        return new BaseComponent[] {getReason()};
+    }
+
+    /**
+     * @param kickReasonComponent the kick reason
+     * @deprecated Use {@link #setReason(BaseComponent)} instead
+     */
+    @Deprecated
+    public void setKickReasonComponent(BaseComponent[] kickReasonComponent)
+    {
+        this.setReason( new ComponentBuilder().append( kickReasonComponent ).build() );
     }
 }

--- a/api/src/main/java/net/md_5/bungee/api/event/ServerKickEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/ServerKickEvent.java
@@ -81,7 +81,7 @@ public class ServerKickEvent extends Event implements Cancellable
 
     /**
      * @return the kick reason
-     * @deprecated Use {@link #getReason()} instead
+     * @deprecated Use component methods instead
      */
     @Deprecated
     public String getKickReason()
@@ -91,7 +91,7 @@ public class ServerKickEvent extends Event implements Cancellable
 
     /**
      * @param reason the kick reason
-     * @deprecated Use {@link #setReason(BaseComponent)} instead
+     * @deprecated Use component methods instead
      */
     @Deprecated
     public void setKickReason(String reason)
@@ -101,7 +101,7 @@ public class ServerKickEvent extends Event implements Cancellable
 
     /**
      * @return the kick reason
-     * @deprecated Use {@link #getReason()} instead
+     * @deprecated Use component methods instead
      */
     @Deprecated
     public BaseComponent[] getKickReasonComponent()
@@ -111,7 +111,7 @@ public class ServerKickEvent extends Event implements Cancellable
 
     /**
      * @param kickReasonComponent the kick reason
-     * @deprecated Use {@link #setReason(BaseComponent)} instead
+     * @deprecated Use component methods instead
      */
     @Deprecated
     public void setKickReasonComponent(BaseComponent[] kickReasonComponent)

--- a/chat/src/main/java/net/md_5/bungee/api/chat/TextComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/TextComponent.java
@@ -27,6 +27,47 @@ public final class TextComponent extends BaseComponent
      * @param message the text to convert
      * @return the components needed to print the message to the client
      */
+    public static BaseComponent fromLegacy(String message)
+    {
+        return fromLegacy( message, ChatColor.WHITE );
+    }
+
+    /**
+     * Converts the old formatting system that used
+     * {@link net.md_5.bungee.api.ChatColor#COLOR_CHAR} into the new json based
+     * system.
+     *
+     * @param message the text to convert
+     * @param defaultColor color to use when no formatting is to be applied
+     * (i.e. after ChatColor.RESET).
+     * @return the components needed to print the message to the client
+     */
+    public static BaseComponent fromLegacy(String message, ChatColor defaultColor)
+    {
+        TextComponent component = new TextComponent();
+
+        BaseComponent[] components = fromLegacyText( message, defaultColor );
+        if ( components.length > 0 )
+        {
+            component.setExtra( Arrays.asList( components ) );
+        }
+
+        return component;
+    }
+
+    /**
+     * Converts the old formatting system that used
+     * {@link net.md_5.bungee.api.ChatColor#COLOR_CHAR} into the new json based
+     * system.
+     *
+     * @param message the text to convert
+     * @return the components needed to print the message to the client
+     * @deprecated {@link #fromLegacy(String)} is preferred as it will
+     * consolidate all components into a single BaseComponent with extra
+     * contents as opposed to an array of components which is non-standard
+     * and may result in unexpected behavior.
+     */
+    @Deprecated
     public static BaseComponent[] fromLegacyText(String message)
     {
         return fromLegacyText( message, ChatColor.WHITE );
@@ -41,7 +82,12 @@ public final class TextComponent extends BaseComponent
      * @param defaultColor color to use when no formatting is to be applied
      * (i.e. after ChatColor.RESET).
      * @return the components needed to print the message to the client
+     * @deprecated {@link #fromLegacy(String, ChatColor)} is preferred as it will
+     * consolidate all components into a single BaseComponent with extra
+     * contents as opposed to an array of components which is non-standard
+     * and may result in unexpected behavior.
      */
+    @Deprecated
     public static BaseComponent[] fromLegacyText(String message, ChatColor defaultColor)
     {
         ArrayList<BaseComponent> components = new ArrayList<>();

--- a/module/cmd-alert/src/main/java/net/md_5/bungee/module/cmd/alert/CommandAlert.java
+++ b/module/cmd-alert/src/main/java/net/md_5/bungee/module/cmd/alert/CommandAlert.java
@@ -41,7 +41,7 @@ public class CommandAlert extends Command
 
             String message = builder.substring( 0, builder.length() - 1 );
 
-            ProxyServer.getInstance().broadcast( TextComponent.fromLegacyText( message ) );
+            ProxyServer.getInstance().broadcast( TextComponent.fromLegacy( message ) );
         }
     }
 }

--- a/module/cmd-kick/src/main/java/net/md_5/bungee/module/cmd/kick/CommandKick.java
+++ b/module/cmd-kick/src/main/java/net/md_5/bungee/module/cmd/kick/CommandKick.java
@@ -33,18 +33,18 @@ public class CommandKick extends Command implements TabExecutor
 
             if ( player == null )
             {
-                sender.sendMessage( TextComponent.fromLegacyText( ProxyServer.getInstance().getTranslation( "user_not_online" ) ) );
+                sender.sendMessage( TextComponent.fromLegacy( ProxyServer.getInstance().getTranslation( "user_not_online" ) ) );
                 return;
             }
 
             if ( args.length == 1 )
             {
-                player.disconnect( TextComponent.fromLegacyText( ProxyServer.getInstance().getTranslation( "kick_message" ) ) );
+                player.disconnect( TextComponent.fromLegacy( ProxyServer.getInstance().getTranslation( "kick_message" ) ) );
             } else
             {
                 String[] reason = new String[ args.length - 1 ];
                 System.arraycopy( args, 1, reason, 0, reason.length );
-                player.disconnect( TextComponent.fromLegacyText( ChatColor.translateAlternateColorCodes( '&', Joiner.on( ' ' ).join( reason ) ) ) );
+                player.disconnect( TextComponent.fromLegacy( ChatColor.translateAlternateColorCodes( '&', Joiner.on( ' ' ).join( reason ) ) ) );
             }
         }
     }

--- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
@@ -730,13 +730,13 @@ public class BungeeCord extends ProxyServer
     @Override
     public void broadcast(String message)
     {
-        broadcast( TextComponent.fromLegacyText( message ) );
+        broadcast( TextComponent.fromLegacy( message ) );
     }
 
     @Override
     public void broadcast(BaseComponent... message)
     {
-        getConsole().sendMessage( BaseComponent.toLegacyText( message ) );
+        getConsole().sendMessage( message );
         for ( ProxiedPlayer player : getPlayers() )
         {
             player.sendMessage( message );
@@ -746,7 +746,7 @@ public class BungeeCord extends ProxyServer
     @Override
     public void broadcast(BaseComponent message)
     {
-        getConsole().sendMessage( message.toLegacyText() );
+        getConsole().sendMessage( message );
         for ( ProxiedPlayer player : getPlayers() )
         {
             player.sendMessage( message );

--- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
@@ -407,7 +407,7 @@ public final class UserConnection implements ProxiedPlayer
     @Override
     public void disconnect(String reason)
     {
-        disconnect( TextComponent.fromLegacyText( reason ) );
+        disconnect( TextComponent.fromLegacy( reason ) );
     }
 
     @Override
@@ -455,7 +455,7 @@ public final class UserConnection implements ProxiedPlayer
     @Override
     public void sendMessage(String message)
     {
-        sendMessage( TextComponent.fromLegacyText( message ) );
+        sendMessage( TextComponent.fromLegacy( message ) );
     }
 
     @Override

--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -434,8 +434,8 @@ public class InitialHandler extends PacketHandler implements PendingConnection
             {
                 if ( result.isCancelled() )
                 {
-                    BaseComponent[] reason = result.getCancelReasonComponents();
-                    disconnect( ( reason != null ) ? reason : TextComponent.fromLegacyText( bungee.getTranslation( "kick_message" ) ) );
+                    BaseComponent reason = result.getReason();
+                    disconnect( ( reason != null ) ? reason : TextComponent.fromLegacy( bungee.getTranslation( "kick_message" ) ) );
                     return;
                 }
                 if ( ch.isClosed() )
@@ -578,8 +578,8 @@ public class InitialHandler extends PacketHandler implements PendingConnection
             {
                 if ( result.isCancelled() )
                 {
-                    BaseComponent[] reason = result.getCancelReasonComponents();
-                    disconnect( ( reason != null ) ? reason : TextComponent.fromLegacyText( bungee.getTranslation( "kick_message" ) ) );
+                    BaseComponent reason = result.getReason();
+                    disconnect( ( reason != null ) ? reason : TextComponent.fromLegacy( bungee.getTranslation( "kick_message" ) ) );
                     return;
                 }
                 if ( ch.isClosed() )
@@ -646,7 +646,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
     {
         if ( canSendKickMessage() )
         {
-            disconnect( TextComponent.fromLegacyText( reason ) );
+            disconnect( TextComponent.fromLegacy( reason ) );
         } else
         {
             ch.close();


### PR DESCRIPTION
Following [cfe00fa47c](https://github.com/SpigotMC/BungeeCord/commit/cfe00fa47c19e71e191c2651deb61239d68ed18b) (`ComponentBuilder#build()` et. al.), this PR adds some API that was missed to further encourage consolidating components into single objects as opposed to arrays, `TextComponent#fromLegacyText()`. While use of this method is discouraged, it is still used occasionally in Spigot to convert legacy text arguments into components. Unlike `ComponentSerializer#parse()` however, the individual components parsed from `#fromLegacyText()` are inserted as individual elements in the array and does not use the `extra` field of a `TextComponent`.

This PR adds `TextComponent#fromLegacy()` to resolve this. It does not change the behaviour of `#fromLegacyText()` and in fact invokes this method and just assigns the resulting array as `extra` values of an empty `TextComponent`. Unlike the previous PR where `ComponentSerializer#parse()` was not deprecated (because it does have genuine uses), the `#fromLegacyText()` methods have been deprecated to encourage use of single object alternatives.