### PR TITLE
fix protocol state issue

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -66,6 +66,7 @@ import net.md_5.bungee.protocol.packet.Handshake;
 import net.md_5.bungee.protocol.packet.Kick;
 import net.md_5.bungee.protocol.packet.LegacyHandshake;
 import net.md_5.bungee.protocol.packet.LegacyPing;
+import net.md_5.bungee.protocol.packet.LoginAcknowledged;
 import net.md_5.bungee.protocol.packet.LoginPayloadResponse;
 import net.md_5.bungee.protocol.packet.LoginRequest;
 import net.md_5.bungee.protocol.packet.LoginSuccess;
@@ -688,6 +689,13 @@ public class InitialHandler extends PacketHandler implements PendingConnection
     public void handle(LoginPayloadResponse response) throws Exception
     {
         disconnect( "Unexpected custom LoginPayloadResponse" );
+    }
+
+    @Override
+    public void handle(LoginAcknowledged loginAcknowledged) throws Exception
+    {
+        // this packet should only be sent after the login success (it should be handled in the UpstreamBridge)
+        disconnect( "Unexpected LoginAcknowledged" );
     }
 
     @Override


### PR DESCRIPTION
right now you can jump after sending a login or transfer  handshake into the config protocol and from the config protocol to the game protocol. So you bassicly can jump to all network protocol. you just need to send a LoginAck after the handshake and you are in config state this should not be possible.