### PR TITLE
Replace most println calls with proxy logger

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/module/JenkinsModuleSource.java
+++ b/proxy/src/main/java/net/md_5/bungee/module/JenkinsModuleSource.java
@@ -7,6 +7,7 @@ import java.net.URL;
 import java.net.URLConnection;
 import lombok.Data;
 import net.md_5.bungee.Util;
+import net.md_5.bungee.api.ProxyServer;
 
 @Data
 public class JenkinsModuleSource implements ModuleSource
@@ -15,7 +16,7 @@ public class JenkinsModuleSource implements ModuleSource
     @Override
     public void retrieve(ModuleSpec module, ModuleVersion version)
     {
-        System.out.println( "Attempting to Jenkins download module " + module.getName() + " v" + version.getBuild() );
+        ProxyServer.getInstance().getLogger().info( "Attempting to Jenkins download module " + module.getName() + " v" + version.getBuild() );
         try
         {
             URL website = new URL( "https://ci.md-5.net/job/BungeeCord/" + version.getBuild() + "/artifact/module/" + module.getName().replace( '_', '-' ) + "/target/" + module.getName() + ".jar" );
@@ -25,10 +26,10 @@ public class JenkinsModuleSource implements ModuleSource
             con.setReadTimeout( 15000 );
 
             Files.write( ByteStreams.toByteArray( con.getInputStream() ), module.getFile() );
-            System.out.println( "Download complete" );
+            ProxyServer.getInstance().getLogger().info( "Download complete" );
         } catch ( IOException ex )
         {
-            System.out.println( "Failed to download: " + Util.exception( ex ) );
+            ProxyServer.getInstance().getLogger().warning( "Failed to download: " + Util.exception( ex ) );
         }
     }
 }

--- a/proxy/src/main/java/net/md_5/bungee/module/ModuleManager.java
+++ b/proxy/src/main/java/net/md_5/bungee/module/ModuleManager.java
@@ -44,7 +44,7 @@ public class ModuleManager
         ModuleVersion bungeeVersion = ModuleVersion.parse( proxy.getVersion() );
         if ( bungeeVersion == null )
         {
-            System.out.println( "Couldn't detect bungee version. Custom build?" );
+            proxy.getLogger().warning( "Couldn't detect bungee version. Custom build?" );
             return;
         }
 
@@ -105,19 +105,19 @@ public class ModuleManager
             ModuleSource source = knownSources.get( uri.getScheme() );
             if ( source == null )
             {
-                System.out.println( "Unknown module source: " + s );
+                proxy.getLogger().warning( "Unknown module source: " + s );
                 continue;
             }
             String name = uri.getAuthority();
             if ( name == null )
             {
-                System.out.println( "Unknown module host: " + s );
+                proxy.getLogger().warning( "Unknown module host: " + s );
                 continue;
             }
 
             ModuleSpec spec = new ModuleSpec( name, new File( moduleDirectory, name + ".jar" ), source );
             modules.add( spec );
-            System.out.println( "Discovered module: " + spec );
+            proxy.getLogger().info( "Discovered module: " + spec );
         }
 
         for ( ModuleSpec module : modules )
@@ -126,7 +126,7 @@ public class ModuleManager
 
             if ( !bungeeVersion.equals( moduleVersion ) )
             {
-                System.out.println( "Attempting to update plugin from " + moduleVersion + " to " + bungeeVersion );
+                proxy.getLogger().info( "Attempting to update plugin from " + moduleVersion + " to " + bungeeVersion );
                 module.getProvider().retrieve( module, bungeeVersion );
             }
         }


### PR DESCRIPTION
We have access to the logger and the logger is already initialized so we should use the logger