### PR TITLE
Fire netty signal when compression state is changed

### DIFF
--- a/protocol/src/main/java/net/md_5/bungee/protocol/channel/CompressionThresholdSignal.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/channel/CompressionThresholdSignal.java
@@ -1,0 +1,23 @@
+package net.md_5.bungee.protocol.channel;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+/**
+ * Signal send through the channel pipeline indicating that compression state has changed.
+ */
+@Getter
+@ToString(callSuper = false)
+@EqualsAndHashCode(callSuper = false)
+@RequiredArgsConstructor
+public class CompressionThresholdSignal
+{
+
+    /**
+     * The compression threshold.
+     */
+    private final int threshold;
+
+}

--- a/proxy/src/main/java/net/md_5/bungee/netty/ChannelWrapper.java
+++ b/proxy/src/main/java/net/md_5/bungee/netty/ChannelWrapper.java
@@ -18,6 +18,7 @@ import net.md_5.bungee.protocol.MinecraftDecoder;
 import net.md_5.bungee.protocol.MinecraftEncoder;
 import net.md_5.bungee.protocol.PacketWrapper;
 import net.md_5.bungee.protocol.Protocol;
+import net.md_5.bungee.protocol.channel.CompressionThresholdSignal;
 import net.md_5.bungee.protocol.packet.Kick;
 
 public class ChannelWrapper
@@ -209,6 +210,7 @@ public class ChannelWrapper
 
         // disable use of composite buffers if we use natives
         updateComposite();
+        ch.pipeline().fireUserEventTriggered( new CompressionThresholdSignal( compressionThreshold ) );
     }
 
     /*


### PR DESCRIPTION
Third party plugins using the API provided in https://github.com/SpigotMC/BungeeCord/pull/3776 need to reorder their own pipeline elements as soon as the compression is enabled, which is currently not possible (at least not in a proper way without delaying packets). This PR adds a simple netty signal which can be used for this very use-case and is provided similar in other proxy/server projects as well.