### PR TITLE
Replace Charsets to StandardCharsets

### DIFF
--- a/chat/src/main/java/net/md_5/bungee/chat/TranslationRegistry.java
+++ b/chat/src/main/java/net/md_5/bungee/chat/TranslationRegistry.java
@@ -1,11 +1,11 @@
 package net.md_5.bungee.chat;
 
-import com.google.common.base.Charsets;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -102,7 +102,7 @@ public final class TranslationRegistry
 
         public JsonProvider(String resourcePath) throws IOException
         {
-            try ( InputStreamReader rd = new InputStreamReader( JsonProvider.class.getResourceAsStream( resourcePath ), Charsets.UTF_8 ) )
+            try ( InputStreamReader rd = new InputStreamReader( JsonProvider.class.getResourceAsStream( resourcePath ), StandardCharsets.UTF_8 ) )
             {
                 JsonObject obj = new Gson().fromJson( rd, JsonObject.class );
                 for ( Map.Entry<String, JsonElement> entries : obj.entrySet() )

--- a/config/src/main/java/net/md_5/bungee/config/JsonConfiguration.java
+++ b/config/src/main/java/net/md_5/bungee/config/JsonConfiguration.java
@@ -1,6 +1,5 @@
 package net.md_5.bungee.config;
 
-import com.google.common.base.Charsets;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
@@ -16,6 +15,7 @@ import java.io.OutputStreamWriter;
 import java.io.Reader;
 import java.io.Writer;
 import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import lombok.AccessLevel;
@@ -37,7 +37,7 @@ public class JsonConfiguration extends ConfigurationProvider
     @Override
     public void save(Configuration config, File file) throws IOException
     {
-        try ( Writer writer = new OutputStreamWriter( new FileOutputStream( file ), Charsets.UTF_8 ) )
+        try ( Writer writer = new OutputStreamWriter( new FileOutputStream( file ), StandardCharsets.UTF_8 ) )
         {
             save( config, writer );
         }
@@ -91,7 +91,7 @@ public class JsonConfiguration extends ConfigurationProvider
     @Override
     public Configuration load(InputStream is, Configuration defaults)
     {
-        return load( new InputStreamReader( is, Charsets.UTF_8 ), defaults );
+        return load( new InputStreamReader( is, StandardCharsets.UTF_8 ), defaults );
     }
 
     @Override

--- a/config/src/main/java/net/md_5/bungee/config/YamlConfiguration.java
+++ b/config/src/main/java/net/md_5/bungee/config/YamlConfiguration.java
@@ -1,6 +1,5 @@
 package net.md_5.bungee.config;
 
-import com.google.common.base.Charsets;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -9,6 +8,7 @@ import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.io.Reader;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import lombok.AccessLevel;
@@ -54,7 +54,7 @@ public class YamlConfiguration extends ConfigurationProvider
     @Override
     public void save(Configuration config, File file) throws IOException
     {
-        try ( Writer writer = new OutputStreamWriter( new FileOutputStream( file ), Charsets.UTF_8 ) )
+        try ( Writer writer = new OutputStreamWriter( new FileOutputStream( file ), StandardCharsets.UTF_8 ) )
         {
             save( config, writer );
         }

--- a/log/src/main/java/net/md_5/bungee/log/LoggingOutputStream.java
+++ b/log/src/main/java/net/md_5/bungee/log/LoggingOutputStream.java
@@ -1,8 +1,8 @@
 package net.md_5.bungee.log;
 
-import com.google.common.base.Charsets;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import lombok.RequiredArgsConstructor;
@@ -19,7 +19,7 @@ public class LoggingOutputStream extends ByteArrayOutputStream
     @Override
     public void flush() throws IOException
     {
-        String contents = toString( Charsets.UTF_8.name() );
+        String contents = toString( StandardCharsets.UTF_8.name() );
         super.reset();
         if ( !contents.isEmpty() && !contents.equals( separator ) )
         {

--- a/protocol/src/main/java/net/md_5/bungee/protocol/DefinedPacket.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/DefinedPacket.java
@@ -1,6 +1,5 @@
 package net.md_5.bungee.protocol;
 
-import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
 import com.google.gson.JsonElement;
 import io.netty.buffer.ByteBuf;
@@ -9,6 +8,7 @@ import io.netty.buffer.ByteBufOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.BitSet;
@@ -39,7 +39,7 @@ public abstract class DefinedPacket
             throw new OverflowPacketException( "Cannot send string longer than " + maxLength + " (got " + s.length() + " characters)" );
         }
 
-        byte[] b = s.getBytes( Charsets.UTF_8 );
+        byte[] b = s.getBytes( StandardCharsets.UTF_8 );
         if ( b.length > maxLength * 3 )
         {
             throw new OverflowPacketException( "Cannot send string longer than " + ( maxLength * 3 ) + " (got " + b.length + " bytes)" );
@@ -62,7 +62,7 @@ public abstract class DefinedPacket
             throw new OverflowPacketException( "Cannot receive string longer than " + maxLen * 3 + " (got " + len + " bytes)" );
         }
 
-        String s = buf.toString( buf.readerIndex(), len, Charsets.UTF_8 );
+        String s = buf.toString( buf.readerIndex(), len, StandardCharsets.UTF_8 );
         buf.readerIndex( buf.readerIndex() + len );
 
         if ( s.length() > maxLen )

--- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
@@ -1,6 +1,5 @@
 package net.md_5.bungee;
 
-import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
@@ -24,6 +23,7 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.nio.charset.StandardCharsets;
 import java.text.Format;
 import java.text.MessageFormat;
 import java.util.ArrayList;
@@ -691,10 +691,10 @@ public class BungeeCord extends ProxyServer
     {
         if ( protocolVersion >= ProtocolConstants.MINECRAFT_1_13 )
         {
-            return new PluginMessage( "minecraft:register", String.join( "\00", Iterables.transform( pluginChannels, PluginMessage.MODERNISE ) ).getBytes( Charsets.UTF_8 ), false );
+            return new PluginMessage( "minecraft:register", String.join( "\00", Iterables.transform( pluginChannels, PluginMessage.MODERNISE ) ).getBytes( StandardCharsets.UTF_8 ), false );
         }
 
-        return new PluginMessage( "REGISTER", String.join( "\00", pluginChannels ).getBytes( Charsets.UTF_8 ), false );
+        return new PluginMessage( "REGISTER", String.join( "\00", pluginChannels ).getBytes( StandardCharsets.UTF_8 ), false );
     }
 
     @Override

--- a/proxy/src/main/java/net/md_5/bungee/conf/YamlConfig.java
+++ b/proxy/src/main/java/net/md_5/bungee/conf/YamlConfig.java
@@ -1,6 +1,5 @@
 package net.md_5.bungee.conf;
 
-import com.google.common.base.Charsets;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.File;
 import java.io.FileInputStream;
@@ -10,6 +9,7 @@ import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.net.SocketAddress;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -176,7 +176,7 @@ public class YamlConfig implements ConfigurationAdapter
     {
         try
         {
-            try ( Writer wr = new OutputStreamWriter( new FileOutputStream( file ), Charsets.UTF_8 ) )
+            try ( Writer wr = new OutputStreamWriter( new FileOutputStream( file ), StandardCharsets.UTF_8 ) )
             {
                 yaml.dump( config, wr );
             }

--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -1,6 +1,5 @@
 package net.md_5.bungee.connection;
 
-import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
 import com.google.gson.Gson;
 import java.math.BigInteger;
@@ -514,7 +513,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
 
     private void finish()
     {
-        offlineId = UUID.nameUUIDFromBytes( ( "OfflinePlayer:" + getName() ).getBytes( Charsets.UTF_8 ) );
+        offlineId = UUID.nameUUIDFromBytes( ( "OfflinePlayer:" + getName() ).getBytes( StandardCharsets.UTF_8 ) );
         if ( uniqueId == null )
         {
             uniqueId = offlineId;

--- a/proxy/src/main/java/net/md_5/bungee/forge/ForgeUtils.java
+++ b/proxy/src/main/java/net/md_5/bungee/forge/ForgeUtils.java
@@ -1,9 +1,9 @@
 package net.md_5.bungee.forge;
 
-import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableSet;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -22,7 +22,7 @@ public class ForgeUtils
      */
     public static Set<String> readRegisteredChannels(PluginMessage pluginMessage)
     {
-        String channels = new String( pluginMessage.getData(), Charsets.UTF_8 );
+        String channels = new String( pluginMessage.getData(), StandardCharsets.UTF_8 );
         String[] split = channels.split( "\0" );
         Set<String> channelSet = ImmutableSet.copyOf( split );
         return channelSet;


### PR DESCRIPTION
This pull request replaces the deprecated Charsets constants with StandardCharsets constants which was added into Java itself since java 7.
According to the documentation 
https://guava.dev/releases/19.0/api/docs/com/google/common/base/Charsets.html
Charsets is no longer needed due to StandardCharsets constants.