### PR TITLE
Consolidate flushes

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
+++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
@@ -161,6 +161,7 @@ public class ServerConnector extends PacketHandler
     public void handle(LoginSuccess loginSuccess) throws Exception
     {
         Preconditions.checkState( thisState == State.LOGIN_SUCCESS, "Not expecting LOGIN_SUCCESS" );
+        user.getCh().setConsolidate( false );
         if ( user.getPendingConnection().getVersion() >= ProtocolConstants.MINECRAFT_1_20_2 )
         {
             ServerConnection server = new ServerConnection( ch, target );

--- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
@@ -799,7 +799,19 @@ public class DownstreamBridge extends PacketHandler
         receivedLogin = true;
         ServerConnector.handleLogin( bungee, server.getCh(), con, server.getInfo(), null, server, login );
 
+        con.getCh().setConsolidate( true );
+        server.getCh().setConsolidate( true );
+
         throw CancelSendSignal.INSTANCE;
+    }
+
+    @Override
+    public void channelReadComplete(ChannelWrapper channel) throws Exception
+    {
+        if ( con.isConnected() )
+        {
+            con.getCh().forceFlush();
+        }
     }
 
     @Override

--- a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
@@ -386,6 +386,15 @@ public class UpstreamBridge extends PacketHandler
     }
 
     @Override
+    public void channelReadComplete(ChannelWrapper channel) throws Exception
+    {
+        if ( con.getServer() != null && con.getServer().isConnected() )
+        {
+            con.getServer().getCh().forceFlush();
+        }
+    }
+
+    @Override
     public String toString()
     {
         return "[" + con.getName() + "] -> UpstreamBridge";

--- a/proxy/src/main/java/net/md_5/bungee/netty/ChannelWrapper.java
+++ b/proxy/src/main/java/net/md_5/bungee/netty/ChannelWrapper.java
@@ -24,6 +24,7 @@ import net.md_5.bungee.protocol.packet.Kick;
 
 public class ChannelWrapper
 {
+    private static final int MAX_CONSOLIDATION = Integer.getInteger("net.md_5.bungee.flush-consolidation-limit", 20);
 
     private final Channel ch;
     @Getter
@@ -33,11 +34,19 @@ public class ChannelWrapper
     private volatile boolean closed;
     @Getter
     private volatile boolean closing;
+    private boolean consolidate;
+    private int consolidationCounter;
 
     public ChannelWrapper(ChannelHandlerContext ctx)
     {
         this.ch = ctx.channel();
         this.remoteAddress = ( this.ch.remoteAddress() == null ) ? this.ch.parent().localAddress() : this.ch.remoteAddress();
+    }
+
+    public void setConsolidate(boolean enabled)
+    {
+        consolidate = enabled;
+        forceFlush();
     }
 
     public Protocol getDecodeProtocol()
@@ -57,6 +66,8 @@ public class ChannelWrapper
 
     public void setEncodeProtocol(Protocol protocol)
     {
+        // before changing the encoder protocol we should always flush to ensure no wrong states
+        forceFlush();
         getMinecraftEncoder().setProtocol( protocol );
     }
 
@@ -89,6 +100,15 @@ public class ChannelWrapper
 
     public void write(Object packet)
     {
+        // ensure netty context to for less context schedules
+        // by default we are mostly in netty context anyway, but plugins can use ProxiedPlayer.unsafe().sendPacket()
+        // in non netty context
+        if ( !ch.eventLoop().inEventLoop() )
+        {
+            ch.eventLoop().execute( () -> write( packet ) );
+            return;
+        }
+
         if ( !closed )
         {
             DefinedPacket defined = null;
@@ -96,11 +116,11 @@ public class ChannelWrapper
             {
                 PacketWrapper wrapper = (PacketWrapper) packet;
                 wrapper.setReleased( true );
-                ch.writeAndFlush( wrapper.buf, ch.voidPromise() );
+                ch.write( wrapper.buf, ch.voidPromise() );
                 defined = wrapper.packet;
             } else
             {
-                ch.writeAndFlush( packet, ch.voidPromise() );
+                ch.write( packet, ch.voidPromise() );
                 if ( packet instanceof DefinedPacket )
                 {
                     defined = (DefinedPacket) packet;
@@ -113,10 +133,31 @@ public class ChannelWrapper
                 if ( nextProtocol != null )
                 {
                     setEncodeProtocol( nextProtocol );
+                    return;
                 }
             }
+            signalFlush();
         }
     }
+
+
+
+    private void signalFlush()
+    {
+        if ( !consolidate || consolidationCounter++ >= MAX_CONSOLIDATION )
+        {
+            forceFlush();
+        }
+
+    }
+
+    public void forceFlush()
+    {
+        ch.flush();
+        consolidationCounter = 0;
+    }
+
+
 
     public void markClosed()
     {

--- a/proxy/src/main/java/net/md_5/bungee/netty/ChannelWrapper.java
+++ b/proxy/src/main/java/net/md_5/bungee/netty/ChannelWrapper.java
@@ -24,7 +24,7 @@ import net.md_5.bungee.protocol.packet.Kick;
 
 public class ChannelWrapper
 {
-    private static final int MAX_CONSOLIDATION = Integer.getInteger("net.md_5.bungee.flush-consolidation-limit", 20);
+    private static final int MAX_CONSOLIDATION = Integer.getInteger( "net.md_5.bungee.flush-consolidation-limit", 20 );
 
     private final Channel ch;
     @Getter

--- a/proxy/src/main/java/net/md_5/bungee/netty/HandlerBoss.java
+++ b/proxy/src/main/java/net/md_5/bungee/netty/HandlerBoss.java
@@ -143,6 +143,15 @@ public class HandlerBoss extends ChannelInboundHandlerAdapter
     }
 
     @Override
+    public void channelReadComplete(ChannelHandlerContext ctx) throws Exception
+    {
+        if ( handler != null )
+        {
+            handler.channelReadComplete( channel );
+        }
+    }
+
+    @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception
     {
         if ( ctx.channel().isActive() )

--- a/proxy/src/main/java/net/md_5/bungee/netty/PacketHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/netty/PacketHandler.java
@@ -32,4 +32,8 @@ public abstract class PacketHandler extends net.md_5.bungee.protocol.AbstractPac
     public void writabilityChanged(ChannelWrapper channel) throws Exception
     {
     }
+
+    public void channelReadComplete(ChannelWrapper channel) throws Exception
+    {
+    }
 }


### PR DESCRIPTION
Inspired by @Janmm14 #3392

I imple simple flush consolidation without modifing the netty pipeline this change consists of tweaks in PacketHandlers, channelWrapper and HandlerBoss

There is a system variable to set the max consolidate amount

Consolidating is enabled after the backend receives the login to ensure all packets in login and config are sent without delay and cannot get lost.

And is disabled while switching to another server

It would be nice if it would be tested.

I will probably test it on network of a friend but more is better (i tested it on my localhost everything was working fine for me)