### PR TITLE
Revert "Add check for '.' and '-' characters in usernames"

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/util/AllowedCharacters.java
+++ b/proxy/src/main/java/net/md_5/bungee/util/AllowedCharacters.java
@@ -17,7 +17,7 @@ public final class AllowedCharacters
     {
         if ( onlineMode )
         {
-            return ( c >= 'a' && c <= 'z' ) || ( c >= '0' && c <= '9' ) || ( c >= 'A' && c <= 'Z' ) || c == '_' || c == '.' || c == '-';
+            return ( c >= 'a' && c <= 'z' ) || ( c >= '0' && c <= '9' ) || ( c >= 'A' && c <= 'Z' ) || c == '_';
         } else
         {
             // Don't allow spaces, Yaml config doesn't support them


### PR DESCRIPTION
i think we can revert this change, as i understand, after my report on jira mojang removed all names with . and - and renamed them to tempuser, All names ever where an example are removed now

https://bugs.mojang.com/browse/MC-255284

https://de.namemc.com/profile/tempusername006.1
https://de.namemc.com/profile/tempusername032.1
https://de.namemc.com/profile/tempusername013.1
https://de.namemc.com/profile/Sengangaren.2

Mojang obviously doesnt want to support these name so we also should not