### PR TITLE
Add ProtocolChangedEvent to the API

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/event/ProtocolChangedEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/ProtocolChangedEvent.java
@@ -1,0 +1,47 @@
+package net.md_5.bungee.api.event;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import net.md_5.bungee.api.connection.Connection;
+import net.md_5.bungee.api.plugin.Event;
+import net.md_5.bungee.protocol.Protocol;
+
+/**
+ * Called when the encode or decode protocol of a {@link Connection} is changed.
+ */
+@Getter
+@ToString(callSuper = false)
+@EqualsAndHashCode(callSuper = false)
+@AllArgsConstructor
+public class ProtocolChangedEvent extends Event
+{
+
+    /**
+     * The old protocol.
+     */
+    private Protocol oldProtocol;
+
+    /**
+     * The new protocol.
+     */
+    private Protocol newProtocol;
+
+    /**
+     * The connection whose protocol is being changed.
+     */
+    private Connection connection;
+
+    /**
+     * The direction of the changed protocol.
+     * encode or decode
+     */
+    private Direction direction;
+
+    public enum Direction
+    {
+        ENCODE,
+        DECODE
+    }
+}

--- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
@@ -36,6 +36,7 @@ import net.md_5.bungee.api.config.ServerInfo;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.connection.Server;
 import net.md_5.bungee.api.event.PluginMessageEvent;
+import net.md_5.bungee.api.event.ProtocolChangedEvent;
 import net.md_5.bungee.api.event.ServerConnectEvent;
 import net.md_5.bungee.api.event.ServerDisconnectEvent;
 import net.md_5.bungee.api.event.ServerKickEvent;
@@ -144,6 +145,12 @@ public class DownstreamBridge extends PacketHandler
             rewrite.rewriteClientbound( packet.buf, con.getServerEntityId(), con.getClientEntityId(), con.getPendingConnection().getVersion() );
         }
         con.sendPacket( packet );
+    }
+
+    @Override
+    public void protocolChanged(ChannelWrapper channel, Protocol oldProtocol, Protocol newProtocol, ProtocolChangedEvent.Direction direction)
+    {
+        bungee.getPluginManager().callEvent( new ProtocolChangedEvent( oldProtocol, newProtocol, server, direction ) );
     }
 
     @Override

--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -36,6 +36,7 @@ import net.md_5.bungee.api.event.LoginEvent;
 import net.md_5.bungee.api.event.PlayerHandshakeEvent;
 import net.md_5.bungee.api.event.PostLoginEvent;
 import net.md_5.bungee.api.event.PreLoginEvent;
+import net.md_5.bungee.api.event.ProtocolChangedEvent;
 import net.md_5.bungee.api.event.ProxyPingEvent;
 import net.md_5.bungee.api.event.ServerConnectEvent;
 import net.md_5.bungee.http.HttpClient;
@@ -153,6 +154,12 @@ public class InitialHandler extends PacketHandler implements PendingConnection
         {
             throw new QuietException( "Unexpected packet received during login process! " + BufUtil.dump( packet.buf, 16 ) );
         }
+    }
+
+    @Override
+    public void protocolChanged(ChannelWrapper channel, Protocol oldProtocol, Protocol newProtocol, ProtocolChangedEvent.Direction direction)
+    {
+        bungee.getPluginManager().callEvent( new ProtocolChangedEvent( oldProtocol, newProtocol, this, direction ) );
     }
 
     @Override

--- a/proxy/src/main/java/net/md_5/bungee/connection/PingHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/PingHandler.java
@@ -9,6 +9,7 @@ import net.md_5.bungee.api.Callback;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.ServerPing;
 import net.md_5.bungee.api.config.ServerInfo;
+import net.md_5.bungee.api.event.ProtocolChangedEvent;
 import net.md_5.bungee.netty.ChannelWrapper;
 import net.md_5.bungee.netty.PacketHandler;
 import net.md_5.bungee.netty.PipelineUtils;
@@ -59,6 +60,12 @@ public class PingHandler extends PacketHandler
         {
             throw new QuietException( "Unexpected packet received during ping process! " + BufUtil.dump( packet.buf, 16 ) );
         }
+    }
+
+    @Override
+    public void protocolChanged(ChannelWrapper channel, Protocol oldProtocol, Protocol newProtocol, ProtocolChangedEvent.Direction direction)
+    {
+        BungeeCord.getInstance().getPluginManager().callEvent( new ProtocolChangedEvent( oldProtocol, newProtocol, this, direction ) );
     }
 
     @Override

--- a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
@@ -19,6 +19,7 @@ import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.event.ChatEvent;
 import net.md_5.bungee.api.event.PlayerDisconnectEvent;
 import net.md_5.bungee.api.event.PluginMessageEvent;
+import net.md_5.bungee.api.event.ProtocolChangedEvent;
 import net.md_5.bungee.api.event.SettingsChangedEvent;
 import net.md_5.bungee.api.event.TabCompleteEvent;
 import net.md_5.bungee.entitymap.EntityMap;
@@ -151,6 +152,12 @@ public class UpstreamBridge extends PacketHandler
             }
             server.getCh().write( packet );
         }
+    }
+
+    @Override
+    public void protocolChanged(ChannelWrapper channel, Protocol oldProtocol, Protocol newProtocol, ProtocolChangedEvent.Direction direction)
+    {
+        BungeeCord.getInstance().getPluginManager().callEvent( new ProtocolChangedEvent( oldProtocol, newProtocol, con, direction ) );
     }
 
     @Override

--- a/proxy/src/main/java/net/md_5/bungee/netty/ChannelWrapper.java
+++ b/proxy/src/main/java/net/md_5/bungee/netty/ChannelWrapper.java
@@ -9,6 +9,7 @@ import java.net.SocketAddress;
 import java.util.concurrent.TimeUnit;
 import lombok.Getter;
 import lombok.Setter;
+import net.md_5.bungee.api.event.ProtocolChangedEvent;
 import net.md_5.bungee.compress.PacketCompressor;
 import net.md_5.bungee.compress.PacketDecompressor;
 import net.md_5.bungee.protocol.DefinedPacket;
@@ -43,7 +44,13 @@ public class ChannelWrapper
 
     public void setDecodeProtocol(Protocol protocol)
     {
+        Protocol oldProtocol = getDecodeProtocol();
         ch.pipeline().get( MinecraftDecoder.class ).setProtocol( protocol );
+        HandlerBoss handlerBoss = ch.pipeline().get( HandlerBoss.class );
+        if ( oldProtocol != protocol && handlerBoss != null )
+        {
+            handlerBoss.getHandler().protocolChanged( this, oldProtocol, protocol, ProtocolChangedEvent.Direction.DECODE );
+        }
     }
 
     public Protocol getEncodeProtocol()
@@ -54,7 +61,13 @@ public class ChannelWrapper
 
     public void setEncodeProtocol(Protocol protocol)
     {
+        Protocol oldProtocol = getEncodeProtocol();
         ch.pipeline().get( MinecraftEncoder.class ).setProtocol( protocol );
+        HandlerBoss handlerBoss = ch.pipeline().get( HandlerBoss.class );
+        if ( oldProtocol != protocol && handlerBoss != null )
+        {
+            handlerBoss.getHandler().protocolChanged( this, oldProtocol, protocol, ProtocolChangedEvent.Direction.ENCODE );
+        }
     }
 
     public void setProtocol(Protocol protocol)

--- a/proxy/src/main/java/net/md_5/bungee/netty/HandlerBoss.java
+++ b/proxy/src/main/java/net/md_5/bungee/netty/HandlerBoss.java
@@ -10,6 +10,8 @@ import io.netty.handler.timeout.ReadTimeoutException;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.logging.Level;
+import lombok.AccessLevel;
+import lombok.Getter;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.connection.CancelSendSignal;
 import net.md_5.bungee.connection.InitialHandler;
@@ -29,6 +31,7 @@ public class HandlerBoss extends ChannelInboundHandlerAdapter
 {
 
     private ChannelWrapper channel;
+    @Getter(AccessLevel.PACKAGE)
     private PacketHandler handler;
 
     public void setHandler(PacketHandler handler)

--- a/proxy/src/main/java/net/md_5/bungee/netty/PacketHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/netty/PacketHandler.java
@@ -1,6 +1,8 @@
 package net.md_5.bungee.netty;
 
+import net.md_5.bungee.api.event.ProtocolChangedEvent;
 import net.md_5.bungee.protocol.PacketWrapper;
+import net.md_5.bungee.protocol.Protocol;
 
 public abstract class PacketHandler extends net.md_5.bungee.protocol.AbstractPacketHandler
 {
@@ -31,5 +33,10 @@ public abstract class PacketHandler extends net.md_5.bungee.protocol.AbstractPac
 
     public void writabilityChanged(ChannelWrapper channel) throws Exception
     {
+    }
+
+    public void protocolChanged(ChannelWrapper channel, Protocol oldProtocol, Protocol newProtocol, ProtocolChangedEvent.Direction direction)
+    {
+
     }
 }


### PR DESCRIPTION
ProtocolChangedEvent  is called when the encode or decode protocol of any Connection is changed.

We now can detect if a 1.20.4 player is changing protocol to config or play via API, but it is also possible to detect if the InitialHandler changes protocol from Handshake to Status or Login