### PR TITLE
Increase the max capacity for decompressed packets

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/compress/PacketDecompressor.java
+++ b/proxy/src/main/java/net/md_5/bungee/compress/PacketDecompressor.java
@@ -41,7 +41,9 @@ public class PacketDecompressor extends MessageToMessageDecoder<ByteBuf>
                 throw new OverflowPacketException( "Packet may not be larger than " + MAX_DECOMPRESSED_LEN + " bytes" );
             }
 
-            ByteBuf decompressed = ctx.alloc().directBuffer( size, size );
+            // do not use size as max capacity, as its possible that the entity rewritter increases the size afterwarts
+            // this would result in a kick (it happens rarely as the entity ids size must differ)
+            ByteBuf decompressed = ctx.alloc().directBuffer( size, MAX_DECOMPRESSED_LEN );
             try
             {
                 zlib.process( in, decompressed );


### PR DESCRIPTION
do not use size as max capacity, as its possible that the entity rewritter increases the size afterwarts this would result in a kick (it happens rarely as the entity ids size must differ)