### PR TITLE
Highly optimize Varint21FrameDecoder

### DIFF
--- a/protocol/src/main/java/net/md_5/bungee/protocol/Varint21FrameDecoder.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/Varint21FrameDecoder.java
@@ -1,15 +1,15 @@
 package net.md_5.bungee.protocol;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.ByteToMessageDecoder;
 import io.netty.handler.codec.CorruptedFrameException;
+import io.netty.util.ByteProcessor;
 import java.util.List;
 
 public class Varint21FrameDecoder extends ByteToMessageDecoder
 {
-
+    private static final ByteProcessor CONTINUE_BIT_PROCESSOR = value -> value < 0;
     private static boolean DIRECT_WARNING;
 
     @Override
@@ -18,60 +18,67 @@ public class Varint21FrameDecoder extends ByteToMessageDecoder
         // If we decode an invalid packet and an exception is thrown (thus triggering a close of the connection),
         // the Netty ByteToMessageDecoder will continue to frame more packets and potentially call fireChannelRead()
         // on them, likely with more invalid packets. Therefore, check if the connection is no longer active and if so
-        // sliently discard the packet.
+        // silently discard the packet.
         if ( !ctx.channel().isActive() )
         {
             in.skipBytes( in.readableBytes() );
             return;
         }
 
-        in.markReaderIndex();
-
-        final byte[] buf = new byte[ 3 ];
-        for ( int i = 0; i < buf.length; i++ )
+        int maxVarIntBytes = Math.min( in.readableBytes(), 3 );
+        int endIdx = in.forEachByte( in.readerIndex(), maxVarIntBytes, CONTINUE_BIT_PROCESSOR );
+        if ( endIdx == -1 )
         {
-            if ( !in.isReadable() )
+            if ( in.readableBytes() < 3 ) // Not enough bytes for the packet length yet
             {
-                in.resetReaderIndex();
                 return;
             }
-
-            buf[i] = in.readByte();
-            if ( buf[i] >= 0 )
-            {
-                int length = DefinedPacket.readVarInt( Unpooled.wrappedBuffer( buf ) );
-                if ( length == 0 )
-                {
-                    throw new CorruptedFrameException( "Empty Packet!" );
-                }
-
-                if ( in.readableBytes() < length )
-                {
-                    in.resetReaderIndex();
-                    return;
-                } else
-                {
-                    if ( in.hasMemoryAddress() )
-                    {
-                        out.add( in.readRetainedSlice( length ) );
-                    } else
-                    {
-                        if ( !DIRECT_WARNING )
-                        {
-                            DIRECT_WARNING = true;
-                            System.out.println( "Netty is not using direct IO buffers." );
-                        }
-
-                        // See https://github.com/SpigotMC/BungeeCord/issues/1717
-                        ByteBuf dst = ctx.alloc().directBuffer( length );
-                        in.readBytes( dst );
-                        out.add( dst );
-                    }
-                    return;
-                }
-            }
+            throw new CorruptedFrameException( "length wider than 21-bit" );
         }
 
-        throw new CorruptedFrameException( "length wider than 21-bit" );
+        int varIntIndex = ( endIdx - in.readerIndex() );
+        int varIntLen = varIntIndex + 1;
+
+        int length = getVarInt( in, varIntIndex );
+        if ( length == 0 )
+        {
+            throw new CorruptedFrameException( "Empty Packet!" );
+        }
+
+        if ( in.readableBytes() - varIntLen >= length )
+        {
+            in.skipBytes( varIntLen );
+            if ( in.hasMemoryAddress() )
+            {
+                out.add( in.readRetainedSlice( length ) );
+            } else
+            {
+                if ( !DIRECT_WARNING )
+                {
+                    DIRECT_WARNING = true;
+                    System.out.println( "Netty is not using direct IO buffers." );
+                }
+
+                // See https://github.com/SpigotMC/BungeeCord/issues/1717
+                ByteBuf dst = ctx.alloc().directBuffer( length );
+                in.readBytes( dst );
+                out.add( dst );
+            }
+        }
+    }
+
+    private static int getVarInt(ByteBuf byteBuf, int varIntIndex)
+    {
+        int readerIndex = byteBuf.readerIndex();
+        if ( varIntIndex == 0 )
+        {
+            return byteBuf.getByte( readerIndex );
+        } else if ( varIntIndex == 1 )
+        {
+            return byteBuf.getByte( readerIndex ) & 0x7F | byteBuf.getByte( readerIndex + 1 ) << 7;
+        } else
+        {
+            return byteBuf.getByte( readerIndex ) & 0x7F | ( byteBuf.getByte( readerIndex + 1 ) & 0x7F ) << 7 | byteBuf.getByte( readerIndex + 2 ) << 14;
+        }
     }
 }


### PR DESCRIPTION
Removed byte[] alloc and reduce loops by using ByteBuf.forEachByte only ones and than parsing the Varint with bitshifting from the buffer