### PR TITLE
Allow protocol encryption in offline mode

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/EncryptionUtil.java
+++ b/proxy/src/main/java/net/md_5/bungee/EncryptionUtil.java
@@ -64,14 +64,14 @@ public class EncryptionUtil
         }
     }
 
-    public static EncryptionRequest encryptRequest()
+    public static EncryptionRequest encryptRequest(boolean shouldAuthenticate)
     {
         String hash = Long.toString( random.nextLong(), 16 );
         byte[] pubKey = keys.getPublic().getEncoded();
         byte[] verify = new byte[ 4 ];
         random.nextBytes( verify );
-        // always auth for now
-        return new EncryptionRequest( hash, pubKey, verify, true );
+
+        return new EncryptionRequest( hash, pubKey, verify, shouldAuthenticate );
     }
 
     public static boolean check(PlayerPublicKey publicKey, UUID uuid) throws GeneralSecurityException

--- a/proxy/src/main/java/net/md_5/bungee/conf/Configuration.java
+++ b/proxy/src/main/java/net/md_5/bungee/conf/Configuration.java
@@ -48,6 +48,11 @@ public class Configuration implements ProxyConfig
      */
     private boolean onlineMode = true;
     /**
+     * Should player connections be encrypted if {@link #onlineMode} is false?
+     * Only supported for versions 1.20.5 and newer
+     */
+    private boolean encryptInOfflineMode = false;
+    /**
      * Whether to check the authentication server public key.
      */
     private boolean enforceSecureProfile;
@@ -91,6 +96,7 @@ public class Configuration implements ProxyConfig
         timeout = adapter.getInt( "timeout", timeout );
         uuid = adapter.getString( "stats", uuid );
         onlineMode = adapter.getBoolean( "online_mode", onlineMode );
+        encryptInOfflineMode = adapter.getBoolean( "encrypt_in_offline_mode", encryptInOfflineMode );
         enforceSecureProfile = adapter.getBoolean( "enforce_secure_profile", enforceSecureProfile );
         logCommands = adapter.getBoolean( "log_commands", logCommands );
         logPings = adapter.getBoolean( "log_pings", logPings );


### PR DESCRIPTION
Snapshot 24w03a for version 1.20.5 added support for protocol encryption for offline-mode servers. This adds support for encrypting player connections if the proxy is in offline mode and the client is new enough.