### PR TITLE
Add Translatable interface for fluid creation of TranslatableComponents

### DIFF
--- a/chat/src/main/java/net/md_5/bungee/api/chat/ComponentBuilder.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/ComponentBuilder.java
@@ -205,6 +205,33 @@ public final class ComponentBuilder
     }
 
     /**
+     * Appends the {@link Translatable} object to the builder and makes the
+     * last element the current target for formatting. The components will have
+     * all the formatting from previous part.
+     *
+     * @param translatable the translatable object to append
+     * @return this ComponentBuilder for chaining
+     */
+    public ComponentBuilder append(Translatable translatable)
+    {
+        return append( translatable, FormatRetention.ALL );
+    }
+
+    /**
+     * Appends the {@link Translatable} object to the builder and makes the
+     * last element the current target for formatting. You can specify the
+     * amount of formatting retained from previous part.
+     *
+     * @param translatable the translatable object to append
+     * @param retention the formatting to retain
+     * @return this ComponentBuilder for chaining
+     */
+    public ComponentBuilder append(Translatable translatable, FormatRetention retention)
+    {
+        return append( translatable.asTranslatableComponent(), retention );
+    }
+
+    /**
      * Appends the text to the builder and makes it the current target for
      * formatting. The text will have all the formatting from previous part.
      *

--- a/chat/src/main/java/net/md_5/bungee/api/chat/ComponentBuilder.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/ComponentBuilder.java
@@ -205,28 +205,28 @@ public final class ComponentBuilder
     }
 
     /**
-     * Appends the {@link Translatable} object to the builder and makes the
-     * last element the current target for formatting. The components will have
-     * all the formatting from previous part.
+     * Appends the {@link TranslationProvider} object to the builder and makes
+     * the last element the current target for formatting. The components will
+     * have all the formatting from previous part.
      *
      * @param translatable the translatable object to append
      * @return this ComponentBuilder for chaining
      */
-    public ComponentBuilder append(Translatable translatable)
+    public ComponentBuilder append(TranslationProvider translatable)
     {
         return append( translatable, FormatRetention.ALL );
     }
 
     /**
-     * Appends the {@link Translatable} object to the builder and makes the
-     * last element the current target for formatting. You can specify the
+     * Appends the {@link TranslationProvider} object to the builder and makes
+     * the last element the current target for formatting. You can specify the
      * amount of formatting retained from previous part.
      *
      * @param translatable the translatable object to append
      * @param retention the formatting to retain
      * @return this ComponentBuilder for chaining
      */
-    public ComponentBuilder append(Translatable translatable, FormatRetention retention)
+    public ComponentBuilder append(TranslationProvider translatable, FormatRetention retention)
     {
         return append( translatable.asTranslatableComponent(), retention );
     }

--- a/chat/src/main/java/net/md_5/bungee/api/chat/Translatable.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/Translatable.java
@@ -1,0 +1,37 @@
+package net.md_5.bungee.api.chat;
+
+/**
+ * An object capable of being translated by the client in a {@link TranslatableComponent}.
+ */
+public interface Translatable {
+
+    /**
+     * Get the translation key.
+     *
+     * @return the translation key
+     */
+    String getTranslationKey();
+
+    /**
+     * Get this translatable object as a {@link TranslatableComponent}.
+     *
+     * @return the translatable component
+     */
+    default TranslatableComponent asTranslatableComponent()
+    {
+        return asTranslatableComponent((Object[]) null);
+    }
+
+    /**
+     * Get this translatable object as a {@link TranslatableComponent}.
+     *
+     * @param with the {@link String Strings} and {@link BaseComponent BaseComponents}
+     * to use in the translation
+     * @return the translatable component
+     */
+    default TranslatableComponent asTranslatableComponent(Object... with)
+    {
+        return new TranslatableComponent(this, with);
+    }
+
+}

--- a/chat/src/main/java/net/md_5/bungee/api/chat/Translatable.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/Translatable.java
@@ -3,7 +3,8 @@ package net.md_5.bungee.api.chat;
 /**
  * An object capable of being translated by the client in a {@link TranslatableComponent}.
  */
-public interface Translatable {
+public interface Translatable
+{
 
     /**
      * Get the translation key.
@@ -19,7 +20,7 @@ public interface Translatable {
      */
     default TranslatableComponent asTranslatableComponent()
     {
-        return asTranslatableComponent((Object[]) null);
+        return asTranslatableComponent( (Object[]) null );
     }
 
     /**
@@ -31,7 +32,7 @@ public interface Translatable {
      */
     default TranslatableComponent asTranslatableComponent(Object... with)
     {
-        return new TranslatableComponent(this, with);
+        return new TranslatableComponent( this, with );
     }
 
 }

--- a/chat/src/main/java/net/md_5/bungee/api/chat/TranslatableComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/TranslatableComponent.java
@@ -96,7 +96,7 @@ public final class TranslatableComponent extends BaseComponent
      * @see #translate
      * @see #setWith(java.util.List)
      */
-    public TranslatableComponent(Translatable translatable, Object... with)
+    public TranslatableComponent(TranslationProvider translatable, Object... with)
     {
         this( translatable.getTranslationKey(), with );
     }

--- a/chat/src/main/java/net/md_5/bungee/api/chat/TranslatableComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/TranslatableComponent.java
@@ -87,6 +87,21 @@ public final class TranslatableComponent extends BaseComponent
     }
 
     /**
+     * Creates a translatable component with the passed substitutions
+     *
+     * @param translatable the translatable object
+     * @param with the {@link java.lang.String}s and
+     * {@link net.md_5.bungee.api.chat.BaseComponent}s to use into the
+     * translation
+     * @see #translate
+     * @see #setWith(java.util.List)
+     */
+    public TranslatableComponent(Translatable translatable, Object... with)
+    {
+        this(translatable.getTranslationKey(), with);
+    }
+
+    /**
      * Creates a duplicate of this TranslatableComponent.
      *
      * @return the duplicate of this TranslatableComponent.

--- a/chat/src/main/java/net/md_5/bungee/api/chat/TranslatableComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/TranslatableComponent.java
@@ -98,7 +98,7 @@ public final class TranslatableComponent extends BaseComponent
      */
     public TranslatableComponent(Translatable translatable, Object... with)
     {
-        this(translatable.getTranslationKey(), with);
+        this( translatable.getTranslationKey(), with );
     }
 
     /**

--- a/chat/src/main/java/net/md_5/bungee/api/chat/TranslationProvider.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/TranslationProvider.java
@@ -3,7 +3,7 @@ package net.md_5.bungee.api.chat;
 /**
  * An object capable of being translated by the client in a {@link TranslatableComponent}.
  */
-public interface Translatable
+public interface TranslationProvider
 {
 
     /**


### PR DESCRIPTION
This PR adds a simple `TranslationProvider` interface to more fluidly create `TranslatableComponent` instances. While nothing in the Bungee API needs to implement `TranslationProvider`, the Spigot API can most certainly use this interface for types such as `ItemType`, `BlockType`, `EntityType`, `Enchantment`, so on and so forth.

While yes [Bukkit does already have a Translatable interface](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/Translatable.html), it cannot be used to directly construct a `TranslatableComponent` which makes working with it cumbersome and forcing developers to access the translation key rather than passing the translatable object directly. Bukkit's `Translatable` interface may extend BungeeChat's `TranslationProvider` interface for convenience.

```java
// Before
TranslatableComponent component = new TranslatableComponent(Material.STONE.getTranslationKey());
// or
BaseComponent component = new ComponentBuilder()
    .append(new TranslatableComponent(Material.STONE.getTranslationKey()))
    .build();

// After
TranslatableComponent component = new TranslatableComponent(Material.STONE);
// or
BaseComponent component = new ComponentBuilder()
    .append(Material.STONE)
    .append(Material.STONE.asTranslatableComponent()) // Alternatively
    .append(Material.STONE.asTranslatableComponent("first arg", 2)) // Can be used to pass args as well
    .build();
```
Perhaps `ComponentBuilder#append(TranslationProvider)` is not clear enough, in which case I propose `appendTranslatable()` instead as a clearer distinction. I'm open to either one.