### PR TITLE
[API] Add and expose `isRunning` 

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/ProxyServer.java
+++ b/api/src/main/java/net/md_5/bungee/api/ProxyServer.java
@@ -311,4 +311,9 @@ public abstract class ProxyServer
      */
     public abstract Title createTitle();
 
+    /**
+     * Gets the operation state of the proxy.
+     * @return true if the proxy is running
+     */
+    public abstract boolean isRunning();
 }

--- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
@@ -831,4 +831,9 @@ public class BungeeCord extends ProxyServer
     {
         return new BungeeTitle();
     }
+
+    @Override
+    public boolean isRunning() {
+        return this.isRunning;
+    }
 }


### PR DESCRIPTION
Exposing this variable on the API level will allow developers to run certain logic if the proxy server shuts down. To my knowledge, there is no way of telling if the proxy is shutting down besides the `onDisable()` method in `Plugin`, and that would only be invoked after clients are disconnected and whatnot.