### PR TITLE
Introducing: ProxyInitializeEvent

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/event/ProxyInitializeEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/ProxyInitializeEvent.java
@@ -2,7 +2,8 @@ package net.md_5.bungee.api.event;
 
 import net.md_5.bungee.api.plugin.Event;
 
-public class ProxyInitializeEvent extends Event {
+public class ProxyInitializeEvent extends Event
+{
 
     private final boolean isListening;
 
@@ -10,11 +11,13 @@ public class ProxyInitializeEvent extends Event {
      * Constructor
      * @param isListening Is Proxy Listening? (Did desired game-port open?)
      */
-    public ProxyInitializeEvent(boolean isListening) {
+    public ProxyInitializeEvent(boolean isListening)
+    {
         this.isListening = isListening;
     }
 
-    public boolean isListening() {
+    public boolean isListening()
+    {
         return this.isListening;
     }
 }

--- a/api/src/main/java/net/md_5/bungee/api/event/ProxyInitializeEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/ProxyInitializeEvent.java
@@ -1,0 +1,20 @@
+package net.md_5.bungee.api.event;
+
+import net.md_5.bungee.api.plugin.Event;
+
+public class ProxyInitializeEvent extends Event {
+
+    private final boolean isListening;
+
+    /**
+     * Constructor
+     * @param isListening Is Proxy Listening? (Did desired game-port open?)
+     */
+    public ProxyInitializeEvent(boolean isListening) {
+        this.isListening = isListening;
+    }
+
+    public boolean isListening() {
+        return this.isListening;
+    }
+}

--- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
@@ -375,7 +375,7 @@ public class BungeeCord extends ProxyServer
                     @Override
                     public void operationComplete(ChannelFuture future) throws Exception
                     {
-                        getPluginManager().callEvent(new ProxyInitializeEvent(future.isSuccess()));
+                        getPluginManager().callEvent( new ProxyInitializeEvent( future.isSuccess() ) );
                         if ( future.isSuccess() )
                         {
                             listeners.add( future.channel() );

--- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
@@ -68,6 +68,7 @@ import net.md_5.bungee.api.config.ConfigurationAdapter;
 import net.md_5.bungee.api.config.ListenerInfo;
 import net.md_5.bungee.api.config.ServerInfo;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
+import net.md_5.bungee.api.event.ProxyInitializeEvent;
 import net.md_5.bungee.api.plugin.Plugin;
 import net.md_5.bungee.api.plugin.PluginManager;
 import net.md_5.bungee.chat.ComponentSerializer;
@@ -374,6 +375,7 @@ public class BungeeCord extends ProxyServer
                     @Override
                     public void operationComplete(ChannelFuture future) throws Exception
                     {
+                        getPluginManager().callEvent(new ProxyInitializeEvent(future.isSuccess()));
                         if ( future.isSuccess() )
                         {
                             listeners.add( future.channel() );


### PR DESCRIPTION
# What did I add?
I added a new event called "ProxyInitializeEvent" which gets called after the future of the listener completes.

# What does it do?
The Event is fired and reports the state of the proxy to registered plugins. This means that one can now know when the proxy is actually "ready" to accept players / when its safe to get a response from the proxy.

For further questions, feel free to contact me :)