### PR TITLE
Fix possible NPE when trying to get encoder protocol

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/ServerConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/ServerConnection.java
@@ -4,7 +4,6 @@ import com.google.common.base.Preconditions;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.ArrayDeque;
-import java.util.LinkedList;
 import java.util.Queue;
 import lombok.Data;
 import lombok.Getter;
@@ -32,7 +31,7 @@ public class ServerConnection implements Server
     private final boolean forgeServer = false;
     @Getter
     private final Queue<KeepAliveData> keepAlives = new ArrayDeque<>();
-    private final Queue<DefinedPacket> packetQueue = new LinkedList<>();
+    private final Queue<DefinedPacket> packetQueue = new ArrayDeque<>();
 
     private final Unsafe unsafe = new Unsafe()
     {

--- a/proxy/src/main/java/net/md_5/bungee/ServerConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/ServerConnection.java
@@ -4,8 +4,8 @@ import com.google.common.base.Preconditions;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.ArrayDeque;
+import java.util.LinkedList;
 import java.util.Queue;
-import java.util.concurrent.ConcurrentLinkedQueue;
 import lombok.Data;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -32,7 +32,7 @@ public class ServerConnection implements Server
     private final boolean forgeServer = false;
     @Getter
     private final Queue<KeepAliveData> keepAlives = new ArrayDeque<>();
-    private final Queue<DefinedPacket> packetQueue = new ConcurrentLinkedQueue<>();
+    private final Queue<DefinedPacket> packetQueue = new LinkedList<>();
 
     private final Unsafe unsafe = new Unsafe()
     {
@@ -45,27 +45,37 @@ public class ServerConnection implements Server
 
     public void sendPacketQueued(DefinedPacket packet)
     {
-        Protocol encodeProtocol = ch.getEncodeProtocol();
-        if ( encodeProtocol == null )
+        ch.scheduleIfNecessary( () ->
         {
-            return;
-        }
-        if ( !encodeProtocol.TO_SERVER.hasPacket( packet.getClass(), ch.getEncodeVersion() ) )
-        {
-            packetQueue.add( packet );
-        } else
-        {
-            unsafe().sendPacket( packet );
-        }
+            if ( ch.isClosed() )
+            {
+                return;
+            }
+            Protocol encodeProtocol = ch.getEncodeProtocol();
+            if ( !encodeProtocol.TO_SERVER.hasPacket( packet.getClass(), ch.getEncodeVersion() ) )
+            {
+                packetQueue.add( packet );
+            } else
+            {
+                unsafe().sendPacket( packet );
+            }
+        } );
     }
 
     public void sendQueuedPackets()
     {
-        DefinedPacket packet;
-        while ( ( packet = packetQueue.poll() ) != null )
+        ch.scheduleIfNecessary( () ->
         {
-            unsafe().sendPacket( packet );
-        }
+            if ( ch.isClosed() )
+            {
+                return;
+            }
+            DefinedPacket packet;
+            while ( ( packet = packetQueue.poll() ) != null )
+            {
+                unsafe().sendPacket( packet );
+            }
+        } );
     }
 
     @Override

--- a/proxy/src/main/java/net/md_5/bungee/ServerConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/ServerConnection.java
@@ -46,6 +46,10 @@ public class ServerConnection implements Server
     public void sendPacketQueued(DefinedPacket packet)
     {
         Protocol encodeProtocol = ch.getEncodeProtocol();
+        if ( encodeProtocol == null )
+        {
+            return;
+        }
         if ( !encodeProtocol.TO_SERVER.hasPacket( packet.getClass(), ch.getEncodeVersion() ) )
         {
             packetQueue.add( packet );

--- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
@@ -11,6 +11,7 @@ import io.netty.channel.ChannelOption;
 import io.netty.util.internal.PlatformDependent;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.util.ArrayDeque;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -145,7 +146,7 @@ public final class UserConnection implements ProxiedPlayer
     @Setter
     private ForgeServerHandler forgeServerHandler;
     /*========================================================================*/
-    private final Queue<DefinedPacket> packetQueue = new LinkedList<>();
+    private final Queue<DefinedPacket> packetQueue = new ArrayDeque<>();
     private final Unsafe unsafe = new Unsafe()
     {
         @Override

--- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
@@ -187,6 +187,10 @@ public final class UserConnection implements ProxiedPlayer
     public void sendPacketQueued(DefinedPacket packet)
     {
         Protocol encodeProtocol = ch.getEncodeProtocol();
+        if ( encodeProtocol == null )
+        {
+            return;
+        }
         if ( !encodeProtocol.TO_CLIENT.hasPacket( packet.getClass(), getPendingConnection().getVersion() ) )
         {
             packetQueue.add( packet );

--- a/proxy/src/main/java/net/md_5/bungee/netty/ChannelWrapper.java
+++ b/proxy/src/main/java/net/md_5/bungee/netty/ChannelWrapper.java
@@ -42,12 +42,7 @@ public class ChannelWrapper
 
     public Protocol getDecodeProtocol()
     {
-        MinecraftDecoder minecraftDecoder = getMinecraftDecoder();
-        if ( minecraftDecoder == null )
-        {
-            return null;
-        }
-        return minecraftDecoder.getProtocol();
+        return getMinecraftDecoder().getProtocol();
     }
 
     public void setDecodeProtocol(Protocol protocol)
@@ -57,12 +52,7 @@ public class ChannelWrapper
 
     public Protocol getEncodeProtocol()
     {
-        MinecraftEncoder minecraftEncoder = getMinecraftEncoder();
-        if ( minecraftEncoder == null )
-        {
-            return null;
-        }
-        return minecraftEncoder.getProtocol();
+        return getMinecraftEncoder().getProtocol();
     }
 
     public void setEncodeProtocol(Protocol protocol)
@@ -241,5 +231,16 @@ public class ChannelWrapper
             } );
             packetCompressor.setCompose( compressorCompose );
         }
+    }
+
+    public void scheduleIfNecessary(Runnable task)
+    {
+        if ( ch.eventLoop().inEventLoop() )
+        {
+            task.run();
+            return;
+        }
+
+        ch.eventLoop().execute( task );
     }
 }

--- a/proxy/src/main/java/net/md_5/bungee/netty/ChannelWrapper.java
+++ b/proxy/src/main/java/net/md_5/bungee/netty/ChannelWrapper.java
@@ -42,23 +42,32 @@ public class ChannelWrapper
 
     public Protocol getDecodeProtocol()
     {
-        return ch.pipeline().get( MinecraftDecoder.class ).getProtocol();
+        MinecraftDecoder minecraftDecoder = getMinecraftDecoder();
+        if ( minecraftDecoder == null )
+        {
+            return null;
+        }
+        return minecraftDecoder.getProtocol();
     }
 
     public void setDecodeProtocol(Protocol protocol)
     {
-        ch.pipeline().get( MinecraftDecoder.class ).setProtocol( protocol );
+        getMinecraftDecoder().setProtocol( protocol );
     }
 
     public Protocol getEncodeProtocol()
     {
-        return ch.pipeline().get( MinecraftEncoder.class ).getProtocol();
-
+        MinecraftEncoder minecraftEncoder = getMinecraftEncoder();
+        if ( minecraftEncoder == null )
+        {
+            return null;
+        }
+        return minecraftEncoder.getProtocol();
     }
 
     public void setEncodeProtocol(Protocol protocol)
     {
-        ch.pipeline().get( MinecraftEncoder.class ).setProtocol( protocol );
+        getMinecraftEncoder().setProtocol( protocol );
     }
 
     public void setProtocol(Protocol protocol)
@@ -69,13 +78,23 @@ public class ChannelWrapper
 
     public void setVersion(int protocol)
     {
-        ch.pipeline().get( MinecraftDecoder.class ).setProtocolVersion( protocol );
-        ch.pipeline().get( MinecraftEncoder.class ).setProtocolVersion( protocol );
+        getMinecraftDecoder().setProtocolVersion( protocol );
+        getMinecraftEncoder().setProtocolVersion( protocol );
+    }
+
+    public MinecraftDecoder getMinecraftDecoder()
+    {
+        return ch.pipeline().get( MinecraftDecoder.class );
+    }
+
+    public MinecraftEncoder getMinecraftEncoder()
+    {
+        return ch.pipeline().get( MinecraftEncoder.class );
     }
 
     public int getEncodeVersion()
     {
-        return ch.pipeline().get( MinecraftEncoder.class ).getProtocolVersion();
+        return getMinecraftEncoder().getProtocolVersion();
     }
 
     public void write(Object packet)


### PR DESCRIPTION
This pull request fixes a rare race condition where the proxy can try to send a packet to a queue when the connection to the player has already been closed and netty has managed to clear all handlers, including MinecraftEncoder and MinecraftDecoder, causing a NullPointerException.

This can usually happen when a player who is already trying to connect to another server unexpectedly disconnects from the proxy, and when the server the player was connecting to kicks the player, which in rare cases causes a connection error message to be sent to the player whose connection is already closed.

The solution to the problem seems simple: 
~~Just return null for those methods that return Protocol if there are no handlers.~~
Schedule eventloop to add packets to the queue when necessary. 
