### PR TITLE
Remove explicit direct buffer check

### DIFF
--- a/native/src/main/java/net/md_5/bungee/jni/cipher/NativeCipher.java
+++ b/native/src/main/java/net/md_5/bungee/jni/cipher/NativeCipher.java
@@ -37,9 +37,6 @@ public class NativeCipher implements BungeeCipher
     @Override
     public void cipher(ByteBuf in, ByteBuf out) throws GeneralSecurityException
     {
-        // Smoke tests
-        in.memoryAddress();
-        out.memoryAddress();
         Preconditions.checkState( ctx != 0, "Invalid pointer to AES key!" );
 
         // Store how many bytes we can cipher

--- a/native/src/main/java/net/md_5/bungee/jni/zlib/NativeZlib.java
+++ b/native/src/main/java/net/md_5/bungee/jni/zlib/NativeZlib.java
@@ -48,9 +48,6 @@ public class NativeZlib implements BungeeZlib
     @Override
     public void process(ByteBuf in, ByteBuf out) throws DataFormatException
     {
-        // Smoke tests
-        in.memoryAddress();
-        out.memoryAddress();
         Preconditions.checkState( ctx != 0, "Invalid pointer to compress!" );
 
         while ( !nativeCompress.finished && ( compress || in.isReadable() ) )


### PR DESCRIPTION
Code does not do anything significant before the normal code calls these functions anyway.

Or has there been done some performance check in the past?