### PR TITLE
Fix potential overriding of cipher by other libraries

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/EncryptionUtil.java
+++ b/proxy/src/main/java/net/md_5/bungee/EncryptionUtil.java
@@ -11,12 +11,12 @@ import java.security.Key;
 import java.security.KeyFactory;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
+import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
 import java.security.Signature;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.X509EncodedKeySpec;
-import java.util.Arrays;
 import java.util.Base64;
 import java.util.Random;
 import java.util.UUID;
@@ -108,17 +108,17 @@ public class EncryptionUtil
             return signature.verify( resp.getEncryptionData().getSignature() );
         } else
         {
-            Cipher cipher = Cipher.getInstance( "RSA" );
+            Cipher cipher = Cipher.getInstance( "RSA/ECB/PKCS1Padding" );
             cipher.init( Cipher.DECRYPT_MODE, keys.getPrivate() );
             byte[] decrypted = cipher.doFinal( resp.getVerifyToken() );
 
-            return Arrays.equals( request.getVerifyToken(), decrypted );
+            return MessageDigest.isEqual( request.getVerifyToken(), decrypted );
         }
     }
 
     public static SecretKey getSecret(EncryptionResponse resp, EncryptionRequest request) throws GeneralSecurityException
     {
-        Cipher cipher = Cipher.getInstance( "RSA" );
+        Cipher cipher = Cipher.getInstance( "RSA/ECB/PKCS1Padding" );
         cipher.init( Cipher.DECRYPT_MODE, keys.getPrivate() );
         return new SecretKeySpec( cipher.doFinal( resp.getSharedSecret() ), "AES" );
     }
@@ -143,7 +143,7 @@ public class EncryptionUtil
 
     public static byte[] encrypt(Key key, byte[] b) throws GeneralSecurityException
     {
-        Cipher hasher = Cipher.getInstance( "RSA" );
+        Cipher hasher = Cipher.getInstance( "RSA/ECB/PKCS1Padding" );
         hasher.init( Cipher.ENCRYPT_MODE, key );
         return hasher.doFinal( b );
     }


### PR DESCRIPTION
This pull request forces the use of specific RSA options, i.e. ECB and PKCS1Padding for cipher.
Specifying "RSA" without specific options will use the default options described above, however libraries such as BouncyCastle provided by various plugins may override this behavior, making it impossible to compare the secret correctly.

In this particular case, the default "RSA" implementation in BouncyCastle uses the following options "RSA/ECB/NoPadding", which results in any secret being impossible to compare, since the padding is not removed from it.

I also considered forcing the "SunJCE" provider in cipher, which also fixes this issue, however I think it is better to allow other libraries to influence this behavior, especially if it can improve performance.

In addition, this pull request also replaces the use of Arrays#equals with MessageDigest#isEqual which should have a positive impact on security.