### PR TITLE
Add ProxyShutdownEvent

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/event/ProxyShutdownEvent.java
+++ b/api/src/main/java/net/md_5/bungee/api/event/ProxyShutdownEvent.java
@@ -1,0 +1,15 @@
+package net.md_5.bungee.api.event;
+
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import net.md_5.bungee.api.plugin.Event;
+
+/**
+ * This event is fired when the proxy is shutting down before players are disconnected
+ */
+@ToString(callSuper = false)
+@EqualsAndHashCode(callSuper = false)
+public class ProxyShutdownEvent extends Event
+{
+
+}

--- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
@@ -68,6 +68,7 @@ import net.md_5.bungee.api.config.ConfigurationAdapter;
 import net.md_5.bungee.api.config.ListenerInfo;
 import net.md_5.bungee.api.config.ServerInfo;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
+import net.md_5.bungee.api.event.ProxyShutdownEvent;
 import net.md_5.bungee.api.plugin.Plugin;
 import net.md_5.bungee.api.plugin.PluginManager;
 import net.md_5.bungee.chat.ComponentSerializer;
@@ -458,6 +459,8 @@ public class BungeeCord extends ProxyServer
         }
         isRunning = false;
 
+        getPluginManager().callEvent( new ProxyShutdownEvent() );
+        
         stopListeners();
         getLogger().info( "Closing pending connections" );
 


### PR DESCRIPTION
This allows plugins to transfer players to a different server with the ProxiedPlayer#transfer() API on proxy shutdown.
The event is called before the players are disconnected.
This is currently not possible.