### PR TITLE
Fix field length for command packets

### DIFF
--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/ClientCommand.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/ClientCommand.java
@@ -32,7 +32,7 @@ public class ClientCommand extends DefinedPacket
     @Override
     public void read(ByteBuf buf, ProtocolConstants.Direction direction, int protocolVersion)
     {
-        command = readString( buf, 256 );
+        command = readString( buf, 32767 );
         timestamp = buf.readLong();
         salt = buf.readLong();
 

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/ClientCommand.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/ClientCommand.java
@@ -35,7 +35,8 @@ public class ClientCommand extends DefinedPacket
         if ( protocolVersion >= ProtocolConstants.MINECRAFT_1_20_5 )
         {
             command = readString( buf, 32767 );
-        } else {
+        } else
+        {
             command = readString( buf, 256 );
         }
         timestamp = buf.readLong();

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/ClientCommand.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/ClientCommand.java
@@ -32,7 +32,12 @@ public class ClientCommand extends DefinedPacket
     @Override
     public void read(ByteBuf buf, ProtocolConstants.Direction direction, int protocolVersion)
     {
-        command = readString( buf, 32767 );
+        if (protocolVersion >= ProtocolConstants.MINECRAFT_1_20_5)
+        {
+            command = readString( buf, 32767 );
+        } else {
+            command = readString( buf, 256 );
+        }
         timestamp = buf.readLong();
         salt = buf.readLong();
 

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/ClientCommand.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/ClientCommand.java
@@ -32,7 +32,7 @@ public class ClientCommand extends DefinedPacket
     @Override
     public void read(ByteBuf buf, ProtocolConstants.Direction direction, int protocolVersion)
     {
-        if (protocolVersion >= ProtocolConstants.MINECRAFT_1_20_5)
+        if ( protocolVersion >= ProtocolConstants.MINECRAFT_1_20_5 )
         {
             command = readString( buf, 32767 );
         } else {

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/ClientCommand.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/ClientCommand.java
@@ -32,13 +32,7 @@ public class ClientCommand extends DefinedPacket
     @Override
     public void read(ByteBuf buf, ProtocolConstants.Direction direction, int protocolVersion)
     {
-        if ( protocolVersion >= ProtocolConstants.MINECRAFT_1_20_5 )
-        {
-            command = readString( buf, 32767 );
-        } else
-        {
-            command = readString( buf, 256 );
-        }
+        command = readString( buf, protocolVersion >= ProtocolConstants.MINECRAFT_1_20_5 ? 32767 : 256 );
         timestamp = buf.readLong();
         salt = buf.readLong();
 

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/UnsignedClientCommand.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/UnsignedClientCommand.java
@@ -21,7 +21,7 @@ public class UnsignedClientCommand extends DefinedPacket
     @Override
     public void read(ByteBuf buf, ProtocolConstants.Direction direction, int protocolVersion)
     {
-        command = readString( buf, 256 );
+        command = readString( buf, 32767 );
     }
 
     @Override

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/UnsignedClientCommand.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/UnsignedClientCommand.java
@@ -24,7 +24,8 @@ public class UnsignedClientCommand extends DefinedPacket
         if ( protocolVersion >= ProtocolConstants.MINECRAFT_1_20_5 )
         {
             command = readString( buf, 32767 );
-        } else {
+        } else
+        {
             command = readString( buf, 256 );
         }
     }

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/UnsignedClientCommand.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/UnsignedClientCommand.java
@@ -21,7 +21,7 @@ public class UnsignedClientCommand extends DefinedPacket
     @Override
     public void read(ByteBuf buf, ProtocolConstants.Direction direction, int protocolVersion)
     {
-        if (protocolVersion >= ProtocolConstants.MINECRAFT_1_20_5)
+        if ( protocolVersion >= ProtocolConstants.MINECRAFT_1_20_5 )
         {
             command = readString( buf, 32767 );
         } else {

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/UnsignedClientCommand.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/UnsignedClientCommand.java
@@ -21,13 +21,7 @@ public class UnsignedClientCommand extends DefinedPacket
     @Override
     public void read(ByteBuf buf, ProtocolConstants.Direction direction, int protocolVersion)
     {
-        if ( protocolVersion >= ProtocolConstants.MINECRAFT_1_20_5 )
-        {
-            command = readString( buf, 32767 );
-        } else
-        {
-            command = readString( buf, 256 );
-        }
+        command = readString( buf, protocolVersion >= ProtocolConstants.MINECRAFT_1_20_5 ? 32767 : 256 );
     }
 
     @Override

--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/UnsignedClientCommand.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/UnsignedClientCommand.java
@@ -21,7 +21,12 @@ public class UnsignedClientCommand extends DefinedPacket
     @Override
     public void read(ByteBuf buf, ProtocolConstants.Direction direction, int protocolVersion)
     {
-        command = readString( buf, 32767 );
+        if (protocolVersion >= ProtocolConstants.MINECRAFT_1_20_5)
+        {
+            command = readString( buf, 32767 );
+        } else {
+            command = readString( buf, 256 );
+        }
     }
 
     @Override


### PR DESCRIPTION
Updates the field length for `ClientCommand` and `UnsingedClientCommand` packets.

Resolves `OverflowPacketException` being thrown, I imagine this is only encountered with usage of the `run_command` chat click event, as players can't send a command this length in the chat bar.

https://wiki.vg/Protocol#Chat_Command