### PR TITLE
Null check team collision rule because it does not exist in 1.8

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
@@ -284,8 +284,11 @@ public class DownstreamBridge extends PacketHandler
                 t.setSuffix( team.getSuffix().getLeftOrCompute( ComponentSerializer::toString ) );
                 t.setFriendlyFire( team.getFriendlyFire() );
                 t.setNameTagVisibility( team.getNameTagVisibility().getKey() );
-                t.setCollisionRule( team.getCollisionRule().getKey() );
                 t.setColor( team.getColor() );
+                if ( team.getCollisionRule() != null )
+                {
+                    t.setCollisionRule( team.getCollisionRule().getKey() );
+                }
             }
             if ( team.getPlayers() != null )
             {


### PR DESCRIPTION
closes #3777