### PR TITLE
Remove unnecessary protocol version check for UnsignedClientCommand

### DIFF
--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/UnsignedClientCommand.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/UnsignedClientCommand.java
@@ -21,7 +21,7 @@ public class UnsignedClientCommand extends DefinedPacket
     @Override
     public void read(ByteBuf buf, ProtocolConstants.Direction direction, int protocolVersion)
     {
-        command = readString( buf, ( protocolVersion >= ProtocolConstants.MINECRAFT_1_20_5 ) ? 32767 : 256 );
+        command = readString( buf );
     }
 
     @Override


### PR DESCRIPTION
UnsignedClientCommand packet is only registered for 1.20.5 and above.
This check was added by #3715 for ClientCommand and  UnsignedClientCommand, but its only required for ClientCommand.