### PR TITLE
Added ProxyDefineCommandsEvent

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/event/ProxyDefineCommandsEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/ProxyDefineCommandsEvent.java
@@ -1,0 +1,35 @@
+package net.md_5.bungee.api.event;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import net.md_5.bungee.api.connection.Connection;
+import net.md_5.bungee.api.plugin.Command;
+
+/**
+ * Called when the proxy intercepts the Commands packet, allowing plugins to
+ * hide commands that clients have permission for without disabling them.
+ */
+@Data
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class ProxyDefineCommandsEvent extends TargetedEvent
+{
+    /**
+     * The commands to send to the player
+     */
+    private final Map<String, Command> commands;
+
+    public ProxyDefineCommandsEvent(Connection sender, Connection receiver, Collection<Map.Entry<String, Command>> commands)
+    {
+        super( sender, receiver );
+        this.commands = new HashMap<>( commands.size() );
+        for ( Map.Entry<String, Command> command : commands )
+        {
+            this.commands.put( command.getKey(), command.getValue() );
+        }
+    }
+}

--- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
@@ -19,6 +19,7 @@ import io.netty.channel.unix.DomainSocketAddress;
 import java.io.DataInput;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -36,6 +37,7 @@ import net.md_5.bungee.api.config.ServerInfo;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.connection.Server;
 import net.md_5.bungee.api.event.PluginMessageEvent;
+import net.md_5.bungee.api.event.ProxyDefineCommandsEvent;
 import net.md_5.bungee.api.event.ServerConnectEvent;
 import net.md_5.bungee.api.event.ServerDisconnectEvent;
 import net.md_5.bungee.api.event.ServerKickEvent;
@@ -743,13 +745,32 @@ public class DownstreamBridge extends PacketHandler
     @Override
     public void handle(Commands commands) throws Exception
     {
+        final Collection<Map.Entry<String, Command>> unmodifiedCommandMap = bungee.getPluginManager().getCommands();
+        final ProxyDefineCommandsEvent event = new ProxyDefineCommandsEvent( server, con, unmodifiedCommandMap );
+        bungee.getPluginManager().callEvent( event );
+
         boolean modified = false;
 
-        for ( Map.Entry<String, Command> command : bungee.getPluginManager().getCommands() )
+        // If an event handler REMOVED OR CHANGED a command then set modified.
+        for ( Map.Entry<String, Command> unmodifiedCommand : unmodifiedCommandMap )
         {
+            if ( event.getCommands().get( unmodifiedCommand.getKey() ) != unmodifiedCommand.getValue() )
+            {
+                modified = true;
+            }
+        }
+
+        for ( Map.Entry<String, Command> command : event.getCommands().entrySet() )
+        {
+            // If an event handler ADDED a command then set modified.
+            if ( unmodifiedCommandMap.stream().noneMatch( entry -> entry.getKey().equals( command.getKey() ) ) )
+            {
+                modified = true;
+            }
+
             if ( !bungee.getDisabledCommands().contains( command.getKey() ) && commands.getRoot().getChild( command.getKey() ) == null && command.getValue().hasPermission( con ) )
             {
-                CommandNode dummy = LiteralArgumentBuilder.literal( command.getKey() ).executes( DUMMY_COMMAND )
+                CommandNode<?> dummy = LiteralArgumentBuilder.literal( command.getKey() ).executes( DUMMY_COMMAND )
                         .then( RequiredArgumentBuilder.argument( "args", StringArgumentType.greedyString() )
                                 .suggests( Commands.SuggestionRegistry.ASK_SERVER ).executes( DUMMY_COMMAND ) )
                         .build();


### PR DESCRIPTION
In migrating from waterfall from bungeecord, this was the only missing API that my network is missing. I've re-implemented it here without directly copying - only the surface API is the same.

We use it to hide commands from tab completion to improve searchability for players, whilst allowing them to have permission to use the command.

Why give them permission if it's hidden? The command is triggered via a button in chat or via `Command.execute`; it is never triggered manually but it isn't a problem if they somehow discover it.