### PR TITLE
Add more InitialHandler security checks

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -196,6 +196,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
     @Override
     public void handle(LegacyHandshake legacyHandshake) throws Exception
     {
+        Preconditions.checkState( !this.legacy, "Not expecting LegacyHandshake" );
         this.legacy = true;
         ch.close( bungee.getTranslation( "outdated_client", bungee.getGameVersion() ) );
     }
@@ -203,6 +204,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
     @Override
     public void handle(LegacyPing ping) throws Exception
     {
+        Preconditions.checkState( !this.legacy, "Not expecting LegacyPing" );
         this.legacy = true;
         final boolean v1_5 = ping.isV1_5();
 
@@ -342,7 +344,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
     @Override
     public void handle(Handshake handshake) throws Exception
     {
-        Preconditions.checkState( thisState == State.HANDSHAKE, "Not expecting HANDSHAKE" );
+        Preconditions.checkState( thisState == State.HANDSHAKE && !this.legacy, "Not expecting HANDSHAKE" );
         this.handshake = handshake;
         ch.setVersion( handshake.getProtocolVersion() );
         ch.getHandle().pipeline().remove( PipelineUtils.LEGACY_KICKER );
@@ -420,7 +422,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
     @Override
     public void handle(LoginRequest loginRequest) throws Exception
     {
-        Preconditions.checkState( thisState == State.USERNAME, "Not expecting USERNAME" );
+        Preconditions.checkState( thisState == State.USERNAME && this.loginRequest == null, "Not expecting USERNAME" );
 
         if ( !AllowedCharacters.isValidName( loginRequest.getData(), onlineMode ) )
         {


### PR DESCRIPTION
Its in possible to use async events to do some weird stuff in the networking this should fix it.

You could send some packets multiple times or send packets that should not be possible to send in some states

Its for exaple possible to call the LoginEvent multiple times with an connection if an async intent is registered