### PR TITLE
Force wrong configuration values

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "java.checkstyle.configuration": "${workspaceFolder}/checkstyle.xml"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.checkstyle.configuration": "${workspaceFolder}/checkstyle.xml"
+}

--- a/proxy/src/main/java/net/md_5/bungee/conf/YamlConfig.java
+++ b/proxy/src/main/java/net/md_5/bungee/conf/YamlConfig.java
@@ -112,58 +112,71 @@ public class YamlConfig implements ConfigurationAdapter
     }
 
     @SuppressWarnings("unchecked")
-    private <T> T get(String path, T def, Map submap) {
-        int index = path.indexOf('.');
-        if (index == -1) {
-            Object val = submap.get(path);
-            if (val == null && def != null) {
+    private <T> T get(String path, T def, Map submap)
+    {
+        int index = path.indexOf( '.' );
+        if ( index == -1 )
+        {
+            Object val = submap.get( path );
+            if ( val == null && def != null )
+            {
                 val = def;
-                submap.put(path, def);
+                submap.put( path, def );
                 save();
             }
-            return convertValue(val, def);
-        } else {
-            String first = path.substring(0, index);
-            String second = path.substring(index + 1);
-            Map sub = (Map) submap.get(first);
-            if (sub == null) {
+            return convertValue( val, def );
+        } else
+        {
+            String first = path.substring( 0, index );
+            String second = path.substring( index + 1 );
+            Map sub = (Map) submap.get( first );
+            if ( sub == null )
+            {
                 sub = new LinkedHashMap();
-                submap.put(first, sub);
+                submap.put( first, sub );
             }
-            return get(second, def, sub);
+            return get( second, def, sub );
         }
     }
-    
-    private <T> T convertValue(Object value, T defaultValue) {
-        if (value == null) {
+
+    private <T> T convertValue(Object value, T defaultValue)
+    {
+        if ( value == null )
+        {
             return defaultValue;
         }
-    
-        if (defaultValue instanceof Integer) {
-            return (T) convertToInteger(value);
+
+        if ( defaultValue instanceof Integer )
+        {
+            return (T) convertToInteger( value );
         }
-    
-        if (defaultValue instanceof Double) {
-            return (T) convertToDouble(value);
+
+        if ( defaultValue instanceof Double )
+        {
+            return (T) convertToDouble( value );
         }
-    
+
         // Add more type conversions as needed
-    
+
         return (T) value;
     }
-    
-    private Integer convertToInteger(Object value) {
-        if (value instanceof Number) {
-            return ((Number) value).intValue();
+
+    private Integer convertToInteger(Object value)
+    {
+        if ( value instanceof Number )
+        {
+            return ( (Number) value ).intValue();
         }
-        return Integer.valueOf(value.toString());
+        return Integer.valueOf( value.toString() );
     }
-    
-    private Double convertToDouble(Object value) {
-        if (value instanceof Number) {
-            return ((Number) value).doubleValue();
+
+    private Double convertToDouble(Object value)
+    {
+        if ( value instanceof Number )
+        {
+            return ( (Number) value ).doubleValue();
         }
-        return Double.valueOf(value.toString());
+        return Double.valueOf( value.toString() );
     }
 
     private void set(String path, Object val)

--- a/proxy/src/main/java/net/md_5/bungee/conf/YamlConfig.java
+++ b/proxy/src/main/java/net/md_5/bungee/conf/YamlConfig.java
@@ -111,6 +111,29 @@ public class YamlConfig implements ConfigurationAdapter
         return get( path, def, config );
     }
 
+    @SuppressWarnings("unchecked")
+    private <T> T get(String path, T def, Map submap) {
+        int index = path.indexOf('.');
+        if (index == -1) {
+            Object val = submap.get(path);
+            if (val == null && def != null) {
+                val = def;
+                submap.put(path, def);
+                save();
+            }
+            return convertValue(val, def);
+        } else {
+            String first = path.substring(0, index);
+            String second = path.substring(index + 1);
+            Map sub = (Map) submap.get(first);
+            if (sub == null) {
+                sub = new LinkedHashMap();
+                submap.put(first, sub);
+            }
+            return get(second, def, sub);
+        }
+    }
+    
     private <T> T convertValue(Object value, T defaultValue) {
         if (value == null) {
             return defaultValue;

--- a/proxy/src/main/java/net/md_5/bungee/conf/YamlConfig.java
+++ b/proxy/src/main/java/net/md_5/bungee/conf/YamlConfig.java
@@ -111,32 +111,36 @@ public class YamlConfig implements ConfigurationAdapter
         return get( path, def, config );
     }
 
-    @SuppressWarnings("unchecked")
-    private <T> T get(String path, T def, Map submap)
-    {
-        int index = path.indexOf( '.' );
-        if ( index == -1 )
-        {
-            Object val = submap.get( path );
-            if ( val == null && def != null )
-            {
-                val = def;
-                submap.put( path, def );
-                save();
-            }
-            return (T) val;
-        } else
-        {
-            String first = path.substring( 0, index );
-            String second = path.substring( index + 1, path.length() );
-            Map sub = (Map) submap.get( first );
-            if ( sub == null )
-            {
-                sub = new LinkedHashMap();
-                submap.put( first, sub );
-            }
-            return get( second, def, sub );
+    private <T> T convertValue(Object value, T defaultValue) {
+        if (value == null) {
+            return defaultValue;
         }
+    
+        if (defaultValue instanceof Integer) {
+            return (T) convertToInteger(value);
+        }
+    
+        if (defaultValue instanceof Double) {
+            return (T) convertToDouble(value);
+        }
+    
+        // Add more type conversions as needed
+    
+        return (T) value;
+    }
+    
+    private Integer convertToInteger(Object value) {
+        if (value instanceof Number) {
+            return ((Number) value).intValue();
+        }
+        return Integer.valueOf(value.toString());
+    }
+    
+    private Double convertToDouble(Object value) {
+        if (value instanceof Number) {
+            return ((Number) value).doubleValue();
+        }
+        return Double.valueOf(value.toString());
     }
 
     private void set(String path, Object val)


### PR DESCRIPTION
Pterodactyl and other type of panels force outdated values into BungeeCord. When BungeeCord changes the type of an already existing value, panels keep forcing old values causing exceptions on BungeeCord load and leading to a crash.

This patch aims to convert the wrong values into the right values.

This fixes compatibility with pterodactyl panels which was broken due to the new update. This happened more than once before.

This patch has been tested on FlameCord with multiple users, showing good results.