### PR TITLE
Match all TLDs in TextComponent url Pattern

### DIFF
--- a/chat/src/main/java/net/md_5/bungee/api/chat/TextComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/TextComponent.java
@@ -18,7 +18,7 @@ import net.md_5.bungee.api.ChatColor;
 public final class TextComponent extends BaseComponent
 {
 
-    private static final Pattern url = Pattern.compile( "^(?:(https?)://)?([-\\w_\\.]{2,}\\.[a-z-]{2,24})(/\\S*)?$" );
+    private static final Pattern url = Pattern.compile( "^(?:https?://([-\\w_\\.]+\\.[a-z-]{2,24})|([-\\w_\\.]{2,}\\.[a-z]{2,4}))(/\\S*)?$" );
 
     /**
      * Converts the old formatting system that used

--- a/chat/src/main/java/net/md_5/bungee/api/chat/TextComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/TextComponent.java
@@ -18,7 +18,7 @@ import net.md_5.bungee.api.ChatColor;
 public final class TextComponent extends BaseComponent
 {
 
-    private static final Pattern url = Pattern.compile( "^(?:(https?)://)?([-\\w_\\.]{2,}\\.[a-z]{2,4})(/\\S*)?$" );
+    private static final Pattern url = Pattern.compile( "^(?:(https?)://)?([-\\w_\\.]{2,}\\.[a-z-]{2,24})(/\\S*)?$" );
 
     /**
      * Converts the old formatting system that used


### PR DESCRIPTION
List of all tlds can be found here (the longest is 24 chars) http://data.iana.org/TLD/tlds-alpha-by-domain.txt


example domain that has an online website:
This is the longest (decoded its https://whois.nic.vermögensberatung/ containing the german ö letter)
https://whois.nic.xn--vermgensberatung-pwb/ 
