### PR TITLE
Only serialize color that color is actually present

### DIFF
--- a/chat/src/main/java/net/md_5/bungee/chat/ComponentStyleSerializer.java
+++ b/chat/src/main/java/net/md_5/bungee/chat/ComponentStyleSerializer.java
@@ -62,7 +62,7 @@ public class ComponentStyleSerializer implements JsonSerializer<ComponentStyle>,
         {
             object.addProperty( "obfuscated", style.isObfuscatedRaw() );
         }
-        if ( style.hasColor() )
+        if ( style.hasColor() && style.getColor() != ChatColor.RESET )
         {
             object.addProperty( "color", style.getColor().getName() );
         }

--- a/chat/src/main/java/net/md_5/bungee/chat/ComponentStyleSerializer.java
+++ b/chat/src/main/java/net/md_5/bungee/chat/ComponentStyleSerializer.java
@@ -62,7 +62,7 @@ public class ComponentStyleSerializer implements JsonSerializer<ComponentStyle>,
         {
             object.addProperty( "obfuscated", style.isObfuscatedRaw() );
         }
-        if ( style.hasColor() && style.getColor() != ChatColor.RESET )
+        if ( style.hasColor() && style.getColor().getColor() != null )
         {
             object.addProperty( "color", style.getColor().getName() );
         }


### PR DESCRIPTION
Since 1.20.3/4, Minecraft cannot parse json with color `reset` (or any other that is not a color) set. It will just throw `Invalid chat component: Invalid color name: reset` strictly, making some plugins that trying to set component color to reset causing errors.