### PR TITLE
fix: inverted isEmpty method on ComponentStyle

### DIFF
--- a/chat/src/main/java/net/md_5/bungee/api/chat/ComponentStyle.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/ComponentStyle.java
@@ -186,15 +186,15 @@ public final class ComponentStyle implements Cloneable
     }
 
     /**
-     * Returns whether this style has any formatting explicitly set.
+     * Returns whether this style has no formatting explicitly set.
      *
-     * @return true if at least one value is set, false if none are set
+     * @return true if no value is set, false if at least one is set
      */
     public boolean isEmpty()
     {
-        return color != null || font != null || bold != null
-                || italic != null || underlined != null
-                || strikethrough != null || obfuscated != null;
+        return color == null && font == null && bold == null
+                && italic == null && underlined == null
+                && strikethrough == null && obfuscated == null;
     }
 
     @Override

--- a/chat/src/test/java/net/md_5/bungee/api/chat/ComponentsTest.java
+++ b/chat/src/test/java/net/md_5/bungee/api/chat/ComponentsTest.java
@@ -835,6 +835,18 @@ public class ComponentsTest
         assertTrue( component.hasFormatting() );
     }
 
+    @Test
+    public void testStyleIsEmpty()
+    {
+        ComponentStyle style = ComponentStyle.builder().build();
+        assertTrue( style.isEmpty() );
+
+        style = ComponentStyle.builder()
+            .bold( true )
+            .build();
+        assertFalse( style.isEmpty() );
+    }
+
     /*
      * In legacy chat, colors and reset both reset all formatting.
      * Make sure it works in combination with ComponentBuilder.

--- a/chat/src/test/java/net/md_5/bungee/api/chat/ComponentsTest.java
+++ b/chat/src/test/java/net/md_5/bungee/api/chat/ComponentsTest.java
@@ -825,6 +825,16 @@ public class ComponentsTest
         );
     }
 
+    @Test
+    public void testHasFormatting()
+    {
+        BaseComponent component = new TextComponent();
+        assertFalse( component.hasFormatting() );
+
+        component.setBold( true );
+        assertTrue( component.hasFormatting() );
+    }
+
     /*
      * In legacy chat, colors and reset both reset all formatting.
      * Make sure it works in combination with ComponentBuilder.


### PR DESCRIPTION
Fixes #3610
Relates to #3569 and 737d545fb60523bd7deafd5551f06615c0b87f0e

cc @2008Choco 