### PR TITLE
Fix potential race conditions when connecting to multiple servers at the same time

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
+++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
@@ -361,7 +361,10 @@ public class ServerConnector extends PacketHandler
             if ( user.getServer() != null )
             {
                 // Begin config mode
-                user.unsafe().sendPacket( new StartConfiguration() );
+                if ( user.getCh().getEncodeProtocol() != Protocol.CONFIGURATION )
+                {
+                    user.unsafe().sendPacket( new StartConfiguration() );
+                }
             } else
             {
                 LoginResult loginProfile = user.getPendingConnection().getLoginProfile();

--- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
@@ -306,6 +306,11 @@ public final class UserConnection implements ProxiedPlayer
     {
         Preconditions.checkNotNull( request, "request" );
 
+        ch.getHandle().eventLoop().execute( () -> connect0( request ) );
+    }
+
+    private void connect0(final ServerConnectRequest request)
+    {
         final Callback<ServerConnectRequest.Result> callback = request.getCallback();
         ServerConnectEvent event = new ServerConnectEvent( this, request.getTarget(), request.getReason(), request );
         if ( bungee.getPluginManager().callEvent( event ).isCancelled() )
@@ -390,11 +395,11 @@ public final class UserConnection implements ProxiedPlayer
             }
         };
         Bootstrap b = new Bootstrap()
-                .channel( PipelineUtils.getChannel( target.getAddress() ) )
-                .group( ch.getHandle().eventLoop() )
-                .handler( initializer )
-                .option( ChannelOption.CONNECT_TIMEOUT_MILLIS, request.getConnectTimeout() )
-                .remoteAddress( target.getAddress() );
+            .channel( PipelineUtils.getChannel( target.getAddress() ) )
+            .group( ch.getHandle().eventLoop() )
+            .handler( initializer )
+            .option( ChannelOption.CONNECT_TIMEOUT_MILLIS, request.getConnectTimeout() )
+            .remoteAddress( target.getAddress() );
         // Windows is bugged, multi homed users will just have to live with random connecting IPs
         if ( getPendingConnection().getListener().isSetLocalAddress() && !PlatformDependent.isWindows() && getPendingConnection().getListener().getSocketAddress() instanceof InetSocketAddress )
         {

--- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
@@ -320,10 +320,6 @@ public final class UserConnection implements ProxiedPlayer
                 callback.done( ServerConnectRequest.Result.EVENT_CANCEL, null );
             }
 
-            if ( getServer() == null && !ch.isClosing() )
-            {
-                throw new IllegalStateException( "Cancelled ServerConnectEvent with no server or disconnect." );
-            }
             return;
         }
 

--- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
@@ -395,11 +395,11 @@ public final class UserConnection implements ProxiedPlayer
             }
         };
         Bootstrap b = new Bootstrap()
-            .channel( PipelineUtils.getChannel( target.getAddress() ) )
-            .group( ch.getHandle().eventLoop() )
-            .handler( initializer )
-            .option( ChannelOption.CONNECT_TIMEOUT_MILLIS, request.getConnectTimeout() )
-            .remoteAddress( target.getAddress() );
+                .channel( PipelineUtils.getChannel( target.getAddress() ) )
+                .group( ch.getHandle().eventLoop() )
+                .handler( initializer )
+                .option( ChannelOption.CONNECT_TIMEOUT_MILLIS, request.getConnectTimeout() )
+                .remoteAddress( target.getAddress() );
         // Windows is bugged, multi homed users will just have to live with random connecting IPs
         if ( getPendingConnection().getListener().isSetLocalAddress() && !PlatformDependent.isWindows() && getPendingConnection().getListener().getSocketAddress() instanceof InetSocketAddress )
         {


### PR DESCRIPTION
This pull request fixes 2 very rare bugs that cause a race condition when connecting to a server.

1. It is possible to open multiple connections to the same server at the same time if you call the UserConnection#connect method from different threads.

This pull request fixes this by scheduling the connection to the server in an eventloop.

2. There is a possibility that the proxy could send a StartConfiguration packet in a situation where the client is still in the Configuration phase, causing the client to disconnect from the proxy with a "CookieRequest" decoding error.
This most often happens when the proxy opens multiple connections to different servers at the same time.

This pull request fixes this by ensuring that the StartConfiguration packet is only sent when the client is not in the Configuration phase.