### PR TITLE
Add api for custom authentication

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/event/CustomAuthenticationEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/CustomAuthenticationEvent.java
@@ -1,0 +1,39 @@
+package net.md_5.bungee.api.event;
+
+import java.util.UUID;
+import lombok.Data;
+import net.md_5.bungee.api.Callback;
+import net.md_5.bungee.api.connection.PendingConnection;
+import net.md_5.bungee.protocol.Property;
+
+/**
+ * This Event is called if the mojang authentication is disabled,
+ * and we need to authenticate the player ourselves.
+ */
+@Data
+public class CustomAuthenticationEvent extends AsyncEvent<CustomAuthenticationEvent>
+{
+    /*
+     * The pending connection that needs to be authenticated
+     */
+    private final PendingConnection connection;
+    /*
+    * The name of the players session
+    */
+    private String name;
+    /*
+     * The uuid of the players session
+     */
+    private UUID uuid;
+    /*
+     * The properties of the players session (skin, cape, etc.)
+     */
+    private Property[] properties;
+
+    public CustomAuthenticationEvent(PendingConnection connection, Callback<CustomAuthenticationEvent> done)
+    {
+        super( done );
+        this.connection = connection;
+    }
+
+}

--- a/api/src/main/java/net/md_5/bungee/api/event/PreLoginEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/PreLoginEvent.java
@@ -1,5 +1,6 @@
 package net.md_5.bungee.api.event;
 
+import com.google.common.base.Preconditions;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -8,6 +9,7 @@ import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.api.connection.PendingConnection;
 import net.md_5.bungee.api.plugin.Cancellable;
+import net.md_5.bungee.protocol.ProtocolConstants;
 
 /**
  * Event called to represent a player first making their presence and username
@@ -35,6 +37,10 @@ public class PreLoginEvent extends AsyncEvent<PreLoginEvent> implements Cancella
      * Connection attempting to login.
      */
     private final PendingConnection connection;
+    /**
+     * Whether the client should authenticate
+     */
+    private boolean authenticate = true;
 
     public PreLoginEvent(PendingConnection connection, Callback<PreLoginEvent> done)
     {
@@ -83,5 +89,16 @@ public class PreLoginEvent extends AsyncEvent<PreLoginEvent> implements Cancella
     public void setCancelReason(BaseComponent... cancelReason)
     {
         setReason( TextComponent.fromArray( cancelReason ) );
+    }
+
+    /**
+     * @param authenticate whether the client should authenticate
+     * only available for 1.20.5 clients and above
+     * if set to false BungeeCord needs to have an CustomAuthenticationEvent listener registered
+     */
+    public void setAuthenticate(boolean authenticate)
+    {
+        Preconditions.checkArgument( connection.getVersion() >= ProtocolConstants.MINECRAFT_1_20_5, "authenticate can only be set for 1.20.5 clients and above" );
+        this.authenticate = authenticate;
     }
 }

--- a/proxy/src/main/java/net/md_5/bungee/EncryptionUtil.java
+++ b/proxy/src/main/java/net/md_5/bungee/EncryptionUtil.java
@@ -67,14 +67,14 @@ public class EncryptionUtil
         }
     }
 
-    public static EncryptionRequest encryptRequest()
+    public static EncryptionRequest encryptRequest(boolean auth)
     {
         String hash = Long.toString( random.nextLong(), 16 );
         byte[] pubKey = keys.getPublic().getEncoded();
         byte[] verify = new byte[ 4 ];
         random.nextBytes( verify );
         // always auth for now
-        return new EncryptionRequest( hash, pubKey, verify, true );
+        return new EncryptionRequest( hash, pubKey, verify, auth );
     }
 
     public static boolean check(PlayerPublicKey publicKey, UUID uuid) throws GeneralSecurityException

--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -136,6 +136,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
     @Getter
     private boolean transferred;
     private UserConnection userCon;
+    private boolean authenticate;
 
     @Override
     public boolean shouldHandle(PacketWrapper packet) throws Exception
@@ -483,7 +484,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
                 if ( onlineMode )
                 {
                     thisState = State.ENCRYPT;
-                    unsafe().sendPacket( request = EncryptionUtil.encryptRequest() );
+                    unsafe().sendPacket( request = EncryptionUtil.encryptRequest( result.isAuthenticate() ) );
                 } else
                 {
                     thisState = State.FINISHING;
@@ -502,11 +503,31 @@ public class InitialHandler extends PacketHandler implements PendingConnection
         Preconditions.checkState( thisState == State.ENCRYPT, "Not expecting ENCRYPT" );
         Preconditions.checkState( EncryptionUtil.check( loginRequest.getPublicKey(), encryptResponse, request ), "Invalid verification" );
 
+        thisState = State.FINISHING;
+
         SecretKey sharedKey = EncryptionUtil.getSecret( encryptResponse, request );
         BungeeCipher decrypt = EncryptionUtil.getCipher( false, sharedKey );
         ch.addBefore( PipelineUtils.FRAME_DECODER, PipelineUtils.DECRYPT_HANDLER, new CipherDecoder( decrypt ) );
         BungeeCipher encrypt = EncryptionUtil.getCipher( true, sharedKey );
         ch.addBefore( PipelineUtils.FRAME_PREPENDER, PipelineUtils.ENCRYPT_HANDLER, new CipherEncoder( encrypt ) );
+
+        if ( !authenticate )
+        {
+            bungee.getPluginManager().callEvent( new CustomAuthenticationEvent( this, (event, error) ->
+            {
+                if ( ch.isClosing() )
+                {
+                    return;
+                }
+                Preconditions.checkNotNull( event.getName(), "Name cannot be null" );
+                Preconditions.checkNotNull( event.getUuid(), "UUID cannot be null" );
+                name = event.getName();
+                uniqueId = event.getUuid();
+                loginProfile = new LoginResult( uniqueId.toString().replace( "-", "" ), name, event.getProperties() );
+                finish();
+            } ) );
+            return;
+        }
 
         String encName = URLEncoder.encode( InitialHandler.this.getName(), "UTF-8" );
 
@@ -519,7 +540,6 @@ public class InitialHandler extends PacketHandler implements PendingConnection
             sha.update( bit );
         }
         String encodedHash = URLEncoder.encode( new BigInteger( sha.digest() ).toString( 16 ), "UTF-8" );
-
         String preventProxy = ( BungeeCord.getInstance().config.isPreventProxyConnections() && getSocketAddress() instanceof InetSocketAddress ) ? "&ip=" + URLEncoder.encode( getAddress().getAddress().getHostAddress(), "UTF-8" ) : "";
         String authURL = "https://sessionserver.mojang.com/session/minecraft/hasJoined?username=" + encName + "&serverId=" + encodedHash + preventProxy;
 
@@ -547,7 +567,6 @@ public class InitialHandler extends PacketHandler implements PendingConnection
                 }
             }
         };
-        thisState = State.FINISHING;
         HttpClient.get( authURL, ch.getHandle().eventLoop(), handler );
     }
 

--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -485,7 +485,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
                 if ( onlineMode )
                 {
                     thisState = State.ENCRYPT;
-                    unsafe().sendPacket( request = EncryptionUtil.encryptRequest( result.isAuthenticate() ) );
+                    unsafe().sendPacket( request = EncryptionUtil.encryptRequest( authenticate = result.isAuthenticate() ) );
                 } else
                 {
                     thisState = State.FINISHING;

--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -39,6 +39,7 @@ import net.md_5.bungee.api.config.ListenerInfo;
 import net.md_5.bungee.api.config.ServerInfo;
 import net.md_5.bungee.api.connection.PendingConnection;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
+import net.md_5.bungee.api.event.CustomAuthenticationEvent;
 import net.md_5.bungee.api.event.LoginEvent;
 import net.md_5.bungee.api.event.PlayerHandshakeEvent;
 import net.md_5.bungee.api.event.PostLoginEvent;


### PR DESCRIPTION
PreLoginEvent now has an option for disabling the authentification, if disabled after encryption a custom authentification event is called to authentificate the player, In this event the session data can be set (if not set an exception is thrown (client gets kicked))

Its possible now to cache the session of a player by their ip address as example or to authentificate the player with Cookie data
as mentioned by mojang here

![image](https://github.com/SpigotMC/BungeeCord/assets/48880402/29fc044a-63ee-402f-b519-d6336c87d820)
