### PR TITLE
Use retainedSlice if possible in MinecraftDecoder & remove useless EntityMaps

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/entitymap/EntityMap.java
+++ b/proxy/src/main/java/net/md_5/bungee/entitymap/EntityMap.java
@@ -83,18 +83,13 @@ public abstract class EntityMap
             case ProtocolConstants.MINECRAFT_1_20:
                 return EntityMap_1_16_2.INSTANCE_1_19_4;
             case ProtocolConstants.MINECRAFT_1_20_2:
-                return EntityMap_1_16_2.INSTANCE_1_20_2;
             case ProtocolConstants.MINECRAFT_1_20_3:
-                return EntityMap_1_16_2.INSTANCE_1_20_3;
             case ProtocolConstants.MINECRAFT_1_20_5:
             case ProtocolConstants.MINECRAFT_1_21:
-                return EntityMap_1_16_2.INSTANCE_1_20_5;
             case ProtocolConstants.MINECRAFT_1_21_2:
-                return EntityMap_1_16_2.INSTANCE_1_21_2;
             case ProtocolConstants.MINECRAFT_1_21_4:
-                return EntityMap_1_16_2.INSTANCE_1_21_4;
             case ProtocolConstants.MINECRAFT_1_21_5:
-                return EntityMap_1_16_2.INSTANCE_1_21_5;
+                return null;
         }
         throw new RuntimeException( "Version " + version + " has no entity map" );
     }

--- a/proxy/src/main/java/net/md_5/bungee/entitymap/EntityMap_1_16_2.java
+++ b/proxy/src/main/java/net/md_5/bungee/entitymap/EntityMap_1_16_2.java
@@ -20,12 +20,6 @@ class EntityMap_1_16_2 extends EntityMap
     static final EntityMap_1_16_2 INSTANCE_1_19 = new EntityMap_1_16_2( 0x02, 0x2F );
     static final EntityMap_1_16_2 INSTANCE_1_19_1 = new EntityMap_1_16_2( 0x02, 0x30 );
     static final EntityMap_1_16_2 INSTANCE_1_19_4 = new EntityMap_1_16_2( 0x03, 0x30 );
-    static final EntityMap_1_16_2 INSTANCE_1_20_2 = new EntityMap_1_16_2( -1, 0x33 );
-    static final EntityMap_1_16_2 INSTANCE_1_20_3 = new EntityMap_1_16_2( -1, 0x34 );
-    static final EntityMap_1_16_2 INSTANCE_1_20_5 = new EntityMap_1_16_2( -1, 0x37 );
-    static final EntityMap_1_16_2 INSTANCE_1_21_2 = new EntityMap_1_16_2( -1, 0x39 );
-    static final EntityMap_1_16_2 INSTANCE_1_21_4 = new EntityMap_1_16_2( -1, 0x3B );
-    static final EntityMap_1_16_2 INSTANCE_1_21_5 = new EntityMap_1_16_2( -1, 0x3C );
     //
     private final int spawnPlayerId;
     private final int spectateId;


### PR DESCRIPTION
Only copy the buf in MinecraftDecoder when we apply the buf to the rewritter later, this only happens for Game Packets, so for all other states we can just use retainedSlice.

Also i removed redundant EntityMaps from 1.20.2 up to the latest version
I tested the spectate feature on 1.20.2 and 1.21.4 and it worked for me fine in offline mode and in online mode with ip-forward disabled.

I think these versions get the uuids from the tablist. so we don't have to remap it again in the spactate packet as we already have in the tablist.

I also tested it on 1.8.8, also worked fine for me

Also as i removed the entity map from 1.20.2 and up we dont have to copy the buf there at all anymore
