### PR TITLE
check packet to be queued for unsafe#sendPacket for all client with version >= 1.20.2

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/BungeeTitle.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeTitle.java
@@ -154,13 +154,7 @@ public class BungeeTitle implements Title
     {
         if ( packet != null )
         {
-            if ( player.getPendingConnection().getVersion() >= ProtocolConstants.MINECRAFT_1_17 )
-            {
-                ( (UserConnection) player ).sendPacketQueued( packet.newPacket );
-            } else
-            {
-                player.unsafe().sendPacket( packet.oldPacket );
-            }
+            player.unsafe().sendPacket( player.getPendingConnection().getVersion() >= ProtocolConstants.MINECRAFT_1_17 ? packet.newPacket : packet.oldPacket );
         }
     }
 

--- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
@@ -144,7 +144,7 @@ public final class UserConnection implements ProxiedPlayer
     private ForgeServerHandler forgeServerHandler;
     /*========================================================================*/
     private final Queue<DefinedPacket> packetQueue = new ConcurrentLinkedQueue<>();
-    private final boolean possibleQueueing = getPendingConnection().getVersion() >= ProtocolConstants.MINECRAFT_1_20_2;
+    private boolean possibleQueueing;
     private final Unsafe unsafe = new Unsafe()
     {
         @Override
@@ -162,6 +162,8 @@ public final class UserConnection implements ProxiedPlayer
 
     public boolean init()
     {
+        this.possibleQueueing = getPendingConnection().getVersion() >= ProtocolConstants.MINECRAFT_1_20_2;
+
         this.entityRewrite = EntityMap.getEntityMap( getPendingConnection().getVersion() );
 
         this.displayName = name;

--- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
@@ -144,12 +144,19 @@ public final class UserConnection implements ProxiedPlayer
     private ForgeServerHandler forgeServerHandler;
     /*========================================================================*/
     private final Queue<DefinedPacket> packetQueue = new ConcurrentLinkedQueue<>();
+    private final boolean possibleQueueing = getPendingConnection().getVersion() >= ProtocolConstants.MINECRAFT_1_20_2;
     private final Unsafe unsafe = new Unsafe()
     {
         @Override
         public void sendPacket(DefinedPacket packet)
         {
-            ch.write( packet );
+            if ( possibleQueueing )
+            {
+                sendPacketQueued( packet );
+            } else
+            {
+                ch.write( packet );
+            }
         }
     };
 

--- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
@@ -196,7 +196,7 @@ public final class UserConnection implements ProxiedPlayer
             packetQueue.add( packet );
         } else
         {
-            unsafe().sendPacket( packet );
+            ch.write( packet );
         }
     }
 


### PR DESCRIPTION
This change makes it much easier for all developers to send packets in the newer versions as the sendPacketQueued is not implemented via api and can only be called with reflections if we use only api.

All in all the change should make the networking more safe for further changes and implementation of new api.
And could indirectly fix problems with bad plugins that have not been specially updated for the new networking behaviour