### PR TITLE
don't close health check directly

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/netty/HandlerBoss.java
+++ b/proxy/src/main/java/net/md_5/bungee/netty/HandlerBoss.java
@@ -30,6 +30,7 @@ public class HandlerBoss extends ChannelInboundHandlerAdapter
 
     private ChannelWrapper channel;
     private PacketHandler handler;
+    private boolean healthCheck;
 
     public void setHandler(PacketHandler handler)
     {
@@ -96,7 +97,7 @@ public class HandlerBoss extends ChannelInboundHandlerAdapter
                     channel.setRemoteAddress( newAddress );
                 } else
                 {
-                    channel.close();
+                    healthCheck = true;
                 }
             } finally
             {
@@ -146,7 +147,7 @@ public class HandlerBoss extends ChannelInboundHandlerAdapter
     {
         if ( ctx.channel().isActive() )
         {
-            boolean logExceptions = !( handler instanceof PingHandler );
+            boolean logExceptions = !( handler instanceof PingHandler ) && !healthCheck;
 
             if ( logExceptions )
             {


### PR DESCRIPTION
Fixes #3689
Just check if the connection is a health check if so don't log exceptions