### PR TITLE
PostLoginEvent override target server and change to AsyncEvent

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/event/PostLoginEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/PostLoginEvent.java
@@ -3,8 +3,9 @@ package net.md_5.bungee.api.event;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import net.md_5.bungee.api.Callback;
+import net.md_5.bungee.api.config.ServerInfo;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
-import net.md_5.bungee.api.plugin.Event;
 
 /**
  * Event called as soon as a connection has a {@link ProxiedPlayer} and is ready
@@ -13,11 +14,22 @@ import net.md_5.bungee.api.plugin.Event;
 @Data
 @ToString(callSuper = false)
 @EqualsAndHashCode(callSuper = false)
-public class PostLoginEvent extends Event
+public class PostLoginEvent extends AsyncEvent<PostLoginEvent>
 {
 
     /**
      * The player involved with this event.
      */
     private final ProxiedPlayer player;
+
+    /**
+     * The overriden target server to send the player to on first join
+     */
+    private ServerInfo targetServer;
+
+    public PostLoginEvent(ProxiedPlayer player, Callback<PostLoginEvent> done)
+    {
+        super( done );
+        this.player = player;
+    }
 }


### PR DESCRIPTION
This PR allows developers to easily override the target server the player is connecting to, rather than making the developer listen to ServerConnect event - checking if the server the player is on is null, and then setting the server. 

Making it asynchronous also allows developers to call external API's to determine what server to connect the player to. 

This would make it easier for developers to connect the player to the target sharded hub server.