### PR TITLE
Keep ChatColor unset in conversion to legacy

### DIFF
--- a/chat/src/main/java/net/md_5/bungee/api/chat/BaseComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/BaseComponent.java
@@ -665,7 +665,10 @@ public abstract class BaseComponent
 
     void addFormat(StringBuilder builder)
     {
-        builder.append( getColor() );
+        if ( style.hasColor() || parent != null )
+        {
+            builder.append( getColor() );
+        }
         if ( isBold() )
         {
             builder.append( ChatColor.BOLD );

--- a/chat/src/test/java/net/md_5/bungee/api/chat/ComponentsTest.java
+++ b/chat/src/test/java/net/md_5/bungee/api/chat/ComponentsTest.java
@@ -560,30 +560,6 @@ public class ComponentsTest
     }
 
     @Test
-    public void testTranslateComponent()
-    {
-        TranslatableComponent item = new TranslatableComponent( "item.swordGold.name" );
-        item.setColor( AQUA );
-        TranslatableComponent component = new TranslatableComponent( "commands.give.success", item, "5",
-                "thinkofdeath" );
-
-        assertEquals( "Given Golden Sword * 5 to thinkofdeath", component.toPlainText() );
-        assertEquals( "Given " + AQUA + "Golden Sword * " + WHITE + "5 to " + WHITE + "thinkofdeath", component.toLegacyText() );
-
-        BaseComponent legacyColorTest = new ComponentBuilder( "Test " ).color( RED ).append( component ).build();
-        assertEquals( RED + "Test " + RED + "Given " + AQUA + "Golden Sword" + RED + " * " + RED + "5" + RED + " to "
-                        + RED + "thinkofdeath", legacyColorTest.toLegacyText() );
-
-        TranslatableComponent positional = new TranslatableComponent( "book.pageIndicator", "5", "50" );
-
-        assertEquals( "Page 5 of 50", positional.toPlainText() );
-        assertEquals( "Page " + WHITE + "5 of " + WHITE + "50", positional.toLegacyText() );
-
-        TranslatableComponent one_four_two = new TranslatableComponent( "filled_map.buried_treasure" );
-        assertEquals( "Buried Treasure Map", one_four_two.toPlainText() );
-    }
-
-    @Test
     public void testBuilderCreate()
     {
         this.testBuilder(

--- a/chat/src/test/java/net/md_5/bungee/api/chat/ComponentsTest.java
+++ b/chat/src/test/java/net/md_5/bungee/api/chat/ComponentsTest.java
@@ -1,5 +1,6 @@
 package net.md_5.bungee.api.chat;
 
+import static net.md_5.bungee.api.ChatColor.*;
 import static org.junit.jupiter.api.Assertions.*;
 import java.awt.Color;
 import java.util.function.BiFunction;
@@ -7,7 +8,6 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.ObjIntConsumer;
 import java.util.function.Supplier;
-import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.chat.hover.content.Entity;
 import net.md_5.bungee.api.chat.hover.content.Text;
 import net.md_5.bungee.chat.ComponentSerializer;
@@ -137,9 +137,9 @@ public class ComponentsTest
     {
         ComponentBuilder builder = new ComponentBuilder();
         assertNotNull( builder.getCurrentComponent() );
-        builder.color( ChatColor.GREEN );
+        builder.color( GREEN );
         builder.append( "test ", ComponentBuilder.FormatRetention.ALL );
-        assertEquals( builder.getCurrentComponent().getColor(), ChatColor.GREEN );
+        assertEquals( builder.getCurrentComponent().getColor(), GREEN );
     }
 
     @Test
@@ -176,8 +176,16 @@ public class ComponentsTest
     @Test
     public void testToLegacyFromLegacy()
     {
-        String text = "§a§lHello §f§kworld§7!";
+        String text = "" + GREEN + BOLD + "Hello " + WHITE + MAGIC + "world" + GRAY + "!";
         assertEquals( text, TextComponent.toLegacyText( TextComponent.fromLegacyText( text ) ) );
+    }
+
+    @Test
+    public void testNoColorComponent()
+    {
+        String json = "{\"text\":\"Hello World\"}";
+        BaseComponent[] components = ComponentSerializer.parse( json );
+        assertEquals( "Hello World", BaseComponent.toLegacyText( components ) );
     }
 
     @Test
@@ -218,7 +226,7 @@ public class ComponentsTest
     @Test
     public void testLegacyComponentBuilderAppend()
     {
-        String text = "§a§lHello §r§kworld§7!";
+        String text = "" + GREEN + BOLD + "Hello " + RESET + MAGIC + "world" + GRAY + "!";
         BaseComponent[] components = TextComponent.fromLegacyText( text );
         BaseComponent[] builderComponents = new ComponentBuilder().append( components ).create();
         assertArrayEquals( components, builderComponents );
@@ -350,7 +358,7 @@ public class ComponentsTest
     {
         TextComponent first = new TextComponent( "Hello" );
         first.setBold( true );
-        first.setColor( ChatColor.RED );
+        first.setColor( RED );
         first.setClickEvent( new ClickEvent( ClickEvent.Action.RUN_COMMAND, "test" ) );
         first.setHoverEvent( hoverEventSupplier.get() );
 
@@ -376,7 +384,7 @@ public class ComponentsTest
 
     private void testBuilderClone(Function<ComponentBuilder, String> legacyTextFunction)
     {
-        ComponentBuilder builder = new ComponentBuilder( "Hello " ).color( ChatColor.RED ).append( "world" ).color( ChatColor.DARK_RED );
+        ComponentBuilder builder = new ComponentBuilder( "Hello " ).color( RED ).append( "world" ).color( DARK_RED );
         ComponentBuilder cloned = new ComponentBuilder( builder );
 
         assertEquals( legacyTextFunction.apply( builder ), legacyTextFunction.apply( cloned ) );
@@ -448,7 +456,7 @@ public class ComponentsTest
                 ComponentBuilder::create,
                 (components, index) -> components[index],
                 BaseComponent::toPlainText,
-                ChatColor.YELLOW + "Hello " + ChatColor.GREEN + "world!",
+                YELLOW + "Hello " + GREEN + "world!",
                 BaseComponent::toLegacyText
         );
     }
@@ -461,8 +469,7 @@ public class ComponentsTest
                 ComponentBuilder::build,
                 (component, index) -> component.getExtra().get( index ),
                 (component) -> BaseComponent.toPlainText( component ),
-                // An extra format code is appended to the beginning because there is an empty TextComponent at the start of every component
-                ChatColor.WHITE.toString() + ChatColor.YELLOW + "Hello " + ChatColor.GREEN + "world!",
+                YELLOW + "Hello " + GREEN + "world!",
                 (component) -> BaseComponent.toLegacyText( component )
         );
     }
@@ -472,8 +479,9 @@ public class ComponentsTest
         ClickEvent clickEvent = new ClickEvent( ClickEvent.Action.RUN_COMMAND, "/help " );
         HoverEvent hoverEvent = hoverEventSupplier.get();
 
-        ComponentBuilder builder = new ComponentBuilder( "Hello " ).color( ChatColor.YELLOW );
-        builder.append( new ComponentBuilder( "world!" ).color( ChatColor.GREEN ).event( hoverEvent ).event( clickEvent ).create() ); // Intentionally using create() to append multiple individual components
+        ComponentBuilder builder = new ComponentBuilder( "Hello " ).color( YELLOW );
+        // Intentionally using create() to append multiple individual components
+        builder.append( new ComponentBuilder( "world!" ).color( GREEN ).event( hoverEvent ).event( clickEvent ).create() );
 
         T component = componentBuilder.apply( builder );
 
@@ -489,7 +497,7 @@ public class ComponentsTest
         this.testBuilderAppendLegacy(
                 ComponentBuilder::create,
                 BaseComponent::toPlainText,
-                ChatColor.YELLOW + "Hello " + ChatColor.GREEN + "world!",
+                YELLOW + "Hello " + GREEN + "world!",
                 BaseComponent::toLegacyText
         );
     }
@@ -500,16 +508,15 @@ public class ComponentsTest
         this.testBuilderAppendLegacy(
                 ComponentBuilder::build,
                 (component) -> BaseComponent.toPlainText( component ),
-                // An extra format code is appended to the beginning because there is an empty TextComponent at the start of every component
-                ChatColor.WHITE.toString() + ChatColor.YELLOW + "Hello " + ChatColor.GREEN + "world!",
+                YELLOW + "Hello " + GREEN + "world!",
                 (component) -> BaseComponent.toLegacyText( component )
         );
     }
 
     private <T> void testBuilderAppendLegacy(Function<ComponentBuilder, T> componentBuilder, Function<T, String> toPlainTextFunction, String expectedLegacyString, Function<T, String> toLegacyTextFunction)
     {
-        ComponentBuilder builder = new ComponentBuilder( "Hello " ).color( ChatColor.YELLOW );
-        builder.appendLegacy( "§aworld!" );
+        ComponentBuilder builder = new ComponentBuilder( "Hello " ).color( YELLOW );
+        builder.appendLegacy( GREEN + "world!" );
 
         T component = componentBuilder.apply( builder );
 
@@ -521,26 +528,25 @@ public class ComponentsTest
     public void testBasicComponent()
     {
         TextComponent textComponent = new TextComponent( "Hello world" );
-        textComponent.setColor( ChatColor.RED );
+        textComponent.setColor( RED );
 
         assertEquals( "Hello world", textComponent.toPlainText() );
-        assertEquals( ChatColor.RED + "Hello world", textComponent.toLegacyText() );
+        assertEquals( RED + "Hello world", textComponent.toLegacyText() );
     }
 
     @Test
     public void testLegacyConverter()
     {
-        BaseComponent[] test1 = TextComponent.fromLegacyText( ChatColor.AQUA + "Aqua " + ChatColor.RED + ChatColor.BOLD + "RedBold" );
+        BaseComponent[] test1 = TextComponent.fromLegacyText( AQUA + "Aqua " + RED + BOLD + "RedBold" );
 
         assertEquals( "Aqua RedBold", BaseComponent.toPlainText( test1 ) );
-        assertEquals( ChatColor.AQUA + "Aqua " + ChatColor.RED + ChatColor.BOLD + "RedBold", BaseComponent.toLegacyText( test1 ) );
+        assertEquals( AQUA + "Aqua " + RED + BOLD + "RedBold", BaseComponent.toLegacyText( test1 ) );
 
-        BaseComponent[] test2 = TextComponent.fromLegacyText( "Text http://spigotmc.org " + ChatColor.GREEN + "google.com/test" );
+        BaseComponent[] test2 = TextComponent.fromLegacyText( "Text http://spigotmc.org " + GREEN + "google.com/test" );
 
         assertEquals( "Text http://spigotmc.org google.com/test", BaseComponent.toPlainText( test2 ) );
         //The extra ChatColor instances are sometimes inserted when not needed but it doesn't change the result
-        assertEquals( ChatColor.WHITE + "Text " + ChatColor.WHITE + "http://spigotmc.org" + ChatColor.WHITE
-                + " " + ChatColor.GREEN + "google.com/test" + ChatColor.GREEN, BaseComponent.toLegacyText( test2 ) );
+        assertEquals( "Text http://spigotmc.org " + GREEN + "google.com/test" + GREEN, BaseComponent.toLegacyText( test2 ) );
 
         ClickEvent url1 = test2[1].getClickEvent();
         assertNotNull( url1 );
@@ -557,20 +563,21 @@ public class ComponentsTest
     public void testTranslateComponent()
     {
         TranslatableComponent item = new TranslatableComponent( "item.swordGold.name" );
-        item.setColor( ChatColor.AQUA );
-        TranslatableComponent translatableComponent = new TranslatableComponent( "commands.give.success",
-                item, "5",
+        item.setColor( AQUA );
+        TranslatableComponent component = new TranslatableComponent( "commands.give.success", item, "5",
                 "thinkofdeath" );
 
-        assertEquals( "Given Golden Sword * 5 to thinkofdeath", translatableComponent.toPlainText() );
-        assertEquals( ChatColor.WHITE + "Given " + ChatColor.AQUA + "Golden Sword" + ChatColor.WHITE
-                + " * " + ChatColor.WHITE + "5" + ChatColor.WHITE + " to " + ChatColor.WHITE + "thinkofdeath",
-                translatableComponent.toLegacyText() );
+        assertEquals( "Given Golden Sword * 5 to thinkofdeath", component.toPlainText() );
+        assertEquals( "Given " + AQUA + "Golden Sword * " + WHITE + "5 to " + WHITE + "thinkofdeath", component.toLegacyText() );
+
+        BaseComponent legacyColorTest = new ComponentBuilder( "Test " ).color( RED ).append( component ).build();
+        assertEquals( RED + "Test " + RED + "Given " + AQUA + "Golden Sword" + RED + " * " + RED + "5" + RED + " to "
+                        + RED + "thinkofdeath", legacyColorTest.toLegacyText() );
 
         TranslatableComponent positional = new TranslatableComponent( "book.pageIndicator", "5", "50" );
 
         assertEquals( "Page 5 of 50", positional.toPlainText() );
-        assertEquals( ChatColor.WHITE + "Page " + ChatColor.WHITE + "5" + ChatColor.WHITE + " of " + ChatColor.WHITE + "50", positional.toLegacyText() );
+        assertEquals( "Page " + WHITE + "5 of " + WHITE + "50", positional.toLegacyText() );
 
         TranslatableComponent one_four_two = new TranslatableComponent( "filled_map.buried_treasure" );
         assertEquals( "Buried Treasure Map", one_four_two.toPlainText() );
@@ -582,7 +589,7 @@ public class ComponentsTest
         this.testBuilder(
                 ComponentBuilder::create,
                 BaseComponent::toPlainText,
-                ChatColor.RED + "Hello " + ChatColor.BLUE + ChatColor.BOLD + "World" + ChatColor.YELLOW + ChatColor.BOLD + "!",
+                RED + "Hello " + BLUE + BOLD + "World" + YELLOW + BOLD + "!",
                 BaseComponent::toLegacyText
         );
     }
@@ -593,17 +600,15 @@ public class ComponentsTest
         this.testBuilder(
                 ComponentBuilder::build,
                 (component) -> BaseComponent.toPlainText( component ),
-                // An extra format code is appended to the beginning because there is an empty TextComponent at the start of every component
-                ChatColor.WHITE.toString() + ChatColor.RED + "Hello " + ChatColor.BLUE + ChatColor.BOLD + "World" + ChatColor.YELLOW + ChatColor.BOLD + "!",
+                RED + "Hello " + BLUE + BOLD + "World" + YELLOW + BOLD + "!",
                 (component) -> BaseComponent.toLegacyText( component )
         );
     }
 
     private <T> void testBuilder(Function<ComponentBuilder, T> componentBuilder, Function<T, String> toPlainTextFunction, String expectedLegacyString, Function<T, String> toLegacyTextFunction)
     {
-        T component = componentBuilder.apply( new ComponentBuilder( "Hello " ).color( ChatColor.RED ).
-                append( "World" ).bold( true ).color( ChatColor.BLUE ).
-                append( "!" ).color( ChatColor.YELLOW ) );
+        T component = componentBuilder.apply( new ComponentBuilder( "Hello " ).color( RED ).append( "World" )
+                .bold( true ).color( BLUE ).append( "!" ).color( YELLOW ) );
 
         assertEquals( "Hello World!", toPlainTextFunction.apply( component ) );
         assertEquals( expectedLegacyString, toLegacyTextFunction.apply( component ) );
@@ -629,11 +634,10 @@ public class ComponentsTest
 
     private <T> void testBuilderReset(Function<ComponentBuilder, T> componentBuilder, BiFunction<T, Integer, BaseComponent> extraGetter)
     {
-        T component = componentBuilder.apply( new ComponentBuilder( "Hello " ).color( ChatColor.RED )
-                .append( "World" ).reset() );
+        T component = componentBuilder.apply( new ComponentBuilder( "Hello " ).color( RED ).append( "World" ).reset() );
 
-        assertEquals( ChatColor.RED, extraGetter.apply( component, 0 ).getColor() );
-        assertEquals( ChatColor.WHITE, extraGetter.apply( component, 1 ).getColor() );
+        assertEquals( RED, extraGetter.apply( component, 0 ).getColor() );
+        assertEquals( WHITE, extraGetter.apply( component, 1 ).getColor() );
     }
 
     @Test
@@ -656,31 +660,31 @@ public class ComponentsTest
 
     private <T> void testBuilderFormatRetention(Function<ComponentBuilder, T> componentBuilder, BiFunction<T, Integer, BaseComponent> extraGetter)
     {
-        T noneRetention = componentBuilder.apply( new ComponentBuilder( "Hello " ).color( ChatColor.RED )
+        T noneRetention = componentBuilder.apply( new ComponentBuilder( "Hello " ).color( RED )
                 .append( "World", ComponentBuilder.FormatRetention.NONE ) );
 
-        assertEquals( ChatColor.RED, extraGetter.apply( noneRetention, 0 ).getColor() );
-        assertEquals( ChatColor.WHITE, extraGetter.apply( noneRetention, 1 ).getColor() );
+        assertEquals( RED, extraGetter.apply( noneRetention, 0 ).getColor() );
+        assertEquals( WHITE, extraGetter.apply( noneRetention, 1 ).getColor() );
 
         HoverEvent testEvent = new HoverEvent( HoverEvent.Action.SHOW_TEXT, new Text( new ComponentBuilder( "test" ).build() ) );
 
-        T formattingRetention = componentBuilder.apply( new ComponentBuilder( "Hello " ).color( ChatColor.RED )
-                .event( testEvent ).append( "World", ComponentBuilder.FormatRetention.FORMATTING ) );
+        T formattingRetention = componentBuilder.apply( new ComponentBuilder( "Hello " ).color( RED ).event( testEvent )
+                .append( "World", ComponentBuilder.FormatRetention.FORMATTING ) );
 
-        assertEquals( ChatColor.RED, extraGetter.apply( formattingRetention, 0 ).getColor() );
+        assertEquals( RED, extraGetter.apply( formattingRetention, 0 ).getColor() );
         assertEquals( testEvent, extraGetter.apply( formattingRetention, 0 ).getHoverEvent() );
-        assertEquals( ChatColor.RED, extraGetter.apply( formattingRetention, 1 ).getColor() );
+        assertEquals( RED, extraGetter.apply( formattingRetention, 1 ).getColor() );
         assertNull( extraGetter.apply( formattingRetention, 1 ).getHoverEvent() );
 
         ClickEvent testClickEvent = new ClickEvent( ClickEvent.Action.OPEN_URL, "http://www.example.com" );
 
-        T eventRetention = componentBuilder.apply( new ComponentBuilder( "Hello " ).color( ChatColor.RED )
-                .event( testEvent ).event( testClickEvent ).append( "World", ComponentBuilder.FormatRetention.EVENTS ) );
+        T eventRetention = componentBuilder.apply( new ComponentBuilder( "Hello " ).color( RED ).event( testEvent )
+                .event( testClickEvent ).append( "World", ComponentBuilder.FormatRetention.EVENTS ) );
 
-        assertEquals( ChatColor.RED, extraGetter.apply( eventRetention, 0 ).getColor() );
+        assertEquals( RED, extraGetter.apply( eventRetention, 0 ).getColor() );
         assertEquals( testEvent, extraGetter.apply( eventRetention, 0 ).getHoverEvent() );
         assertEquals( testClickEvent, extraGetter.apply( eventRetention, 0 ).getClickEvent() );
-        assertEquals( ChatColor.WHITE, extraGetter.apply( eventRetention, 1 ).getColor() );
+        assertEquals( WHITE, extraGetter.apply( eventRetention, 1 ).getColor() );
         assertEquals( testEvent, extraGetter.apply( eventRetention, 1 ).getHoverEvent() );
         assertEquals( testClickEvent, extraGetter.apply( eventRetention, 1 ).getClickEvent() );
     }
@@ -698,9 +702,9 @@ public class ComponentsTest
     {
         TextComponent a = new TextComponent( "A" );
         TextComponent b = new TextComponent( "B" );
-        b.setColor( ChatColor.AQUA );
+        b.setColor( AQUA );
         TextComponent c = new TextComponent( "C" );
-        c.setColor( ChatColor.RED );
+        c.setColor( RED );
         a.addExtra( b );
         b.addExtra( c );
         c.addExtra( a );
@@ -712,7 +716,7 @@ public class ComponentsTest
     {
         TextComponent a = new TextComponent( "A" );
         TextComponent b = new TextComponent( "B" );
-        b.setColor( ChatColor.AQUA );
+        b.setColor( AQUA );
         a.addExtra( b );
         a.addExtra( b );
         ComponentSerializer.toString( a );
@@ -723,9 +727,9 @@ public class ComponentsTest
     {
         TextComponent a = new TextComponent( "A" );
         TextComponent b = new TextComponent( "B" );
-        b.setColor( ChatColor.AQUA );
+        b.setColor( AQUA );
         TextComponent c = new TextComponent( "C" );
-        c.setColor( ChatColor.RED );
+        c.setColor( RED );
         a.addExtra( b );
         a.addExtra( c );
         c.addExtra( a );
@@ -741,15 +745,15 @@ public class ComponentsTest
         // collect all invalid color codes (e.g. §z, §g, ...)
         for ( char alphChar : "0123456789abcdefghijklmnopqrstuvwxyz".toCharArray() )
         {
-            if ( ChatColor.ALL_CODES.indexOf( alphChar ) == -1 )
+            if ( ALL_CODES.indexOf( alphChar ) == -1 )
             {
-                allInvalidColorCodes.append( ChatColor.COLOR_CHAR );
+                allInvalidColorCodes.append( COLOR_CHAR );
                 allInvalidColorCodes.append( alphChar );
             }
         }
 
         // last char is a single '§'
-        allInvalidColorCodes.append( ChatColor.COLOR_CHAR );
+        allInvalidColorCodes.append( COLOR_CHAR );
 
         String invalidColorCodesLegacyText = fromAndToLegacyText( allInvalidColorCodes.toString() );
         String emptyLegacyText = fromAndToLegacyText( "" );
@@ -761,10 +765,10 @@ public class ComponentsTest
     @Test
     public void testFormattingOnlyTextConversion()
     {
-        String text = "§a";
+        String text = GREEN.toString();
 
         BaseComponent[] converted = TextComponent.fromLegacyText( text );
-        assertEquals( ChatColor.GREEN, converted[0].getColor() );
+        assertEquals( GREEN, converted[0].getColor() );
 
         String roundtripLegacyText = BaseComponent.toLegacyText( converted );
 
@@ -799,7 +803,7 @@ public class ComponentsTest
     @Test
     public void testLegacyHack()
     {
-        BaseComponent[] hexColored = new ComponentBuilder().color( ChatColor.of( Color.GRAY ) ).append( "Test" ).create();
+        BaseComponent[] hexColored = new ComponentBuilder().color( of( Color.GRAY ) ).append( "Test" ).create();
         String legacy = TextComponent.toLegacyText( hexColored );
 
         BaseComponent[] reColored = TextComponent.fromLegacyText( legacy );
@@ -854,7 +858,7 @@ public class ComponentsTest
     private <T> void testLegacyResetInBuilder(Function<ComponentBuilder, T> componentBuilder, Function<T, String> componentSerializer)
     {
         ComponentBuilder builder = new ComponentBuilder();
-        BaseComponent[] a = TextComponent.fromLegacyText( "§4§n44444§rdd§6§l6666" );
+        BaseComponent[] a = TextComponent.fromLegacyText( "" + DARK_RED + UNDERLINE + "44444" + RESET + "dd" + GOLD + BOLD + "6666" );
 
         String expected = "{\"extra\":[{\"underlined\":true,\"color\":\"dark_red\",\"text\":\"44444\"},{\"color\":"
                 + "\"white\",\"text\":\"dd\"},{\"bold\":true,\"color\":\"gold\",\"text\":\"6666\"}],\"text\":\"\"}";
@@ -865,7 +869,7 @@ public class ComponentsTest
         String test1 = componentSerializer.apply( componentBuilder.apply( builder ) );
         assertEquals( expected, test1 );
 
-        BaseComponent[] b = TextComponent.fromLegacyText( "§rrrrr" );
+        BaseComponent[] b = TextComponent.fromLegacyText( RESET + "rrrr" );
         builder.append( b );
 
         String test2 = componentSerializer.apply( componentBuilder.apply( builder ) );

--- a/chat/src/test/java/net/md_5/bungee/api/chat/TranslatableComponentTest.java
+++ b/chat/src/test/java/net/md_5/bungee/api/chat/TranslatableComponentTest.java
@@ -26,4 +26,28 @@ public class TranslatableComponentTest
         assertEquals( "Test string with a placeholder", BaseComponent.toPlainText( parsed ) );
         assertEquals( "Test string with " + WHITE + "a placeholder", BaseComponent.toLegacyText( parsed ) );
     }
+
+    @Test
+    public void testTranslateComponent()
+    {
+        TranslatableComponent item = new TranslatableComponent( "item.swordGold.name" );
+        item.setColor( AQUA );
+        TranslatableComponent component = new TranslatableComponent( "commands.give.success", item, "5",
+                "thinkofdeath" );
+
+        assertEquals( "Given Golden Sword * 5 to thinkofdeath", component.toPlainText() );
+        assertEquals( "Given " + AQUA + "Golden Sword * " + WHITE + "5 to " + WHITE + "thinkofdeath", component.toLegacyText() );
+
+        BaseComponent legacyColorTest = new ComponentBuilder( "Test " ).color( RED ).append( component ).build();
+        assertEquals( RED + "Test " + RED + "Given " + AQUA + "Golden Sword" + RED + " * " + RED + "5" + RED + " to "
+                + RED + "thinkofdeath", legacyColorTest.toLegacyText() );
+
+        TranslatableComponent positional = new TranslatableComponent( "book.pageIndicator", "5", "50" );
+
+        assertEquals( "Page 5 of 50", positional.toPlainText() );
+        assertEquals( "Page " + WHITE + "5 of " + WHITE + "50", positional.toLegacyText() );
+
+        TranslatableComponent one_four_two = new TranslatableComponent( "filled_map.buried_treasure" );
+        assertEquals( "Buried Treasure Map", one_four_two.toPlainText() );
+    }
 }

--- a/chat/src/test/java/net/md_5/bungee/api/chat/TranslatableComponentTest.java
+++ b/chat/src/test/java/net/md_5/bungee/api/chat/TranslatableComponentTest.java
@@ -1,5 +1,6 @@
 package net.md_5.bungee.api.chat;
 
+import static net.md_5.bungee.api.ChatColor.*;
 import static org.junit.jupiter.api.Assertions.*;
 import net.md_5.bungee.chat.ComponentSerializer;
 import org.junit.jupiter.api.Test;
@@ -12,17 +13,17 @@ public class TranslatableComponentTest
     {
         TranslatableComponent testComponent = new TranslatableComponent( "Test string with %s placeholders: %s", 2, "aoeu" );
         assertEquals( "Test string with 2 placeholders: aoeu", testComponent.toPlainText() );
-        assertEquals( "§fTest string with §f2§f placeholders: §faoeu", testComponent.toLegacyText() );
+        assertEquals( "Test string with " + WHITE + "2 placeholders: " + WHITE + "aoeu", testComponent.toLegacyText() );
     }
 
     @Test
     public void testJsonSerialisation()
     {
-        TranslatableComponent testComponent = new TranslatableComponent( "Test string with %s placeholder", "a" );
-        String jsonString = ComponentSerializer.toString( testComponent );
-        BaseComponent[] baseComponents = ComponentSerializer.parse( jsonString );
+        TranslatableComponent translatable = new TranslatableComponent( "Test string with %s placeholder", "a" );
+        String jsonString = ComponentSerializer.toString( translatable );
+        BaseComponent[] parsed = ComponentSerializer.parse( jsonString );
 
-        assertEquals( "Test string with a placeholder", TextComponent.toPlainText( baseComponents ) );
-        assertEquals( "§fTest string with §fa§f placeholder", TextComponent.toLegacyText( baseComponents ) );
+        assertEquals( "Test string with a placeholder", BaseComponent.toPlainText( parsed ) );
+        assertEquals( "Test string with " + WHITE + "a placeholder", BaseComponent.toLegacyText( parsed ) );
     }
 }


### PR DESCRIPTION
This PR introduces the suggested change in #3623 and improves test case code and changes the test cases affected by this change of removing unneccessary color codes in legacy output.

This PR has a slight unwanted side effect when converting uncolored translatable components with styled parameters to legacy - in these cases the style of the parameter will stay after the styled parameter ends.

Should we fix that with special casing in transable component somehow and what would be the best way of doing so?