### PR TITLE
Fix forgotten boolean write in EncryptionResponse#write

### DIFF
--- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/EncryptionResponse.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/EncryptionResponse.java
@@ -45,6 +45,10 @@ public class EncryptionResponse extends DefinedPacket
             writeArray( verifyToken, buf );
         } else
         {
+            if ( protocolVersion >= ProtocolConstants.MINECRAFT_1_19 && protocolVersion <= ProtocolConstants.MINECRAFT_1_19_3 )
+            {
+                buf.writeBoolean( false );
+            }
             buf.writeLong( encryptionData.getSalt() );
             writeArray( encryptionData.getSignature(), buf );
         }


### PR DESCRIPTION
actually this method is never used as we dont support backend encryption right now.
but it should be fixed anyway