### PR TITLE
Fix channel closing issue

### DIFF
--- a/protocol/src/main/java/net/md_5/bungee/protocol/Varint21FrameDecoder.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/Varint21FrameDecoder.java
@@ -21,13 +21,9 @@ public class Varint21FrameDecoder extends ByteToMessageDecoder
     @Override
     protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception
     {
-        // If we decode an invalid packet and an exception is thrown (thus triggering a close of the connection),
-        // the Netty ByteToMessageDecoder will continue to frame more packets and potentially call fireChannelRead()
-        // on them, likely with more invalid packets. Therefore, check if the connection is no longer active and if so
-        // sliently discard the packet.
-        if ( !ctx.channel().isActive() || discard )
+        if ( discard )
         {
-            in.skipBytes( in.readableBytes() );
+            in.clear();
             return;
         }
 

--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -170,12 +170,11 @@ public class InitialHandler extends PacketHandler implements PendingConnection
     @Override
     public void exception(Throwable t) throws Exception
     {
+        // Note: after this method is executed the HandlerBoss will instantly close the connection
+        // that means we can't schedule something here
         if ( canSendKickMessage() )
         {
-            disconnect( ChatColor.RED + Util.exception( t ) );
-        } else
-        {
-            ch.close();
+            unsafe.sendPacket( new Kick( TextComponent.fromLegacy( ChatColor.RED + Util.exception( t ) ) ) );
         }
     }
 

--- a/proxy/src/main/java/net/md_5/bungee/netty/ChannelWrapper.java
+++ b/proxy/src/main/java/net/md_5/bungee/netty/ChannelWrapper.java
@@ -160,9 +160,6 @@ public class ChannelWrapper
             // clear tcp read buffer
             discardInbound();
 
-            // disable auto read so the pipeline doesn't read more traffic
-            ch.config().setAutoRead( false );
-
             // Minecraft client can take some time to switch protocols.
             // Sending the wrong disconnect packet whilst a protocol switch is in progress will crash it.
             // Delay 250ms to ensure that the protocol switch (if any) has definitely taken place.

--- a/proxy/src/main/java/net/md_5/bungee/netty/ChannelWrapper.java
+++ b/proxy/src/main/java/net/md_5/bungee/netty/ChannelWrapper.java
@@ -132,6 +132,9 @@ public class ChannelWrapper
         {
             closed = closing = true;
 
+            // disable auto read so the pipeline doesn't read more traffic
+            ch.config().setAutoRead( false );
+
             if ( packet != null && ch.isActive() )
             {
                 ch.writeAndFlush( packet ).addListeners( ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE, ChannelFutureListener.CLOSE );
@@ -148,6 +151,9 @@ public class ChannelWrapper
         if ( !closing )
         {
             closing = true;
+
+            // disable auto read so the pipeline doesn't read more traffic
+            ch.config().setAutoRead( false );
 
             // Minecraft client can take some time to switch protocols.
             // Sending the wrong disconnect packet whilst a protocol switch is in progress will crash it.

--- a/proxy/src/main/java/net/md_5/bungee/netty/ChannelWrapper.java
+++ b/proxy/src/main/java/net/md_5/bungee/netty/ChannelWrapper.java
@@ -171,7 +171,7 @@ public class ChannelWrapper
      * Disable auto read so the pipeline doesn't read more traffic
      * Also discard all inbound traffic to free the tcp read buffer
      */
-    private void discardInbound()
+    void discardInbound()
     {
         ch.config().setAutoRead( false );
         Varint21FrameDecoder frameDecoder = ch.pipeline().get( Varint21FrameDecoder.class );

--- a/proxy/src/main/java/net/md_5/bungee/netty/ChannelWrapper.java
+++ b/proxy/src/main/java/net/md_5/bungee/netty/ChannelWrapper.java
@@ -170,7 +170,6 @@ public class ChannelWrapper
     /**
      * Disable auto read so the pipeline doesn't read more traffic
      * Also discard all inbound traffic to free the tcp read buffer
-     * This clears the tcp read buffer
      */
     private void discardInbound()
     {

--- a/proxy/src/main/java/net/md_5/bungee/netty/ChannelWrapper.java
+++ b/proxy/src/main/java/net/md_5/bungee/netty/ChannelWrapper.java
@@ -140,9 +140,6 @@ public class ChannelWrapper
 
             closed = closing = true;
 
-            // disable auto read so the pipeline doesn't read more traffic
-            ch.config().setAutoRead( false );
-
             if ( packet != null && ch.isActive() )
             {
                 ch.writeAndFlush( packet ).addListeners( ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE, ChannelFutureListener.CLOSE );

--- a/proxy/src/main/java/net/md_5/bungee/netty/HandlerBoss.java
+++ b/proxy/src/main/java/net/md_5/bungee/netty/HandlerBoss.java
@@ -128,6 +128,14 @@ public class HandlerBoss extends ChannelInboundHandlerAdapter
                 {
                     handler, limiter.getCounter(), limiter.getDataCounter()
                 } );
+
+                // somehow sometimes if you spam big packets fast enough the channel will not be closed immediately
+                // it seems that this only happens on linux, the PacketLimiter will trigger a kick multiple times
+                // but the connection will still be active
+                if ( channel.getHandle().isActive() )
+                {
+                    ctx.close();
+                }
                 return;
             }
 

--- a/proxy/src/main/java/net/md_5/bungee/netty/HandlerBoss.java
+++ b/proxy/src/main/java/net/md_5/bungee/netty/HandlerBoss.java
@@ -218,6 +218,8 @@ public class HandlerBoss extends ChannelInboundHandlerAdapter
                 }
             }
 
+            channel.discardInbound();
+
             if ( handler != null )
             {
                 try

--- a/proxy/src/main/java/net/md_5/bungee/netty/HandlerBoss.java
+++ b/proxy/src/main/java/net/md_5/bungee/netty/HandlerBoss.java
@@ -128,14 +128,6 @@ public class HandlerBoss extends ChannelInboundHandlerAdapter
                 {
                     handler, limiter.getCounter(), limiter.getDataCounter()
                 } );
-
-                // somehow sometimes if you spam big packets fast enough the channel will not be closed immediately
-                // it seems that this only happens on linux, the PacketLimiter will trigger a kick multiple times
-                // but the connection will still be active
-                if ( channel.getHandle().isActive() )
-                {
-                    ctx.close();
-                }
                 return;
             }
 


### PR DESCRIPTION
somehow sometimes if you spam big packets fast enough the channel will not be closed immediately
 it seems that this only happens on linux, the PacketLimiter will trigger a kick multiple times
but the connection will still be active

