### PR TITLE
Print the disconnect message of the InitialHandler

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/netty/HandlerBoss.java
+++ b/proxy/src/main/java/net/md_5/bungee/netty/HandlerBoss.java
@@ -60,9 +60,22 @@ public class HandlerBoss extends ChannelInboundHandlerAdapter
             channel.markClosed();
             handler.disconnected( channel );
 
-            if ( !( handler instanceof InitialHandler || handler instanceof PingHandler ) )
+            if ( !( handler instanceof PingHandler ) )
             {
-                ProxyServer.getInstance().getLogger().log( Level.INFO, "{0} has disconnected", handler );
+                if ( handler instanceof InitialHandler )
+                {
+                    InitialHandler initialHandler = (InitialHandler) handler;
+                    if ( initialHandler.getDisconnectMessage() != null )
+                    {
+                        ProxyServer.getInstance().getLogger().log( Level.INFO, "{0} has disconnected: {1}", new Object[]
+                        {
+                            handler, initialHandler.getDisconnectMessage().toPlainText()
+                        } );
+                    }
+                } else
+                {
+                    ProxyServer.getInstance().getLogger().log( Level.INFO, "{0} has disconnected", handler );
+                }
             }
         }
     }


### PR DESCRIPTION
closes https://github.com/SpigotMC/BungeeCord/pull/3279

The code should be self explaining.
I added a field for the disconnect message, so the HandlerBoss can print this message.

- Why?
Because i hate it if i can't see why a connections are getting disconnected, especially when the server gets attacked.
