### PR TITLE
Optimize chat

### DIFF
--- a/chat/src/main/java/net/md_5/bungee/api/ChatColor.java
+++ b/chat/src/main/java/net/md_5/bungee/api/ChatColor.java
@@ -244,7 +244,7 @@ public final class ChatColor
     public static ChatColor of(String string)
     {
         Preconditions.checkArgument( string != null, "string cannot be null" );
-        if ( string.startsWith( "#" ) && string.length() == 7 )
+        if ( string.length() == 7 && string.charAt( 0 ) == '#' )
         {
             int rgb;
             try

--- a/chat/src/main/java/net/md_5/bungee/chat/BaseComponentSerializer.java
+++ b/chat/src/main/java/net/md_5/bungee/chat/BaseComponentSerializer.java
@@ -23,59 +23,62 @@ public class BaseComponentSerializer
     {
         component.applyStyle( context.deserialize( object, ComponentStyle.class ) );
 
-        if ( object.has( "insertion" ) )
+        JsonElement insertion = object.get( "insertion" );
+        if ( insertion != null )
         {
-            component.setInsertion( object.get( "insertion" ).getAsString() );
+            component.setInsertion( insertion.getAsString() );
         }
 
         //Events
-        if ( object.has( "clickEvent" ) )
+        JsonObject clickEvent = object.getAsJsonObject( "clickEvent" );
+        if ( clickEvent != null )
         {
-            JsonObject event = object.getAsJsonObject( "clickEvent" );
             component.setClickEvent( new ClickEvent(
-                    ClickEvent.Action.valueOf( event.get( "action" ).getAsString().toUpperCase( Locale.ROOT ) ),
-                    ( event.has( "value" ) ) ? event.get( "value" ).getAsString() : "" ) );
+                    ClickEvent.Action.valueOf( clickEvent.get( "action" ).getAsString().toUpperCase( Locale.ROOT ) ),
+                    ( clickEvent.has( "value" ) ) ? clickEvent.get( "value" ).getAsString() : "" ) );
         }
-        if ( object.has( "hoverEvent" ) )
+        JsonObject hoverEventJson = object.getAsJsonObject( "hoverEvent" );
+        if ( hoverEventJson != null )
         {
-            JsonObject event = object.getAsJsonObject( "hoverEvent" );
             HoverEvent hoverEvent = null;
-            HoverEvent.Action action = HoverEvent.Action.valueOf( event.get( "action" ).getAsString().toUpperCase( Locale.ROOT ) );
+            HoverEvent.Action action = HoverEvent.Action.valueOf( hoverEventJson.get( "action" ).getAsString().toUpperCase( Locale.ROOT ) );
 
-            if ( event.has( "value" ) )
+            JsonElement value = hoverEventJson.get( "value" );
+            if ( value != null )
             {
-                JsonElement contents = event.get( "value" );
 
                 // Plugins previously had support to pass BaseComponent[] into any action.
                 // If the GSON is possible to be parsed as BaseComponent, attempt to parse as so.
                 BaseComponent[] components;
-                if ( contents.isJsonArray() )
+                if ( value.isJsonArray() )
                 {
-                    components = context.deserialize( contents, BaseComponent[].class );
+                    components = context.deserialize( value, BaseComponent[].class );
                 } else
                 {
                     components = new BaseComponent[]
                     {
-                        context.deserialize( contents, BaseComponent.class )
+                        context.deserialize( value, BaseComponent.class )
                     };
                 }
                 hoverEvent = new HoverEvent( action, components );
-            } else if ( event.has( "contents" ) )
+            } else
             {
-                JsonElement contents = event.get( "contents" );
-
-                Content[] list;
-                if ( contents.isJsonArray() )
+                JsonElement contents = hoverEventJson.get( "contents" );
+                if ( contents != null )
                 {
-                    list = context.deserialize( contents, HoverEvent.getClass( action, true ) );
-                } else
-                {
-                    list = new Content[]
+                    Content[] list;
+                    if ( contents.isJsonArray() )
                     {
-                        context.deserialize( contents, HoverEvent.getClass( action, false ) )
-                    };
+                        list = context.deserialize( contents, HoverEvent.getClass( action, true ) );
+                    } else
+                    {
+                        list = new Content[]
+                        {
+                                context.deserialize( contents, HoverEvent.getClass( action, false ) )
+                        };
+                    }
+                    hoverEvent = new HoverEvent( action, new ArrayList<>( Arrays.asList( list ) ) );
                 }
-                hoverEvent = new HoverEvent( action, new ArrayList<>( Arrays.asList( list ) ) );
             }
 
             if ( hoverEvent != null )
@@ -84,9 +87,10 @@ public class BaseComponentSerializer
             }
         }
 
-        if ( object.has( "extra" ) )
+        JsonElement extra = object.get( "extra" );
+        if ( extra != null )
         {
-            component.setExtra( Arrays.asList( context.<BaseComponent[]>deserialize( object.get( "extra" ), BaseComponent[].class ) ) );
+            component.setExtra( Arrays.asList( context.deserialize( extra, BaseComponent[].class ) ) );
         }
     }
 

--- a/chat/src/main/java/net/md_5/bungee/chat/ComponentSerializer.java
+++ b/chat/src/main/java/net/md_5/bungee/chat/ComponentSerializer.java
@@ -20,6 +20,7 @@ import net.md_5.bungee.api.chat.ScoreComponent;
 import net.md_5.bungee.api.chat.SelectorComponent;
 import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.api.chat.TranslatableComponent;
+import net.md_5.bungee.api.chat.hover.content.Content;
 import net.md_5.bungee.api.chat.hover.content.Entity;
 import net.md_5.bungee.api.chat.hover.content.EntitySerializer;
 import net.md_5.bungee.api.chat.hover.content.Item;
@@ -161,6 +162,16 @@ public class ComponentSerializer implements JsonDeserializer<BaseComponent>
     public static String toString(Object object)
     {
         return gson.toJson( object );
+    }
+
+    public static String toString(Content content)
+    {
+        return gson.toJson( content );
+    }
+
+    public static String toString(JsonElement element)
+    {
+        return gson.toJson( element );
     }
 
     public static String toString(BaseComponent component)

--- a/chat/src/main/java/net/md_5/bungee/chat/ComponentStyleSerializer.java
+++ b/chat/src/main/java/net/md_5/bungee/chat/ComponentStyleSerializer.java
@@ -9,6 +9,7 @@ import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 import java.lang.reflect.Type;
+import java.util.Map;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.chat.ComponentStyle;
 import net.md_5.bungee.api.chat.ComponentStyleBuilder;
@@ -77,33 +78,34 @@ public class ComponentStyleSerializer implements JsonSerializer<ComponentStyle>,
     {
         ComponentStyleBuilder builder = ComponentStyle.builder();
         JsonObject object = json.getAsJsonObject();
-        if ( object.has( "bold" ) )
+        for ( Map.Entry<String, JsonElement> entry : object.entrySet() )
         {
-            builder.bold( getAsBoolean( object.get( "bold" ) ) );
-        }
-        if ( object.has( "italic" ) )
-        {
-            builder.italic( getAsBoolean( object.get( "italic" ) ) );
-        }
-        if ( object.has( "underlined" ) )
-        {
-            builder.underlined( getAsBoolean( object.get( "underlined" ) ) );
-        }
-        if ( object.has( "strikethrough" ) )
-        {
-            builder.strikethrough( getAsBoolean( object.get( "strikethrough" ) ) );
-        }
-        if ( object.has( "obfuscated" ) )
-        {
-            builder.obfuscated( getAsBoolean( object.get( "obfuscated" ) ) );
-        }
-        if ( object.has( "color" ) )
-        {
-            builder.color( ChatColor.of( object.get( "color" ).getAsString() ) );
-        }
-        if ( object.has( "font" ) )
-        {
-            builder.font( object.get( "font" ).getAsString() );
+            String name = entry.getKey();
+            JsonElement value = entry.getValue();
+            switch ( name )
+            {
+                case "bold":
+                    builder.bold( getAsBoolean( value ) );
+                    break;
+                case "italic":
+                    builder.italic( getAsBoolean( value ) );
+                    break;
+                case "underlined":
+                    builder.underlined( getAsBoolean( value ) );
+                    break;
+                case "strikethrough":
+                    builder.strikethrough( getAsBoolean( value ) );
+                    break;
+                case "obfuscated":
+                    builder.obfuscated( getAsBoolean( value ) );
+                    break;
+                case "color":
+                    builder.color( ChatColor.of( value.getAsString() ) );
+                    break;
+                case "font":
+                    builder.font( value.getAsString() );
+                    break;
+            }
         }
         return builder.build();
     }

--- a/chat/src/main/java/net/md_5/bungee/chat/KeybindComponentSerializer.java
+++ b/chat/src/main/java/net/md_5/bungee/chat/KeybindComponentSerializer.java
@@ -17,13 +17,14 @@ public class KeybindComponentSerializer extends BaseComponentSerializer implemen
     public KeybindComponent deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException
     {
         JsonObject object = json.getAsJsonObject();
-        if ( !object.has( "keybind" ) )
+        JsonElement keybind = object.get( "keybind" );
+        if ( keybind == null )
         {
             throw new JsonParseException( "Could not parse JSON: missing 'keybind' property" );
         }
         KeybindComponent component = new KeybindComponent();
         deserialize( object, component, context );
-        component.setKeybind( object.get( "keybind" ).getAsString() );
+        component.setKeybind( keybind.getAsString() );
         return component;
     }
 

--- a/chat/src/main/java/net/md_5/bungee/chat/ScoreComponentSerializer.java
+++ b/chat/src/main/java/net/md_5/bungee/chat/ScoreComponentSerializer.java
@@ -17,22 +17,29 @@ public class ScoreComponentSerializer extends BaseComponentSerializer implements
     public ScoreComponent deserialize(JsonElement element, Type type, JsonDeserializationContext context) throws JsonParseException
     {
         JsonObject json = element.getAsJsonObject();
-        if ( !json.has( "score" ) )
+        JsonObject score = json.getAsJsonObject( "score" );
+        if ( score == null )
         {
             throw new JsonParseException( "Could not parse JSON: missing 'score' property" );
         }
-        JsonObject score = json.get( "score" ).getAsJsonObject();
-        if ( !score.has( "name" ) || !score.has( "objective" ) )
+        JsonElement nameJson = score.get( "name" );
+        if ( nameJson == null )
+        {
+            throw new JsonParseException( "A score component needs at least a name (and an objective)" );
+        }
+        JsonElement objectiveJson = score.get( "objective" );
+        if ( objectiveJson == null )
         {
             throw new JsonParseException( "A score component needs at least a name and an objective" );
         }
 
-        String name = score.get( "name" ).getAsString();
-        String objective = score.get( "objective" ).getAsString();
+        String name = nameJson.getAsString();
+        String objective = objectiveJson.getAsString();
         ScoreComponent component = new ScoreComponent( name, objective );
-        if ( score.has( "value" ) && !score.get( "value" ).getAsString().isEmpty() )
+        JsonElement value = score.get( "value" );
+        if ( value != null && !value.getAsString().isEmpty() )
         {
-            component.setValue( score.get( "value" ).getAsString() );
+            component.setValue( value.getAsString() );
         }
 
         deserialize( json, component, context );

--- a/chat/src/main/java/net/md_5/bungee/chat/SelectorComponentSerializer.java
+++ b/chat/src/main/java/net/md_5/bungee/chat/SelectorComponentSerializer.java
@@ -17,15 +17,17 @@ public class SelectorComponentSerializer extends BaseComponentSerializer impleme
     public SelectorComponent deserialize(JsonElement element, Type type, JsonDeserializationContext context) throws JsonParseException
     {
         JsonObject object = element.getAsJsonObject();
-        if ( !object.has( "selector" ) )
+        JsonElement selector = object.get( "selector" );
+        if ( selector == null )
         {
             throw new JsonParseException( "Could not parse JSON: missing 'selector' property" );
         }
-        SelectorComponent component = new SelectorComponent( object.get( "selector" ).getAsString() );
+        SelectorComponent component = new SelectorComponent( selector.getAsString() );
 
-        if ( object.has( "separator" ) )
+        JsonElement separator = object.get( "separator" );
+        if ( separator != null )
         {
-            component.setSeparator( ComponentSerializer.deserialize( object.get( "separator" ).getAsString() ) );
+            component.setSeparator( ComponentSerializer.deserialize( separator.getAsString() ) );
         }
 
         deserialize( object, component, context );

--- a/chat/src/main/java/net/md_5/bungee/chat/TextComponentSerializer.java
+++ b/chat/src/main/java/net/md_5/bungee/chat/TextComponentSerializer.java
@@ -18,9 +18,10 @@ public class TextComponentSerializer extends BaseComponentSerializer implements 
     {
         TextComponent component = new TextComponent();
         JsonObject object = json.getAsJsonObject();
-        if ( object.has( "text" ) )
+        JsonElement text = object.get( "text" );
+        if ( text != null )
         {
-            component.setText( object.get( "text" ).getAsString() );
+            component.setText( text.getAsString() );
         }
         deserialize( object, component, context );
         return component;

--- a/chat/src/main/java/net/md_5/bungee/chat/TranslatableComponentSerializer.java
+++ b/chat/src/main/java/net/md_5/bungee/chat/TranslatableComponentSerializer.java
@@ -21,18 +21,21 @@ public class TranslatableComponentSerializer extends BaseComponentSerializer imp
         TranslatableComponent component = new TranslatableComponent();
         JsonObject object = json.getAsJsonObject();
         deserialize( object, component, context );
-        if ( !object.has( "translate" ) )
+        JsonElement translate = object.get( "translate" );
+        if ( translate == null )
         {
             throw new JsonParseException( "Could not parse JSON: missing 'translate' property" );
         }
-        component.setTranslate( object.get( "translate" ).getAsString() );
-        if ( object.has( "with" ) )
+        component.setTranslate( translate.getAsString() );
+        JsonElement with = object.get( "with" );
+        if ( with != null )
         {
-            component.setWith( Arrays.asList( context.deserialize( object.get( "with" ), BaseComponent[].class ) ) );
+            component.setWith( Arrays.asList( context.deserialize( with, BaseComponent[].class ) ) );
         }
-        if ( object.has( "fallback" ) )
+        JsonElement fallback = object.get( "fallback" );
+        if ( fallback != null )
         {
-            component.setFallback( object.get( "fallback" ).getAsString() );
+            component.setFallback( fallback.getAsString() );
         }
         return component;
     }

--- a/chat/src/test/java/net/md_5/bungee/api/chat/ComponentsTest.java
+++ b/chat/src/test/java/net/md_5/bungee/api/chat/ComponentsTest.java
@@ -20,14 +20,14 @@ public class ComponentsTest
     {
         String json = ComponentSerializer.toString( components );
         BaseComponent[] parsed = ComponentSerializer.parse( json );
-        assertEquals( TextComponent.toLegacyText( parsed ), TextComponent.toLegacyText( components ) );
+        assertEquals( BaseComponent.toLegacyText( parsed ), BaseComponent.toLegacyText( components ) );
     }
 
     public static void testDissembleReassemble(BaseComponent component)
     {
         String json = ComponentSerializer.toString( component );
         BaseComponent[] parsed = ComponentSerializer.parse( json );
-        assertEquals( TextComponent.toLegacyText( parsed ), TextComponent.toLegacyText( component ) );
+        assertEquals( BaseComponent.toLegacyText( parsed ), BaseComponent.toLegacyText( component ) );
     }
 
     public static void testAssembleDissemble(String json, boolean modern)
@@ -177,7 +177,7 @@ public class ComponentsTest
     public void testToLegacyFromLegacy()
     {
         String text = "§a§lHello §f§kworld§7!";
-        assertEquals( text, TextComponent.toLegacyText( TextComponent.fromLegacyText( text ) ) );
+        assertEquals( text, BaseComponent.toLegacyText( TextComponent.fromLegacyText( text ) ) );
     }
 
     @Test
@@ -337,16 +337,16 @@ public class ComponentsTest
     @Test
     public void testFormatRetentionCopyFormattingCreate()
     {
-        this.testFormatRetentionCopyFormatting( () -> new HoverEvent( HoverEvent.Action.SHOW_TEXT, new ComponentBuilder( "Test" ).create() ) );
+        ComponentsTest.testFormatRetentionCopyFormatting( () -> new HoverEvent( HoverEvent.Action.SHOW_TEXT, new ComponentBuilder( "Test" ).create() ) );
     }
 
     @Test
     public void testFormatRetentionCopyFormattingBuild()
     {
-        this.testFormatRetentionCopyFormatting( () -> new HoverEvent( HoverEvent.Action.SHOW_TEXT, new Text( new ComponentBuilder( "Test" ).build() ) ) );
+        testFormatRetentionCopyFormatting( () -> new HoverEvent( HoverEvent.Action.SHOW_TEXT, new Text( new ComponentBuilder( "Test" ).build() ) ) );
     }
 
-    private void testFormatRetentionCopyFormatting(Supplier<HoverEvent> hoverEventSupplier)
+    private static void testFormatRetentionCopyFormatting(Supplier<HoverEvent> hoverEventSupplier)
     {
         TextComponent first = new TextComponent( "Hello" );
         first.setBold( true );
@@ -365,16 +365,16 @@ public class ComponentsTest
     @Test
     public void testBuilderCloneCreate()
     {
-        this.testBuilderClone( (builder) -> TextComponent.toLegacyText( builder.create() ) );
+        testBuilderClone( (builder) -> BaseComponent.toLegacyText( builder.create() ) );
     }
 
     @Test
     public void testBuilderCloneBuild()
     {
-        this.testBuilderClone( (builder) -> TextComponent.toLegacyText( builder.build() ) );
+        testBuilderClone( (builder) -> BaseComponent.toLegacyText( builder.build() ) );
     }
 
-    private void testBuilderClone(Function<ComponentBuilder, String> legacyTextFunction)
+    private static void testBuilderClone(Function<ComponentBuilder, String> legacyTextFunction)
     {
         ComponentBuilder builder = new ComponentBuilder( "Hello " ).color( ChatColor.RED ).append( "world" ).color( ChatColor.DARK_RED );
         ComponentBuilder cloned = new ComponentBuilder( builder );
@@ -385,7 +385,7 @@ public class ComponentsTest
     @Test
     public void testBuilderAppendCreateMixedComponents()
     {
-        this.testBuilderAppendMixedComponents(
+        testBuilderAppendMixedComponents(
                 ComponentBuilder::create,
                 (components, index) -> components[index]
         );
@@ -394,13 +394,13 @@ public class ComponentsTest
     @Test
     public void testBuilderAppendBuildMixedComponents()
     {
-        this.testBuilderAppendMixedComponents(
+        testBuilderAppendMixedComponents(
                 ComponentBuilder::build,
                 (component, index) -> component.getExtra().get( index )
         );
     }
 
-    private <T> void testBuilderAppendMixedComponents(Function<ComponentBuilder, T> componentBuilder, BiFunction<T, Integer, BaseComponent> extraGetter)
+    private static <T> void testBuilderAppendMixedComponents(Function<ComponentBuilder, T> componentBuilder, BiFunction<T, Integer, BaseComponent> extraGetter)
     {
         ComponentBuilder builder = new ComponentBuilder( "Hello " );
         TextComponent textComponent = new TextComponent( "world " );
@@ -443,7 +443,7 @@ public class ComponentsTest
     @Test
     public void testBuilderAppendCreate()
     {
-        this.testBuilderAppend(
+        testBuilderAppend(
                 () -> new HoverEvent( HoverEvent.Action.SHOW_TEXT, new ComponentBuilder( "Hello world" ).create() ),
                 ComponentBuilder::create,
                 (components, index) -> components[index],
@@ -456,7 +456,7 @@ public class ComponentsTest
     @Test
     public void testBuilderAppendBuild()
     {
-        this.testBuilderAppend(
+        testBuilderAppend(
                 () -> new HoverEvent( HoverEvent.Action.SHOW_TEXT, new Text( new ComponentBuilder( "Hello world" ).build() ) ),
                 ComponentBuilder::build,
                 (component, index) -> component.getExtra().get( index ),
@@ -467,7 +467,7 @@ public class ComponentsTest
         );
     }
 
-    private <T> void testBuilderAppend(Supplier<HoverEvent> hoverEventSupplier, Function<ComponentBuilder, T> componentBuilder, BiFunction<T, Integer, BaseComponent> extraGetter, Function<T, String> toPlainTextFunction, String expectedLegacyText, Function<T, String> toLegacyTextFunction)
+    private static <T> void testBuilderAppend(Supplier<HoverEvent> hoverEventSupplier, Function<ComponentBuilder, T> componentBuilder, BiFunction<T, Integer, BaseComponent> extraGetter, Function<T, String> toPlainTextFunction, String expectedLegacyText, Function<T, String> toLegacyTextFunction)
     {
         ClickEvent clickEvent = new ClickEvent( ClickEvent.Action.RUN_COMMAND, "/help " );
         HoverEvent hoverEvent = hoverEventSupplier.get();
@@ -486,7 +486,7 @@ public class ComponentsTest
     @Test
     public void testBuilderAppendLegacyCreate()
     {
-        this.testBuilderAppendLegacy(
+        testBuilderAppendLegacy(
                 ComponentBuilder::create,
                 BaseComponent::toPlainText,
                 ChatColor.YELLOW + "Hello " + ChatColor.GREEN + "world!",
@@ -497,7 +497,7 @@ public class ComponentsTest
     @Test
     public void testBuilderAppendLegacyBuild()
     {
-        this.testBuilderAppendLegacy(
+        testBuilderAppendLegacy(
                 ComponentBuilder::build,
                 (component) -> BaseComponent.toPlainText( component ),
                 // An extra format code is appended to the beginning because there is an empty TextComponent at the start of every component
@@ -506,7 +506,7 @@ public class ComponentsTest
         );
     }
 
-    private <T> void testBuilderAppendLegacy(Function<ComponentBuilder, T> componentBuilder, Function<T, String> toPlainTextFunction, String expectedLegacyString, Function<T, String> toLegacyTextFunction)
+    private static <T> void testBuilderAppendLegacy(Function<ComponentBuilder, T> componentBuilder, Function<T, String> toPlainTextFunction, String expectedLegacyString, Function<T, String> toLegacyTextFunction)
     {
         ComponentBuilder builder = new ComponentBuilder( "Hello " ).color( ChatColor.YELLOW );
         builder.appendLegacy( "§aworld!" );
@@ -579,7 +579,7 @@ public class ComponentsTest
     @Test
     public void testBuilderCreate()
     {
-        this.testBuilder(
+        testBuilder(
                 ComponentBuilder::create,
                 BaseComponent::toPlainText,
                 ChatColor.RED + "Hello " + ChatColor.BLUE + ChatColor.BOLD + "World" + ChatColor.YELLOW + ChatColor.BOLD + "!",
@@ -590,7 +590,7 @@ public class ComponentsTest
     @Test
     public void testBuilderBuild()
     {
-        this.testBuilder(
+        testBuilder(
                 ComponentBuilder::build,
                 (component) -> BaseComponent.toPlainText( component ),
                 // An extra format code is appended to the beginning because there is an empty TextComponent at the start of every component
@@ -599,7 +599,7 @@ public class ComponentsTest
         );
     }
 
-    private <T> void testBuilder(Function<ComponentBuilder, T> componentBuilder, Function<T, String> toPlainTextFunction, String expectedLegacyString, Function<T, String> toLegacyTextFunction)
+    private static <T> void testBuilder(Function<ComponentBuilder, T> componentBuilder, Function<T, String> toPlainTextFunction, String expectedLegacyString, Function<T, String> toLegacyTextFunction)
     {
         T component = componentBuilder.apply( new ComponentBuilder( "Hello " ).color( ChatColor.RED ).
                 append( "World" ).bold( true ).color( ChatColor.BLUE ).
@@ -612,7 +612,7 @@ public class ComponentsTest
     @Test
     public void testBuilderCreateReset()
     {
-        this.testBuilderReset(
+        testBuilderReset(
                 ComponentBuilder::create,
                 (components, index) -> components[index]
         );
@@ -621,13 +621,13 @@ public class ComponentsTest
     @Test
     public void testBuilderBuildReset()
     {
-        this.testBuilderReset(
+        testBuilderReset(
                 ComponentBuilder::build,
                 (component, index) -> component.getExtra().get( index )
         );
     }
 
-    private <T> void testBuilderReset(Function<ComponentBuilder, T> componentBuilder, BiFunction<T, Integer, BaseComponent> extraGetter)
+    private static <T> void testBuilderReset(Function<ComponentBuilder, T> componentBuilder, BiFunction<T, Integer, BaseComponent> extraGetter)
     {
         T component = componentBuilder.apply( new ComponentBuilder( "Hello " ).color( ChatColor.RED )
                 .append( "World" ).reset() );
@@ -639,7 +639,7 @@ public class ComponentsTest
     @Test
     public void testBuilderCreateFormatRetention()
     {
-        this.testBuilderFormatRetention(
+        testBuilderFormatRetention(
                 ComponentBuilder::create,
                 (components, index) -> components[index]
         );
@@ -648,13 +648,13 @@ public class ComponentsTest
     @Test
     public void testBuilderBuildFormatRetention()
     {
-        this.testBuilderFormatRetention(
+        testBuilderFormatRetention(
                 ComponentBuilder::build,
                 (component, index) -> component.getExtra().get( index )
         );
     }
 
-    private <T> void testBuilderFormatRetention(Function<ComponentBuilder, T> componentBuilder, BiFunction<T, Integer, BaseComponent> extraGetter)
+    private static <T> void testBuilderFormatRetention(Function<ComponentBuilder, T> componentBuilder, BiFunction<T, Integer, BaseComponent> extraGetter)
     {
         T noneRetention = componentBuilder.apply( new ComponentBuilder( "Hello " ).color( ChatColor.RED )
                 .append( "World", ComponentBuilder.FormatRetention.NONE ) );
@@ -800,7 +800,7 @@ public class ComponentsTest
     public void testLegacyHack()
     {
         BaseComponent[] hexColored = new ComponentBuilder().color( ChatColor.of( Color.GRAY ) ).append( "Test" ).create();
-        String legacy = TextComponent.toLegacyText( hexColored );
+        String legacy = BaseComponent.toLegacyText( hexColored );
 
         BaseComponent[] reColored = TextComponent.fromLegacyText( legacy );
 
@@ -810,7 +810,7 @@ public class ComponentsTest
     @Test
     public void testLegacyResetInBuilderCreate()
     {
-        this.testLegacyResetInBuilder(
+        testLegacyResetInBuilder(
                 ComponentBuilder::create,
                 ComponentSerializer::toString
         );
@@ -819,7 +819,7 @@ public class ComponentsTest
     @Test
     public void testLegacyResetInBuilderBuild()
     {
-        this.testLegacyResetInBuilder(
+        testLegacyResetInBuilder(
                 ComponentBuilder::build,
                 ComponentSerializer::toString
         );
@@ -851,7 +851,7 @@ public class ComponentsTest
      * In legacy chat, colors and reset both reset all formatting.
      * Make sure it works in combination with ComponentBuilder.
      */
-    private <T> void testLegacyResetInBuilder(Function<ComponentBuilder, T> componentBuilder, Function<T, String> componentSerializer)
+    private static <T> void testLegacyResetInBuilder(Function<ComponentBuilder, T> componentBuilder, Function<T, String> componentSerializer)
     {
         ComponentBuilder builder = new ComponentBuilder();
         BaseComponent[] a = TextComponent.fromLegacyText( "§4§n44444§rdd§6§l6666" );

--- a/chat/src/test/java/net/md_5/bungee/api/chat/TranslatableComponentTest.java
+++ b/chat/src/test/java/net/md_5/bungee/api/chat/TranslatableComponentTest.java
@@ -22,7 +22,7 @@ public class TranslatableComponentTest
         String jsonString = ComponentSerializer.toString( testComponent );
         BaseComponent[] baseComponents = ComponentSerializer.parse( jsonString );
 
-        assertEquals( "Test string with a placeholder", TextComponent.toPlainText( baseComponents ) );
-        assertEquals( "§fTest string with §fa§f placeholder", TextComponent.toLegacyText( baseComponents ) );
+        assertEquals( "Test string with a placeholder", BaseComponent.toPlainText( baseComponents ) );
+        assertEquals( "§fTest string with §fa§f placeholder", BaseComponent.toLegacyText( baseComponents ) );
     }
 }

--- a/protocol/src/main/java/net/md_5/bungee/protocol/DefinedPacket.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/DefinedPacket.java
@@ -3,6 +3,7 @@ package net.md_5.bungee.protocol;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufInputStream;
 import io.netty.buffer.ByteBufOutputStream;
@@ -93,17 +94,37 @@ public abstract class DefinedPacket
         return s;
     }
 
-    public static Either<String, BaseComponent> readEitherBaseComponent(ByteBuf buf, int protocolVersion, boolean string)
+    public static Either<String, Deserializable<Either<String, SpecificTag>, BaseComponent>> readEitherBaseComponent(ByteBuf buf, int protocolVersion, boolean string)
     {
         return ( string ) ? Either.left( readString( buf ) ) : Either.right( readBaseComponent( buf, protocolVersion ) );
     }
 
-    public static BaseComponent readBaseComponent(ByteBuf buf, int protocolVersion)
+    public static Deserializable<Either<String, SpecificTag>, BaseComponent> readBaseComponent(ByteBuf buf, int protocolVersion)
     {
         return readBaseComponent( buf, Short.MAX_VALUE, protocolVersion );
     }
 
-    public static BaseComponent readBaseComponent(ByteBuf buf, int maxStringLength, int protocolVersion)
+    public static Deserializable<Either<String, SpecificTag>, BaseComponent> readBaseComponent(ByteBuf buf, int maxStringLength, int protocolVersion)
+    {
+        if ( protocolVersion >= ProtocolConstants.MINECRAFT_1_20_3 )
+        {
+            SpecificTag nbt = (SpecificTag) readTag( buf, protocolVersion );
+
+            return new FunctionDeserializable<>( Either.right( nbt ), (ov) -> ComponentSerializer.deserialize( TagUtil.toJson( ov.getRight() ) ) );
+        } else
+        {
+            String string = readString( buf, maxStringLength );
+
+            return new FunctionDeserializable<>( Either.left( string ), (ov) -> ComponentSerializer.deserialize( ov.getLeft() ) );
+        }
+    }
+
+    public static BaseComponent readRawComponent(ByteBuf buf, int protocolVersion)
+    {
+        return readRawComponent( buf, Short.MAX_VALUE, protocolVersion );
+    }
+
+    public static BaseComponent readRawComponent(ByteBuf buf, int maxStringLength, int protocolVersion)
     {
         if ( protocolVersion >= ProtocolConstants.MINECRAFT_1_20_3 )
         {
@@ -127,7 +148,7 @@ public abstract class DefinedPacket
         return ComponentSerializer.deserializeStyle( json );
     }
 
-    public static void writeEitherBaseComponent(Either<String, BaseComponent> message, ByteBuf buf, int protocolVersion)
+    public static void writeEitherBaseComponent(Either<String, Deserializable<Either<String, SpecificTag>, BaseComponent>> message, ByteBuf buf, int protocolVersion)
     {
         if ( message.isLeft() )
         {
@@ -138,7 +159,56 @@ public abstract class DefinedPacket
         }
     }
 
-    public static void writeBaseComponent(BaseComponent message, ByteBuf buf, int protocolVersion)
+    public static void writeBaseComponent(Deserializable<Either<String, SpecificTag>, BaseComponent> message, ByteBuf buf, int protocolVersion)
+    {
+        if ( protocolVersion >= ProtocolConstants.MINECRAFT_1_20_3 )
+        {
+            if ( message.hasDeserialized() )
+            {
+                BaseComponent baseComponent = message.get();
+                JsonElement json = ComponentSerializer.toJson( baseComponent );
+                SpecificTag nbt = TagUtil.fromJson( json );
+
+                writeTag( nbt, buf, protocolVersion );
+            } else
+            {
+                Either<String, SpecificTag> eitherStrJsonElem = message.original();
+                if ( eitherStrJsonElem.isLeft() )
+                {
+                    writeTag( TagUtil.fromJson( JsonParser.parseString( eitherStrJsonElem.getLeft() ) ), buf, protocolVersion );
+                } else
+                {
+                    writeTag( eitherStrJsonElem.getRight(), buf, protocolVersion );
+                }
+            }
+            JsonElement json = ComponentSerializer.toJson( message.get() );
+            SpecificTag nbt = TagUtil.fromJson( json );
+
+            writeTag( nbt, buf, protocolVersion );
+        } else
+        {
+            if ( message.hasDeserialized() )
+            {
+                String string = ComponentSerializer.toString( message.get() );
+
+                writeString( string, buf );
+            } else
+            {
+                Either<String, SpecificTag> eitherStrJsonElem = message.original();
+                if ( eitherStrJsonElem.isLeft() )
+                {
+                    writeString( eitherStrJsonElem.getLeft(), buf );
+                } else
+                {
+                    String string = ComponentSerializer.toString( TagUtil.toJson( eitherStrJsonElem.getRight() ) );
+
+                    writeString( string, buf );
+                }
+            }
+        }
+    }
+
+    public static void writeRawComponent(BaseComponent message, ByteBuf buf, int protocolVersion)
     {
         if ( protocolVersion >= ProtocolConstants.MINECRAFT_1_20_3 )
         {
@@ -398,7 +468,7 @@ public abstract class DefinedPacket
                 writeComponentStyle( (ComponentStyle) format.getValue(), buf, protocolVersion );
                 break;
             case FIXED:
-                writeBaseComponent( (BaseComponent) format.getValue(), buf, protocolVersion );
+                writeRawComponent( (BaseComponent) format.getValue(), buf, protocolVersion );
                 break;
         }
     }
@@ -413,7 +483,7 @@ public abstract class DefinedPacket
             case 1:
                 return new NumberFormat( NumberFormat.Type.STYLED, readComponentStyle( buf, protocolVersion ) );
             case 2:
-                return new NumberFormat( NumberFormat.Type.FIXED, readBaseComponent( buf, protocolVersion ) );
+                return new NumberFormat( NumberFormat.Type.FIXED, readRawComponent( buf, protocolVersion ) );
             default:
                 throw new IllegalArgumentException( "Unknown number format " + format );
         }

--- a/protocol/src/main/java/net/md_5/bungee/protocol/Deserializable.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/Deserializable.java
@@ -1,0 +1,28 @@
+package net.md_5.bungee.protocol;
+
+/**
+ * Represents a value that can be deserialized from another value if needed.
+ * @param <OV> the original value
+ * @param <D> the deserialized value
+ */
+public interface Deserializable<OV, D>
+{
+    /**
+     * @return the deserialized value
+     */
+    D get();
+
+    /**
+     * If {@link #hasDeserialized()} returns true, this method may return null. This usually hapens after code has
+     * edited the deserialized value and wrote it back to its original place.
+     * @return the original value, if available
+     */
+    OV original();
+
+    /**
+     * If the value has been deserialized, it is adviced to no longer call {@link #original()}, as the deserialized
+     * value may have been modified.
+     * @return true if the value has been deserialized
+     */
+    boolean hasDeserialized();
+}

--- a/protocol/src/main/java/net/md_5/bungee/protocol/FunctionDeserializable.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/FunctionDeserializable.java
@@ -1,0 +1,22 @@
+package net.md_5.bungee.protocol;
+
+import java.util.function.Function;
+import org.jetbrains.annotations.NotNull;
+
+public class FunctionDeserializable<OV, D> extends SimpleDeserializable<OV, D>
+{
+    private final Function<OV, D> function;
+
+    public FunctionDeserializable(OV ov, Function<OV, D> supplier)
+    {
+        super( ov );
+        this.function = supplier;
+    }
+
+    @NotNull
+    @Override
+    public D deserialize()
+    {
+        return function.apply( original() );
+    }
+}

--- a/protocol/src/main/java/net/md_5/bungee/protocol/NoOrigDeserializable.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/NoOrigDeserializable.java
@@ -1,0 +1,27 @@
+package net.md_5.bungee.protocol;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class NoOrigDeserializable<OV, D> implements Deserializable<OV, D>
+{
+    private final D value;
+
+    @Override
+    public D get()
+    {
+        return value;
+    }
+
+    @Override
+    public OV original()
+    {
+        return null;
+    }
+
+    @Override
+    public boolean hasDeserialized()
+    {
+        return true;
+    }
+}

--- a/protocol/src/main/java/net/md_5/bungee/protocol/SimpleDeserializable.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/SimpleDeserializable.java
@@ -1,0 +1,41 @@
+package net.md_5.bungee.protocol;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public abstract class SimpleDeserializable<OV, D> implements Deserializable<OV, D>
+{
+    private final OV original;
+    private D deserialized;
+
+    /**
+     * Method called to get the deserialized value. Called only once unless multiple threads are calling get() at the
+     * same time.
+     * @return the deserialized value
+     */
+    @NonNull
+    protected abstract D deserialize();
+
+    @Override
+    public final D get()
+    {
+        if ( !hasDeserialized() )
+        {
+            return deserialized = deserialize();
+        }
+        return deserialized;
+    }
+
+    @Override
+    public final boolean hasDeserialized()
+    {
+        return deserialized != null;
+    }
+
+    @Override
+    public final OV original()
+    {
+        return original;
+    }
+}

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/BossBar.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/BossBar.java
@@ -8,7 +8,11 @@ import lombok.NoArgsConstructor;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.protocol.AbstractPacketHandler;
 import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.protocol.Deserializable;
+import net.md_5.bungee.protocol.Either;
+import net.md_5.bungee.protocol.NoOrigDeserializable;
 import net.md_5.bungee.protocol.ProtocolConstants;
+import se.llbit.nbt.SpecificTag;
 
 @Data
 @NoArgsConstructor
@@ -18,7 +22,7 @@ public class BossBar extends DefinedPacket
 
     private UUID uuid;
     private int action;
-    private BaseComponent title;
+    private Deserializable<Either<String, SpecificTag>, BaseComponent> title;
     private float health;
     private int color;
     private int division;
@@ -106,5 +110,15 @@ public class BossBar extends DefinedPacket
     public void handle(AbstractPacketHandler handler) throws Exception
     {
         handler.handle( this );
+    }
+
+    public BaseComponent getTitle()
+    {
+        return title.get();
+    }
+
+    public void setTitle(BaseComponent title)
+    {
+        this.title = new NoOrigDeserializable<>( title );
     }
 }

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/Kick.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/Kick.java
@@ -9,8 +9,13 @@ import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.chat.ComponentSerializer;
 import net.md_5.bungee.protocol.AbstractPacketHandler;
 import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.protocol.Deserializable;
+import net.md_5.bungee.protocol.Either;
+import net.md_5.bungee.protocol.FunctionDeserializable;
+import net.md_5.bungee.protocol.NoOrigDeserializable;
 import net.md_5.bungee.protocol.Protocol;
 import net.md_5.bungee.protocol.ProtocolConstants;
+import se.llbit.nbt.SpecificTag;
 
 @Data
 @NoArgsConstructor
@@ -19,17 +24,18 @@ import net.md_5.bungee.protocol.ProtocolConstants;
 public class Kick extends DefinedPacket
 {
 
-    private BaseComponent message;
+    private Deserializable<Either<String, SpecificTag>, BaseComponent> messageRaw;
 
     @Override
     public void read(ByteBuf buf, Protocol protocol, ProtocolConstants.Direction direction, int protocolVersion)
     {
         if ( protocol == Protocol.LOGIN )
         {
-            message = ComponentSerializer.deserialize( readString( buf ) );
+            String json = readString( buf );
+            messageRaw = new FunctionDeserializable<>( Either.left( json ), (ov) -> ComponentSerializer.deserialize( ov.getLeft() ) );
         } else
         {
-            message = readBaseComponent( buf, protocolVersion );
+            messageRaw = readBaseComponent( buf, protocolVersion );
         }
     }
 
@@ -38,10 +44,10 @@ public class Kick extends DefinedPacket
     {
         if ( protocol == Protocol.LOGIN )
         {
-            writeString( ComponentSerializer.toString( message ), buf );
+            writeString( ComponentSerializer.toString( messageRaw.get() ), buf );
         } else
         {
-            writeBaseComponent( message, buf, protocolVersion );
+            writeBaseComponent( messageRaw, buf, protocolVersion );
         }
     }
 
@@ -49,5 +55,20 @@ public class Kick extends DefinedPacket
     public void handle(AbstractPacketHandler handler) throws Exception
     {
         handler.handle( this );
+    }
+
+    public Kick(BaseComponent message)
+    {
+        setMessage( message );
+    }
+
+    public BaseComponent getMessage()
+    {
+        return messageRaw.get();
+    }
+
+    public void setMessage(BaseComponent message)
+    {
+        this.messageRaw = new NoOrigDeserializable<>( message );
     }
 }

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/PlayerListHeaderFooter.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/PlayerListHeaderFooter.java
@@ -8,7 +8,11 @@ import lombok.NoArgsConstructor;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.protocol.AbstractPacketHandler;
 import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.protocol.Deserializable;
+import net.md_5.bungee.protocol.Either;
+import net.md_5.bungee.protocol.NoOrigDeserializable;
 import net.md_5.bungee.protocol.ProtocolConstants;
+import se.llbit.nbt.SpecificTag;
 
 @Data
 @NoArgsConstructor
@@ -17,26 +21,52 @@ import net.md_5.bungee.protocol.ProtocolConstants;
 public class PlayerListHeaderFooter extends DefinedPacket
 {
 
-    private BaseComponent header;
-    private BaseComponent footer;
+    private Deserializable<Either<String, SpecificTag>, BaseComponent> headerRaw;
+    private Deserializable<Either<String, SpecificTag>, BaseComponent> footerRaw;
 
     @Override
     public void read(ByteBuf buf, ProtocolConstants.Direction direction, int protocolVersion)
     {
-        header = readBaseComponent( buf, protocolVersion );
-        footer = readBaseComponent( buf, protocolVersion );
+        headerRaw = readBaseComponent( buf, protocolVersion );
+        footerRaw = readBaseComponent( buf, protocolVersion );
     }
 
     @Override
     public void write(ByteBuf buf, ProtocolConstants.Direction direction, int protocolVersion)
     {
-        writeBaseComponent( header, buf, protocolVersion );
-        writeBaseComponent( footer, buf, protocolVersion );
+        writeBaseComponent( headerRaw, buf, protocolVersion );
+        writeBaseComponent( footerRaw, buf, protocolVersion );
     }
 
     @Override
     public void handle(AbstractPacketHandler handler) throws Exception
     {
         handler.handle( this );
+    }
+
+    public PlayerListHeaderFooter(BaseComponent header, BaseComponent footer)
+    {
+        setHeader( header );
+        setFooter( footer );
+    }
+
+    public BaseComponent getHeader()
+    {
+        return headerRaw.get();
+    }
+
+    public void setHeader(BaseComponent header)
+    {
+        this.headerRaw = new NoOrigDeserializable<>( header );
+    }
+
+    public BaseComponent getFooter()
+    {
+        return footerRaw.get();
+    }
+
+    public void setFooter(BaseComponent footer)
+    {
+        this.footerRaw = new NoOrigDeserializable<>( footer );
     }
 }

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/PlayerListItem.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/PlayerListItem.java
@@ -8,9 +8,13 @@ import lombok.NoArgsConstructor;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.protocol.AbstractPacketHandler;
 import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.protocol.Deserializable;
+import net.md_5.bungee.protocol.Either;
+import net.md_5.bungee.protocol.NoOrigDeserializable;
 import net.md_5.bungee.protocol.PlayerPublicKey;
 import net.md_5.bungee.protocol.Property;
 import net.md_5.bungee.protocol.ProtocolConstants;
+import se.llbit.nbt.SpecificTag;
 
 @Data
 @NoArgsConstructor
@@ -39,7 +43,7 @@ public class PlayerListItem extends DefinedPacket
                     item.ping = DefinedPacket.readVarInt( buf );
                     if ( buf.readBoolean() )
                     {
-                        item.displayName = DefinedPacket.readBaseComponent( buf, protocolVersion );
+                        item.displayNameRaw = DefinedPacket.readBaseComponent( buf, protocolVersion );
                     }
                     if ( protocolVersion >= ProtocolConstants.MINECRAFT_1_19 )
                     {
@@ -55,7 +59,7 @@ public class PlayerListItem extends DefinedPacket
                 case UPDATE_DISPLAY_NAME:
                     if ( buf.readBoolean() )
                     {
-                        item.displayName = DefinedPacket.readBaseComponent( buf, protocolVersion );
+                        item.displayNameRaw = DefinedPacket.readBaseComponent( buf, protocolVersion );
                     }
             }
         }
@@ -76,10 +80,10 @@ public class PlayerListItem extends DefinedPacket
                     DefinedPacket.writeProperties( item.properties, buf );
                     DefinedPacket.writeVarInt( item.gamemode, buf );
                     DefinedPacket.writeVarInt( item.ping, buf );
-                    buf.writeBoolean( item.displayName != null );
-                    if ( item.displayName != null )
+                    buf.writeBoolean( item.displayNameRaw != null );
+                    if ( item.displayNameRaw != null )
                     {
-                        DefinedPacket.writeBaseComponent( item.displayName, buf, protocolVersion );
+                        DefinedPacket.writeBaseComponent( item.displayNameRaw, buf, protocolVersion );
                     }
                     if ( protocolVersion >= ProtocolConstants.MINECRAFT_1_19 )
                     {
@@ -93,10 +97,10 @@ public class PlayerListItem extends DefinedPacket
                     DefinedPacket.writeVarInt( item.ping, buf );
                     break;
                 case UPDATE_DISPLAY_NAME:
-                    buf.writeBoolean( item.displayName != null );
-                    if ( item.displayName != null )
+                    buf.writeBoolean( item.displayNameRaw != null );
+                    if ( item.displayNameRaw != null )
                     {
-                        DefinedPacket.writeBaseComponent( item.displayName, buf, protocolVersion );
+                        DefinedPacket.writeBaseComponent( item.displayNameRaw, buf, protocolVersion );
                     }
                     break;
             }
@@ -143,7 +147,16 @@ public class PlayerListItem extends DefinedPacket
         Integer ping;
 
         // ADD_PLAYER & UPDATE_DISPLAY_NAME
-        BaseComponent displayName;
+        Deserializable<Either<String, SpecificTag>, BaseComponent> displayNameRaw;
 
+        public BaseComponent getDisplayName()
+        {
+            return displayNameRaw.get();
+        }
+
+        public void setDisplayName(BaseComponent displayName)
+        {
+            this.displayNameRaw = new NoOrigDeserializable<>( displayName );
+        }
     }
 }

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/PlayerListItemUpdate.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/PlayerListItemUpdate.java
@@ -58,7 +58,7 @@ public class PlayerListItemUpdate extends DefinedPacket
                     case UPDATE_DISPLAY_NAME:
                         if ( buf.readBoolean() )
                         {
-                            item.displayName = DefinedPacket.readBaseComponent( buf, protocolVersion );
+                            item.displayNameRaw = DefinedPacket.readBaseComponent( buf, protocolVersion );
                         }
                         break;
                 }
@@ -103,10 +103,10 @@ public class PlayerListItemUpdate extends DefinedPacket
                         DefinedPacket.writeVarInt( item.ping, buf );
                         break;
                     case UPDATE_DISPLAY_NAME:
-                        buf.writeBoolean( item.displayName != null );
-                        if ( item.displayName != null )
+                        buf.writeBoolean( item.displayNameRaw != null );
+                        if ( item.displayNameRaw != null )
                         {
-                            DefinedPacket.writeBaseComponent( item.displayName, buf, protocolVersion );
+                            DefinedPacket.writeBaseComponent( item.displayNameRaw, buf, protocolVersion );
                         }
                         break;
                 }

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/ScoreboardObjective.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/ScoreboardObjective.java
@@ -9,9 +9,12 @@ import lombok.NoArgsConstructor;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.protocol.AbstractPacketHandler;
 import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.protocol.Deserializable;
 import net.md_5.bungee.protocol.Either;
+import net.md_5.bungee.protocol.NoOrigDeserializable;
 import net.md_5.bungee.protocol.NumberFormat;
 import net.md_5.bungee.protocol.ProtocolConstants;
+import se.llbit.nbt.SpecificTag;
 
 @Data
 @NoArgsConstructor
@@ -21,8 +24,8 @@ public class ScoreboardObjective extends DefinedPacket
 {
 
     private String name;
-    private Either<String, BaseComponent> value;
     private HealthDisplay type;
+    private Either<String, Deserializable<Either<String, SpecificTag>, BaseComponent>> valueRaw;
     /**
      * 0 to create, 1 to remove, 2 to update display text.
      */
@@ -38,11 +41,11 @@ public class ScoreboardObjective extends DefinedPacket
         {
             if ( protocolVersion >= ProtocolConstants.MINECRAFT_1_13 )
             {
-                value = readEitherBaseComponent( buf, protocolVersion, false );
+                valueRaw = readEitherBaseComponent( buf, protocolVersion, false );
                 type = HealthDisplay.values()[readVarInt( buf )];
             } else
             {
-                value = readEitherBaseComponent( buf, protocolVersion, true );
+                valueRaw = readEitherBaseComponent( buf, protocolVersion, true );
                 type = HealthDisplay.fromString( readString( buf ) );
             }
             if ( protocolVersion >= ProtocolConstants.MINECRAFT_1_20_3 )
@@ -59,7 +62,7 @@ public class ScoreboardObjective extends DefinedPacket
         buf.writeByte( action );
         if ( action == 0 || action == 2 )
         {
-            writeEitherBaseComponent( value, buf, protocolVersion );
+            writeEitherBaseComponent( valueRaw, buf, protocolVersion );
             if ( protocolVersion >= ProtocolConstants.MINECRAFT_1_13 )
             {
                 writeVarInt( type.ordinal(), buf );
@@ -96,4 +99,45 @@ public class ScoreboardObjective extends DefinedPacket
             return valueOf( s.toUpperCase( Locale.ROOT ) );
         }
     }
+
+    public ScoreboardObjective(String name, Either<String, BaseComponent> value, HealthDisplay type, byte action, NumberFormat numberFormat)
+    {
+        this.name = name;
+        setValue( value );
+        this.type = type;
+        this.action = action;
+        this.numberFormat = numberFormat;
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public Either<String, BaseComponent> getValue()
+    {
+        if ( valueRaw == null )
+        {
+            return null;
+        }
+        if ( valueRaw.isLeft() )
+        {
+            return (Either) valueRaw;
+        } else
+        {
+            return Either.right( valueRaw.getRight().get() );
+        }
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public void setValue(Either<String, BaseComponent> value)
+    {
+        if ( value == null )
+        {
+            valueRaw = null;
+        } else if ( value.isLeft() )
+        {
+            valueRaw = (Either) value;
+        } else
+        {
+            valueRaw = Either.right( new NoOrigDeserializable<>( value.getRight() ) );
+        }
+    }
+
 }

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/ScoreboardScore.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/ScoreboardScore.java
@@ -8,8 +8,12 @@ import lombok.NoArgsConstructor;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.protocol.AbstractPacketHandler;
 import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.protocol.Deserializable;
+import net.md_5.bungee.protocol.Either;
+import net.md_5.bungee.protocol.NoOrigDeserializable;
 import net.md_5.bungee.protocol.NumberFormat;
 import net.md_5.bungee.protocol.ProtocolConstants;
+import se.llbit.nbt.SpecificTag;
 
 @Data
 @NoArgsConstructor
@@ -25,7 +29,7 @@ public class ScoreboardScore extends DefinedPacket
     private byte action;
     private String scoreName;
     private int value;
-    private BaseComponent displayName;
+    private Deserializable<Either<String, SpecificTag>, BaseComponent> displayNameRaw;
     private NumberFormat numberFormat;
 
     @Override
@@ -46,7 +50,7 @@ public class ScoreboardScore extends DefinedPacket
         }
         if ( protocolVersion >= ProtocolConstants.MINECRAFT_1_20_3 )
         {
-            displayName = readNullable( (b) -> readBaseComponent( b, protocolVersion ), buf );
+            displayNameRaw = readNullable( (b) -> readBaseComponent( b, protocolVersion ), buf );
             numberFormat = readNullable( (b) -> readNumberFormat( b, protocolVersion ), buf );
         }
     }
@@ -66,7 +70,7 @@ public class ScoreboardScore extends DefinedPacket
         }
         if ( protocolVersion >= ProtocolConstants.MINECRAFT_1_20_3 )
         {
-            writeNullable( displayName, (s, b) -> DefinedPacket.writeBaseComponent( s, b, protocolVersion ), buf );
+            writeNullable( displayNameRaw, (s, b) -> DefinedPacket.writeBaseComponent( s, b, protocolVersion ), buf );
             writeNullable( numberFormat, (s, b) -> DefinedPacket.writeNumberFormat( s, b, protocolVersion ), buf );
         }
     }
@@ -75,5 +79,34 @@ public class ScoreboardScore extends DefinedPacket
     public void handle(AbstractPacketHandler handler) throws Exception
     {
         handler.handle( this );
+    }
+
+    public ScoreboardScore(String itemName, byte action, String scoreName, int value, BaseComponent displayName, NumberFormat numberFormat)
+    {
+        this.itemName = itemName;
+        this.action = action;
+        this.scoreName = scoreName;
+        this.value = value;
+        setDisplayName( displayName );
+        this.numberFormat = numberFormat;
+    }
+
+    public BaseComponent getDisplayName()
+    {
+        if ( displayNameRaw == null )
+        {
+            return null;
+        }
+        return displayNameRaw.get();
+    }
+
+    public void setDisplayName(BaseComponent displayName)
+    {
+        if ( displayName == null )
+        {
+            this.displayNameRaw = null;
+            return;
+        }
+        this.displayNameRaw = new NoOrigDeserializable<>( displayName );
     }
 }

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/ServerData.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/ServerData.java
@@ -8,7 +8,11 @@ import lombok.NoArgsConstructor;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.protocol.AbstractPacketHandler;
 import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.protocol.Deserializable;
+import net.md_5.bungee.protocol.Either;
+import net.md_5.bungee.protocol.NoOrigDeserializable;
 import net.md_5.bungee.protocol.ProtocolConstants;
+import se.llbit.nbt.SpecificTag;
 
 @Data
 @NoArgsConstructor
@@ -17,7 +21,7 @@ import net.md_5.bungee.protocol.ProtocolConstants;
 public class ServerData extends DefinedPacket
 {
 
-    private BaseComponent motd;
+    private Deserializable<Either<String, SpecificTag>, BaseComponent> motdRaw;
     private Object icon;
     private boolean preview;
     private boolean enforceSecure;
@@ -27,7 +31,7 @@ public class ServerData extends DefinedPacket
     {
         if ( protocolVersion >= ProtocolConstants.MINECRAFT_1_19_4 || buf.readBoolean() )
         {
-            motd = readBaseComponent( buf, protocolVersion );
+            motdRaw = readBaseComponent( buf, protocolVersion );
         }
         if ( buf.readBoolean() )
         {
@@ -54,13 +58,13 @@ public class ServerData extends DefinedPacket
     @Override
     public void write(ByteBuf buf, ProtocolConstants.Direction direction, int protocolVersion)
     {
-        if ( motd != null )
+        if ( motdRaw != null )
         {
             if ( protocolVersion >= ProtocolConstants.MINECRAFT_1_19_4 )
             {
                 buf.writeBoolean( true );
             }
-            writeBaseComponent( motd, buf, protocolVersion );
+            writeBaseComponent( motdRaw, buf, protocolVersion );
         } else
         {
             if ( protocolVersion >= ProtocolConstants.MINECRAFT_1_19_4 )
@@ -101,5 +105,23 @@ public class ServerData extends DefinedPacket
     public void handle(AbstractPacketHandler handler) throws Exception
     {
         handler.handle( this );
+    }
+
+    public ServerData(BaseComponent motd, Object icon, boolean preview, boolean enforceSecure)
+    {
+        setMotd( motd );
+        this.icon = icon;
+        this.preview = preview;
+        this.enforceSecure = enforceSecure;
+    }
+
+    public BaseComponent getMotd()
+    {
+        return motdRaw.get();
+    }
+
+    public void setMotd(BaseComponent motd)
+    {
+        this.motdRaw = new NoOrigDeserializable<>( motd );
     }
 }

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/Subtitle.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/Subtitle.java
@@ -7,7 +7,11 @@ import lombok.NoArgsConstructor;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.protocol.AbstractPacketHandler;
 import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.protocol.Deserializable;
+import net.md_5.bungee.protocol.Either;
+import net.md_5.bungee.protocol.NoOrigDeserializable;
 import net.md_5.bungee.protocol.ProtocolConstants;
+import se.llbit.nbt.SpecificTag;
 
 @Data
 @NoArgsConstructor
@@ -15,23 +19,38 @@ import net.md_5.bungee.protocol.ProtocolConstants;
 public class Subtitle extends DefinedPacket
 {
 
-    private BaseComponent text;
+    private Deserializable<Either<String, SpecificTag>, BaseComponent> textRaw;
 
     @Override
     public void read(ByteBuf buf, ProtocolConstants.Direction direction, int protocolVersion)
     {
-        text = readBaseComponent( buf, protocolVersion );
+        textRaw = readBaseComponent( buf, protocolVersion );
     }
 
     @Override
     public void write(ByteBuf buf, ProtocolConstants.Direction direction, int protocolVersion)
     {
-        writeBaseComponent( text, buf, protocolVersion );
+        writeBaseComponent( textRaw, buf, protocolVersion );
     }
 
     @Override
     public void handle(AbstractPacketHandler handler) throws Exception
     {
         handler.handle( this );
+    }
+
+    public Subtitle(BaseComponent text)
+    {
+        setText( text );
+    }
+
+    public BaseComponent getText()
+    {
+        return textRaw.get();
+    }
+
+    public void setText(BaseComponent text)
+    {
+        this.textRaw = new NoOrigDeserializable<>( text );
     }
 }

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/SystemChat.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/SystemChat.java
@@ -9,7 +9,11 @@ import net.md_5.bungee.api.ChatMessageType;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.protocol.AbstractPacketHandler;
 import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.protocol.Deserializable;
+import net.md_5.bungee.protocol.Either;
+import net.md_5.bungee.protocol.NoOrigDeserializable;
 import net.md_5.bungee.protocol.ProtocolConstants;
+import se.llbit.nbt.SpecificTag;
 
 @Data
 @NoArgsConstructor
@@ -18,20 +22,20 @@ import net.md_5.bungee.protocol.ProtocolConstants;
 public class SystemChat extends DefinedPacket
 {
 
-    private BaseComponent message;
+    private Deserializable<Either<String, SpecificTag>, BaseComponent> messageRaw;
     private int position;
 
     @Override
     public void read(ByteBuf buf, ProtocolConstants.Direction direction, int protocolVersion)
     {
-        message = readBaseComponent( buf, 262144, protocolVersion );
+        messageRaw = readBaseComponent( buf, 262144, protocolVersion );
         position = ( protocolVersion >= ProtocolConstants.MINECRAFT_1_19_1 ) ? ( ( buf.readBoolean() ) ? ChatMessageType.ACTION_BAR.ordinal() : 0 ) : readVarInt( buf );
     }
 
     @Override
     public void write(ByteBuf buf, ProtocolConstants.Direction direction, int protocolVersion)
     {
-        writeBaseComponent( message, buf, protocolVersion );
+        writeBaseComponent( messageRaw, buf, protocolVersion );
         if ( protocolVersion >= ProtocolConstants.MINECRAFT_1_19_1 )
         {
             buf.writeBoolean( position == ChatMessageType.ACTION_BAR.ordinal() );
@@ -46,4 +50,21 @@ public class SystemChat extends DefinedPacket
     {
         handler.handle( this );
     }
+
+    public SystemChat(BaseComponent message, int position)
+    {
+        this.messageRaw = new NoOrigDeserializable<>( message );
+        this.position = position;
+    }
+
+    public BaseComponent getMessage()
+    {
+        return messageRaw.get();
+    }
+
+    public void setMessage(BaseComponent message)
+    {
+        this.messageRaw = new NoOrigDeserializable<>( message );
+    }
+
 }

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/TabCompleteResponse.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/TabCompleteResponse.java
@@ -13,7 +13,10 @@ import lombok.NoArgsConstructor;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.protocol.AbstractPacketHandler;
 import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.protocol.Deserializable;
+import net.md_5.bungee.protocol.Either;
 import net.md_5.bungee.protocol.ProtocolConstants;
+import se.llbit.nbt.SpecificTag;
 
 @Data
 @NoArgsConstructor
@@ -52,7 +55,7 @@ public class TabCompleteResponse extends DefinedPacket
             for ( int i = 0; i < cnt; i++ )
             {
                 String match = readString( buf );
-                BaseComponent tooltip = buf.readBoolean() ? readBaseComponent( buf, protocolVersion ) : null;
+                Deserializable<Either<String, SpecificTag>, BaseComponent> tooltip = buf.readBoolean() ? readBaseComponent( buf, protocolVersion ) : null;
 
                 matches.add( new Suggestion( range, match, ( tooltip != null ) ? new ComponentMessage( tooltip ) : null ) );
             }
@@ -80,7 +83,7 @@ public class TabCompleteResponse extends DefinedPacket
                 buf.writeBoolean( suggestion.getTooltip() != null );
                 if ( suggestion.getTooltip() != null )
                 {
-                    writeBaseComponent( ( (ComponentMessage) suggestion.getTooltip() ).getComponent(), buf, protocolVersion );
+                    writeBaseComponent( ( (ComponentMessage) suggestion.getTooltip() ).getComponentRaw(), buf, protocolVersion );
                 }
             }
         } else
@@ -99,12 +102,17 @@ public class TabCompleteResponse extends DefinedPacket
     private static class ComponentMessage implements Message
     {
 
-        private final BaseComponent component;
+        private final Deserializable<Either<String, SpecificTag>, BaseComponent> componentRaw;
+
+        public BaseComponent getComponent()
+        {
+            return componentRaw.get();
+        }
 
         @Override
         public String getString()
         {
-            return component.toPlainText();
+            return getComponent().toPlainText();
         }
     }
 }

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/Team.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/Team.java
@@ -8,8 +8,11 @@ import lombok.NoArgsConstructor;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.protocol.AbstractPacketHandler;
 import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.protocol.Deserializable;
 import net.md_5.bungee.protocol.Either;
+import net.md_5.bungee.protocol.NoOrigDeserializable;
 import net.md_5.bungee.protocol.ProtocolConstants;
+import se.llbit.nbt.SpecificTag;
 
 @Data
 @NoArgsConstructor
@@ -23,9 +26,9 @@ public class Team extends DefinedPacket
      * 0 - create, 1 remove, 2 info update, 3 player add, 4 player remove.
      */
     private byte mode;
-    private Either<String, BaseComponent> displayName;
-    private Either<String, BaseComponent> prefix;
-    private Either<String, BaseComponent> suffix;
+    private Either<String, Deserializable<Either<String, SpecificTag>, BaseComponent>> displayNameRaw;
+    private Either<String, Deserializable<Either<String, SpecificTag>, BaseComponent>> prefixRaw;
+    private Either<String, Deserializable<Either<String, SpecificTag>, BaseComponent>> suffixRaw;
     private String nameTagVisibility;
     private String collisionRule;
     private int color;
@@ -52,12 +55,12 @@ public class Team extends DefinedPacket
         {
             if ( protocolVersion < ProtocolConstants.MINECRAFT_1_13 )
             {
-                displayName = readEitherBaseComponent( buf, protocolVersion, true );
-                prefix = readEitherBaseComponent( buf, protocolVersion, true );
-                suffix = readEitherBaseComponent( buf, protocolVersion, true );
+                displayNameRaw = readEitherBaseComponent( buf, protocolVersion, true );
+                prefixRaw = readEitherBaseComponent( buf, protocolVersion, true );
+                suffixRaw = readEitherBaseComponent( buf, protocolVersion, true );
             } else
             {
-                displayName = readEitherBaseComponent( buf, protocolVersion, false );
+                displayNameRaw = readEitherBaseComponent( buf, protocolVersion, false );
             }
             friendlyFire = buf.readByte();
             nameTagVisibility = readString( buf );
@@ -68,8 +71,8 @@ public class Team extends DefinedPacket
             color = ( protocolVersion >= ProtocolConstants.MINECRAFT_1_13 ) ? readVarInt( buf ) : buf.readByte();
             if ( protocolVersion >= ProtocolConstants.MINECRAFT_1_13 )
             {
-                prefix = readEitherBaseComponent( buf, protocolVersion, false );
-                suffix = readEitherBaseComponent( buf, protocolVersion, false );
+                prefixRaw = readEitherBaseComponent( buf, protocolVersion, false );
+                suffixRaw = readEitherBaseComponent( buf, protocolVersion, false );
             }
         }
         if ( mode == 0 || mode == 3 || mode == 4 )
@@ -90,11 +93,11 @@ public class Team extends DefinedPacket
         buf.writeByte( mode );
         if ( mode == 0 || mode == 2 )
         {
-            writeEitherBaseComponent( displayName, buf, protocolVersion );
+            writeEitherBaseComponent( displayNameRaw, buf, protocolVersion );
             if ( protocolVersion < ProtocolConstants.MINECRAFT_1_13 )
             {
-                writeEitherBaseComponent( prefix, buf, protocolVersion );
-                writeEitherBaseComponent( suffix, buf, protocolVersion );
+                writeEitherBaseComponent( prefixRaw, buf, protocolVersion );
+                writeEitherBaseComponent( suffixRaw, buf, protocolVersion );
             }
             buf.writeByte( friendlyFire );
             writeString( nameTagVisibility, buf );
@@ -106,8 +109,8 @@ public class Team extends DefinedPacket
             if ( protocolVersion >= ProtocolConstants.MINECRAFT_1_13 )
             {
                 writeVarInt( color, buf );
-                writeEitherBaseComponent( prefix, buf, protocolVersion );
-                writeEitherBaseComponent( suffix, buf, protocolVersion );
+                writeEitherBaseComponent( prefixRaw, buf, protocolVersion );
+                writeEitherBaseComponent( suffixRaw, buf, protocolVersion );
             } else
             {
                 buf.writeByte( color );
@@ -120,6 +123,78 @@ public class Team extends DefinedPacket
             {
                 writeString( player, buf );
             }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public Either<String, BaseComponent> getDisplayName()
+    {
+        if ( displayNameRaw.isLeft() )
+        {
+            return (Either) displayNameRaw;
+        } else
+        {
+            return Either.right( displayNameRaw.getRight().get() );
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public void setDisplayName(Either<String, BaseComponent> displayName)
+    {
+        if ( displayName.isLeft() )
+        {
+            displayNameRaw = (Either) displayName;
+        } else
+        {
+            displayNameRaw = Either.right( new NoOrigDeserializable<>( displayName.getRight() ) );
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public Either<String, BaseComponent> getPrefix()
+    {
+        if ( prefixRaw.isLeft() )
+        {
+            return (Either) prefixRaw;
+        } else
+        {
+            return Either.right( prefixRaw.getRight().get() );
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public void setPrefix(Either<String, BaseComponent> prefix)
+    {
+        if ( prefix.isLeft() )
+        {
+            prefixRaw = (Either) prefix;
+        } else
+        {
+            prefixRaw = Either.right( new NoOrigDeserializable<>( prefix.getRight() ) );
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public Either<String, BaseComponent> getSuffix()
+    {
+        if ( suffixRaw.isLeft() )
+        {
+            return (Either) suffixRaw;
+        } else
+        {
+            return Either.right( suffixRaw.getRight().get() );
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public void setSuffix(Either<String, BaseComponent> suffix)
+    {
+        if ( suffix.isLeft() )
+        {
+            suffixRaw = (Either) suffix;
+        } else
+        {
+            suffixRaw = Either.right( new NoOrigDeserializable<>( suffix.getRight() ) );
         }
     }
 

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/Title.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/Title.java
@@ -7,7 +7,11 @@ import lombok.NoArgsConstructor;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.protocol.AbstractPacketHandler;
 import net.md_5.bungee.protocol.DefinedPacket;
+import net.md_5.bungee.protocol.Deserializable;
+import net.md_5.bungee.protocol.Either;
+import net.md_5.bungee.protocol.NoOrigDeserializable;
 import net.md_5.bungee.protocol.ProtocolConstants;
+import se.llbit.nbt.SpecificTag;
 
 @Data
 @NoArgsConstructor
@@ -18,7 +22,7 @@ public class Title extends DefinedPacket
     private Action action;
 
     // TITLE & SUBTITLE
-    private BaseComponent text;
+    private Deserializable<Either<String, SpecificTag>, BaseComponent> textRaw;
 
     // TIMES
     private int fadeIn;
@@ -35,7 +39,7 @@ public class Title extends DefinedPacket
     {
         if ( protocolVersion >= ProtocolConstants.MINECRAFT_1_17 )
         {
-            text = readBaseComponent( buf, protocolVersion );
+            textRaw = readBaseComponent( buf, protocolVersion );
             return;
         }
 
@@ -53,7 +57,7 @@ public class Title extends DefinedPacket
             case TITLE:
             case SUBTITLE:
             case ACTIONBAR:
-                text = readBaseComponent( buf, protocolVersion );
+                textRaw = readBaseComponent( buf, protocolVersion );
                 break;
             case TIMES:
                 fadeIn = buf.readInt();
@@ -68,7 +72,7 @@ public class Title extends DefinedPacket
     {
         if ( protocolVersion >= ProtocolConstants.MINECRAFT_1_17 )
         {
-            writeBaseComponent( text, buf, protocolVersion );
+            writeBaseComponent( textRaw, buf, protocolVersion );
             return;
         }
 
@@ -86,7 +90,7 @@ public class Title extends DefinedPacket
             case TITLE:
             case SUBTITLE:
             case ACTIONBAR:
-                writeBaseComponent( text, buf, protocolVersion );
+                writeBaseComponent( textRaw, buf, protocolVersion );
                 break;
             case TIMES:
                 buf.writeInt( fadeIn );
@@ -111,5 +115,24 @@ public class Title extends DefinedPacket
         TIMES,
         CLEAR,
         RESET
+    }
+
+    public Title(Action action, BaseComponent text, int fadeIn, int stay, int fadeOut)
+    {
+        setText( text );
+        this.fadeIn = fadeIn;
+        this.stay = stay;
+        this.fadeOut = fadeOut;
+        this.action = action;
+    }
+
+    public BaseComponent getText()
+    {
+        return textRaw.get();
+    }
+
+    public void setText(BaseComponent text)
+    {
+        this.textRaw = new NoOrigDeserializable<>( text );
     }
 }

--- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
+++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
@@ -304,7 +304,7 @@ public class ServerConnector extends PacketHandler
                     user.unsafe().sendPacket( new ScoreboardScoreReset( score.getItemName(), null ) );
                 } else
                 {
-                    user.unsafe().sendPacket( new ScoreboardScore( score.getItemName(), (byte) 1, score.getScoreName(), score.getValue(), null, null ) );
+                    user.unsafe().sendPacket( new ScoreboardScore( score.getItemName(), (byte) 1, score.getScoreName(), score.getValue(), (BaseComponent) null, null ) );
                 }
             }
             for ( Team team : serverScoreboard.getTeams() )

--- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
@@ -267,9 +267,9 @@ public class DownstreamBridge extends PacketHandler
         {
             if ( team.getMode() == 0 || team.getMode() == 2 )
             {
-                t.setDisplayName( team.getDisplayName().getLeftOrCompute( ComponentSerializer::toString ) );
-                t.setPrefix( team.getPrefix().getLeftOrCompute( ComponentSerializer::toString ) );
-                t.setSuffix( team.getSuffix().getLeftOrCompute( ComponentSerializer::toString ) );
+                t.setDisplayName( team.getDisplayNameRaw().getLeftOrCompute( d -> ComponentSerializer.toString( d.get() ) ) );
+                t.setPrefix( team.getPrefixRaw().getLeftOrCompute( d -> ComponentSerializer.toString( d.get() ) ) );
+                t.setSuffix( team.getSuffixRaw().getLeftOrCompute( d -> ComponentSerializer.toString( d.get() ) ) );
                 t.setFriendlyFire( team.getFriendlyFire() );
                 t.setNameTagVisibility( team.getNameTagVisibility() );
                 t.setCollisionRule( team.getCollisionRule() );


### PR DESCRIPTION
1. Add lazy json deserialization of chat content (until BaseComponent is questioned, save only String/Tag).
2. Micro-optimize chat deserialization by reducing HashMap lookups:
- has-get changed to get-nullcheck
- has-get changed to entry iteration + lookupswitch

While I was at it, some small code style improvements in chat tests.