### PR TITLE
add simple login payload api

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/connection/PendingConnection.java
+++ b/api/src/main/java/net/md_5/bungee/api/connection/PendingConnection.java
@@ -113,4 +113,16 @@ public interface PendingConnection extends Connection
      */
     @ApiStatus.Experimental
     CompletableFuture<byte[]> retrieveCookie(String cookie);
+
+    /**
+     * Sends a login payload request to the client.
+     *
+     * @param channel the channel to send this data via
+     * @param data the data to send
+     * @return a {@link CompletableFuture} that will be completed when the
+     * Login Payload response is received.
+     * @throws IllegalStateException if the player's version is not at least
+     * 1.13
+     */
+    CompletableFuture<byte[]> sendData(String channel, byte[] data);
 }

--- a/api/src/main/java/net/md_5/bungee/api/connection/PendingConnection.java
+++ b/api/src/main/java/net/md_5/bungee/api/connection/PendingConnection.java
@@ -120,7 +120,8 @@ public interface PendingConnection extends Connection
      * @param channel the channel to send this data via
      * @param data the data to send
      * @return a {@link CompletableFuture} that will be completed when the
-     * Login Payload response is received.
+     * Login Payload response is received. If the client doesn't know the channel,
+     * the {@link CompletableFuture} will complete with a null value
      * @throws IllegalStateException if the player's version is not at least
      * 1.13
      */

--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -902,12 +902,6 @@ public class InitialHandler extends PacketHandler implements PendingConnection
         Preconditions.checkState( getVersion() >= ProtocolConstants.MINECRAFT_1_13, "LoginPayloads are only supported in 1.13 and above" );
         Preconditions.checkState( loginRequest != null, "Cannot send login data for status or legacy connections" );
 
-        if ( channel.indexOf( ':' ) == -1 )
-        {
-            // if we request an invalid resource location (no prefix) the client will respond with "minecraft:" prefix
-            channel = "minecraft:" + channel;
-        }
-
         CompletableFuture<byte[]> future = new CompletableFuture<>();
         final int id;
         synchronized ( requestedLoginPayloads )

--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -10,8 +10,10 @@ import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.security.MessageDigest;
 import java.time.Instant;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
+import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
 import java.util.UUID;
@@ -67,6 +69,7 @@ import net.md_5.bungee.protocol.packet.Kick;
 import net.md_5.bungee.protocol.packet.LegacyHandshake;
 import net.md_5.bungee.protocol.packet.LegacyPing;
 import net.md_5.bungee.protocol.packet.LoginAcknowledged;
+import net.md_5.bungee.protocol.packet.LoginPayloadRequest;
 import net.md_5.bungee.protocol.packet.LoginPayloadResponse;
 import net.md_5.bungee.protocol.packet.LoginRequest;
 import net.md_5.bungee.protocol.packet.LoginSuccess;
@@ -96,6 +99,8 @@ public class InitialHandler extends PacketHandler implements PendingConnection
     @Getter
     private final Set<String> registeredChannels = new HashSet<>();
     private State thisState = State.HANDSHAKE;
+    private int loginPayloadId;
+    private final Map<Integer, CompletableFuture<byte[]>> requestedLoginPayloads = new HashMap<>();
     private final Queue<CookieFuture> requestedCookies = new LinkedList<>();
 
     @Data
@@ -688,7 +693,13 @@ public class InitialHandler extends PacketHandler implements PendingConnection
     @Override
     public void handle(LoginPayloadResponse response) throws Exception
     {
-        disconnect( "Unexpected custom LoginPayloadResponse" );
+        CompletableFuture<byte[]> future;
+        synchronized ( requestedLoginPayloads )
+        {
+            future = requestedLoginPayloads.remove( response.getId() );
+        }
+        Preconditions.checkState( future != null, "Unexpected custom LoginPayloadResponse" );
+        future.complete( response.getData() );
     }
 
     @Override
@@ -882,6 +893,30 @@ public class InitialHandler extends PacketHandler implements PendingConnection
         }
         unsafe.sendPacket( new CookieRequest( cookie ) );
 
+        return future;
+    }
+
+    @Override
+    public CompletableFuture<byte[]> sendData(String channel, byte[] data)
+    {
+        Preconditions.checkState( getVersion() >= ProtocolConstants.MINECRAFT_1_13, "LoginPayloads are only supported in 1.13 and above" );
+        Preconditions.checkState( loginRequest != null, "Cannot send login data for status or legacy connections" );
+
+        if ( channel.indexOf( ':' ) == -1 )
+        {
+            // if we request an invalid resource location (no prefix) the client will respond with "minecraft:" prefix
+            channel = "minecraft:" + channel;
+        }
+
+        CompletableFuture<byte[]> future = new CompletableFuture<>();
+        final int id;
+        synchronized ( requestedLoginPayloads )
+        {
+            // thread safe loginPayloadId
+            id = loginPayloadId++;
+            requestedLoginPayloads.put( id, future );
+        }
+        unsafe.sendPacket( new LoginPayloadRequest( id, channel, data ) );
         return future;
     }
 }


### PR DESCRIPTION
With this api you can send a login payload and retrive the response of it with the same method.

It can be used for custom clients.
It could also be used to filter invalid clients that do not response.

If a packet was not requested an exception is thrown.

I made use of the CompletableFutures again.