### PR TITLE
Guarantee the order of AsyncEvent execution when using intentions

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/event/AsyncEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/AsyncEvent.java
@@ -1,19 +1,13 @@
 package net.md_5.bungee.api.event;
 
 import com.google.common.base.Preconditions;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
-import lombok.AccessLevel;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.ToString;
+import lombok.*;
 import net.md_5.bungee.api.Callback;
 import net.md_5.bungee.api.plugin.Event;
 import net.md_5.bungee.api.plugin.Plugin;
-
+import net.md_5.bungee.event.AsyncEventBusEvent;
+import net.md_5.bungee.event.AsyncEventContext;
 /**
  * Represents an event which depends on the result of asynchronous operations.
  *
@@ -23,23 +17,25 @@ import net.md_5.bungee.api.plugin.Plugin;
 @Getter(AccessLevel.NONE)
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public class AsyncEvent<T> extends Event
+public class AsyncEvent<T> extends Event implements AsyncEventBusEvent
 {
 
     private final Callback<T> done;
-    private final Map<Plugin, AtomicInteger> intents = new ConcurrentHashMap<>();
-    private final AtomicBoolean fired = new AtomicBoolean();
-    private final AtomicInteger latch = new AtomicInteger();
+    private volatile boolean completed = false;
+    private final AtomicBoolean intent = new AtomicBoolean();
+    @Setter
+    @EqualsAndHashCode.Exclude
+    @ToString.Exclude
+    private AsyncEventContext<?> asyncEventContext;
 
     @Override
     @SuppressWarnings("unchecked")
-    public void postCall()
+    public void onComplete()
     {
-        if ( latch.get() == 0 )
-        {
-            done.done( (T) this, null );
-        }
-        fired.set( true );
+        Preconditions.checkState( !completed, "Event %s has already been fired", this );
+        completed = true;
+
+        done.done( (T) this, null );
     }
 
     /**
@@ -50,20 +46,12 @@ public class AsyncEvent<T> extends Event
      * event to proceed.
      *
      * @param plugin the plugin registering this intent
+     * @deprecated use {@link #registerIntent()} since intent now has an execution order
      */
+    @Deprecated
     public void registerIntent(Plugin plugin)
     {
-        Preconditions.checkState( !fired.get(), "Event %s has already been fired", this );
-
-        AtomicInteger intentCount = intents.get( plugin );
-        if ( intentCount == null )
-        {
-            intents.put( plugin, new AtomicInteger( 1 ) );
-        } else
-        {
-            intentCount.incrementAndGet();
-        }
-        latch.incrementAndGet();
+        registerIntent();
     }
 
     /**
@@ -71,23 +59,52 @@ public class AsyncEvent<T> extends Event
      * to let the event proceed once all intents have been completed.
      *
      * @param plugin a plugin which has an intent registered for this event
+     * @deprecated use {@link #completeIntent()} since intent now has an execution order
      */
-    @SuppressWarnings("unchecked")
+    @Deprecated
     public void completeIntent(Plugin plugin)
     {
-        AtomicInteger intentCount = intents.get( plugin );
-        Preconditions.checkState( intentCount != null && intentCount.get() > 0, "Plugin %s has not registered intents for event %s", plugin, this );
-
-        intentCount.decrementAndGet();
-        if ( fired.get() )
-        {
-            if ( latch.decrementAndGet() == 0 )
-            {
-                done.done( (T) this, null );
-            }
-        } else
-        {
-            latch.decrementAndGet();
-        }
+        completeIntent();
     }
+
+    /**
+     * Register an intent that this plugin will continue to perform work on a
+     * background task, and wishes to let the event proceed once the registered
+     * background task has completed. The plugin must complete the intent for the
+     * event to proceed.
+     */
+    @Override
+    public void registerIntent()
+    {
+        Preconditions.checkState( !completed, "Event %s has already been fired", this );
+        Preconditions.checkState( !intent.get(), "Intent has already been registered for the event %s", this );
+
+        intent.set( true );
+    }
+
+    /**
+     * Checks if the current event is in the intent state.
+     * @return intent state
+     */
+    @Override
+    public boolean isRegisteredIntent()
+    {
+        return intent.get();
+    }
+
+    /**
+     * Notifies this event that this plugin has completed an intent and wishes
+     * to let the event proceed.
+     */
+    @Override
+    public void completeIntent()
+    {
+        Preconditions.checkState( !completed, "Event %s has already been fired", this );
+        Preconditions.checkState( intent.get(), "Intent has not yet been registered for the event %s", this );
+
+        intent.set( false );
+
+        asyncEventContext.post();
+    }
+
 }

--- a/api/src/main/java/net/md_5/bungee/api/plugin/Event.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/Event.java
@@ -1,15 +1,11 @@
 package net.md_5.bungee.api.plugin;
 
+import net.md_5.bungee.event.EventBusEvent;
+
 /**
  * Dummy class which all callable events must extend.
  */
-public abstract class Event
+public abstract class Event implements EventBusEvent
 {
 
-    /**
-     * Method called after this event has been dispatched to all handlers.
-     */
-    public void postCall()
-    {
-    }
 }

--- a/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
@@ -31,6 +31,7 @@ import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
+import net.md_5.bungee.api.event.AsyncEvent;
 import net.md_5.bungee.event.EventBus;
 import net.md_5.bungee.event.EventHandler;
 import org.yaml.snakeyaml.LoaderOptions;
@@ -410,16 +411,22 @@ public final class PluginManager
         Preconditions.checkNotNull( event, "event" );
 
         long start = System.nanoTime();
-        eventBus.post( event );
-        event.postCall();
+        if ( event instanceof AsyncEvent )
+        {
+            AsyncEvent<?> asyncEvent = (AsyncEvent<?>) event;
+            eventBus.postAsync( asyncEvent );
+        } else
+        {
+            eventBus.post( event );
+        }
 
         long elapsed = System.nanoTime() - start;
         if ( elapsed > 250000000 )
         {
             ProxyServer.getInstance().getLogger().log( Level.WARNING, "Event {0} took {1}ms to process!", new Object[]
-            {
+                {
                 event, elapsed / 1000000
-            } );
+                } );
         }
         return event;
     }

--- a/api/src/test/java/net/md_5/bungee/api/event/AsyncEventPriorityTest.java
+++ b/api/src/test/java/net/md_5/bungee/api/event/AsyncEventPriorityTest.java
@@ -1,0 +1,156 @@
+package net.md_5.bungee.api.event;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import lombok.RequiredArgsConstructor;
+import net.md_5.bungee.api.Callback;
+import net.md_5.bungee.event.EventBus;
+import net.md_5.bungee.event.EventHandler;
+import net.md_5.bungee.event.EventPriority;
+import org.junit.jupiter.api.Test;
+
+public class AsyncEventPriorityTest
+{
+
+    private final EventBus bus = new EventBus();
+    private final CountDownLatch latch = new CountDownLatch( 8 );
+
+    private final ExecutorService executor = Executors.newFixedThreadPool( 8 );
+
+    @Test
+    public void testPriority() throws InterruptedException
+    {
+        bus.register( this );
+        bus.register( new AsyncEventPriorityListenerPartner() );
+        CompletableCallback<AsyncPriorityTestEvent> callback = new CompletableCallback<>( (result, error) ->
+        {
+            assertEquals( 1, latch.getCount() );
+            latch.countDown();
+        } );
+        bus.postAsync( new AsyncPriorityTestEvent( callback ) );
+
+        synchronized ( callback )
+        {
+            callback.wait( 1000 );
+
+            assertEquals( 0, latch.getCount() );
+
+            executor.shutdown();
+        }
+    }
+
+    @EventHandler(priority = Byte.MIN_VALUE)
+    public void onMinPriority(AsyncPriorityTestEvent event)
+    {
+        event.registerIntent();
+
+        executor.execute( () ->
+        {
+            assertEquals( 8, latch.getCount() );
+            latch.countDown();
+
+            event.completeIntent();
+        } );
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onLowestPriority(AsyncPriorityTestEvent event)
+    {
+        event.registerIntent();
+
+        executor.execute( () ->
+        {
+            assertEquals( 7, latch.getCount() );
+            latch.countDown();
+
+            event.completeIntent();
+        } );
+    }
+
+    @EventHandler
+    public void onNormalPriority(AsyncPriorityTestEvent event)
+    {
+        event.registerIntent();
+
+        executor.execute( () ->
+        {
+            assertEquals( 5, latch.getCount() );
+            latch.countDown();
+
+            event.completeIntent();
+        } );
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onHighestPriority(AsyncPriorityTestEvent event)
+    {
+        event.registerIntent();
+
+        executor.execute( () ->
+        {
+            assertEquals( 3, latch.getCount() );
+            latch.countDown();
+
+            event.completeIntent();
+        } );
+    }
+
+    @EventHandler(priority = Byte.MAX_VALUE)
+    public void onMaxPriority(AsyncPriorityTestEvent event)
+    {
+        event.registerIntent();
+
+        executor.execute( () ->
+        {
+            assertEquals( 2, latch.getCount() );
+            latch.countDown();
+
+            event.completeIntent();
+        } );
+    }
+
+    public static class AsyncPriorityTestEvent extends AsyncEvent<AsyncPriorityTestEvent>
+    {
+        public AsyncPriorityTestEvent(Callback<AsyncPriorityTestEvent> done)
+        {
+            super( done );
+        }
+    }
+
+    public class AsyncEventPriorityListenerPartner
+    {
+
+        @EventHandler(priority = EventPriority.HIGH)
+        public void onHighPriority(AsyncPriorityTestEvent event)
+        {
+            assertEquals( 4, latch.getCount() );
+            latch.countDown();
+        }
+
+        @EventHandler(priority = EventPriority.LOW)
+        public void onLowPriority(AsyncPriorityTestEvent event)
+        {
+            assertEquals( 6, latch.getCount() );
+            latch.countDown();
+        }
+    }
+
+    @RequiredArgsConstructor
+    private static class CompletableCallback<T> implements Callback<T>
+    {
+
+        private final Callback<T> callback;
+
+        @Override
+        public void done(T result, Throwable error)
+        {
+            this.callback.done( result, error );
+            synchronized ( this )
+            {
+                notifyAll();
+            }
+        }
+    }
+}

--- a/event/src/main/java/net/md_5/bungee/event/AsyncEventBusEvent.java
+++ b/event/src/main/java/net/md_5/bungee/event/AsyncEventBusEvent.java
@@ -1,0 +1,16 @@
+package net.md_5.bungee.event;
+
+public interface AsyncEventBusEvent extends EventBusEvent
+{
+
+    void onComplete();
+
+    void registerIntent();
+
+    boolean isRegisteredIntent();
+
+    void completeIntent();
+
+    void setAsyncEventContext(AsyncEventContext<?> asyncEventContext);
+
+}

--- a/event/src/main/java/net/md_5/bungee/event/AsyncEventContext.java
+++ b/event/src/main/java/net/md_5/bungee/event/AsyncEventContext.java
@@ -1,0 +1,35 @@
+package net.md_5.bungee.event;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class AsyncEventContext<T extends AsyncEventBusEvent>
+{
+
+    private final T event;
+    private final EventHandlerMethod[] handlers;
+    private final EventBus eventBus;
+
+    private int index = 0;
+
+    public void post()
+    {
+        while ( index < handlers.length )
+        {
+            EventHandlerMethod handler = handlers[index];
+
+            eventBus.executeEventHandler( event, handler );
+
+            index++;
+
+            // Stop current processing until completeIntent is called
+            if ( event.isRegisteredIntent() )
+            {
+                return;
+            }
+        }
+
+        // All handlers have been processed
+        event.onComplete();
+    }
+}

--- a/event/src/main/java/net/md_5/bungee/event/EventBusEvent.java
+++ b/event/src/main/java/net/md_5/bungee/event/EventBusEvent.java
@@ -1,0 +1,6 @@
+package net.md_5.bungee.event;
+
+public interface EventBusEvent
+{
+
+}

--- a/event/src/main/java/net/md_5/bungee/event/EventHandlerMethod.java
+++ b/event/src/main/java/net/md_5/bungee/event/EventHandlerMethod.java
@@ -6,12 +6,11 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @AllArgsConstructor
+@Getter
 public class EventHandlerMethod
 {
 
-    @Getter
     private final Object listener;
-    @Getter
     private final Method method;
 
     public void invoke(Object event) throws IllegalAccessException, IllegalArgumentException, InvocationTargetException

--- a/event/src/test/java/net/md_5/bungee/event/EventBusTest.java
+++ b/event/src/test/java/net/md_5/bungee/event/EventBusTest.java
@@ -32,11 +32,11 @@ public class EventBusTest
         latch.countDown();
     }
 
-    public static class FirstEvent
+    public static class FirstEvent implements EventBusEvent
     {
     }
 
-    public static class SecondEvent
+    public static class SecondEvent implements EventBusEvent
     {
     }
 }

--- a/event/src/test/java/net/md_5/bungee/event/EventPriorityTest.java
+++ b/event/src/test/java/net/md_5/bungee/event/EventPriorityTest.java
@@ -54,7 +54,7 @@ public class EventPriorityTest
         latch.countDown();
     }
 
-    public static class PriorityTestEvent
+    public static class PriorityTestEvent implements EventBusEvent
     {
     }
 

--- a/event/src/test/java/net/md_5/bungee/event/UnregisteringListenerTest.java
+++ b/event/src/test/java/net/md_5/bungee/event/UnregisteringListenerTest.java
@@ -22,7 +22,7 @@ public class UnregisteringListenerTest
         fail( "Event listener wasn't unregistered" );
     }
 
-    public static class TestEvent
+    public static class TestEvent implements EventBusEvent
     {
     }
 }


### PR DESCRIPTION
This pull requester modifies the behavior of AsyncEvent to ensure that all handlers are executed according to their order or priority when using intents.

There is a race condition problem where multiple plugins could register an intent with asynchronous tasks and all tasks would just execute in the background, not guaranteeing any order of execution at all. Event prioritization for asynchronous events doesn't really have any effect.

The current implementation fixes this, by now registering an intent will suspend processing of all listeners until the intent is called to complete. 

I've tried to maintain backwards compatibility with plugins, so let me know if I've missed something