### PR TITLE
Remove redundant PluginMessage handler in InitialHandler

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -195,12 +195,6 @@ public class InitialHandler extends PacketHandler implements PendingConnection
     }
 
     @Override
-    public void handle(PluginMessage pluginMessage) throws Exception
-    {
-        this.relayMessage( pluginMessage );
-    }
-
-    @Override
     public void handle(LegacyHandshake legacyHandshake) throws Exception
     {
         Preconditions.checkState( !this.legacy, "Not expecting LegacyHandshake" );


### PR DESCRIPTION
There is no state in wich we could decode a PluginMessage in InitialHandler, so we should remove it here.