### PR TITLE
Fire exception in pipeline if async task in eventloop throws exception

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
@@ -334,7 +334,7 @@ public final class UserConnection implements ProxiedPlayer
     {
         Preconditions.checkNotNull( request, "request" );
 
-        ch.getHandle().eventLoop().execute( () -> connect0( request ) );
+        ch.scheduleIfNecessary( () -> connect0( request ) );
     }
 
     private void connect0(final ServerConnectRequest request)

--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -2,7 +2,6 @@ package net.md_5.bungee.connection;
 
 import com.google.common.base.Preconditions;
 import com.google.gson.Gson;
-import io.netty.channel.EventLoop;
 import java.math.BigInteger;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
@@ -901,17 +900,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
     {
         return (result, error) ->
         {
-            EventLoop eventLoop = ch.getHandle().eventLoop();
-            if ( eventLoop.inEventLoop() )
-            {
-                if ( !ch.isClosing() )
-                {
-                    callback.done( result, error );
-                }
-                return;
-            }
-
-            eventLoop.execute( () ->
+            ch.scheduleIfNecessary( () ->
             {
                 if ( !ch.isClosing() )
                 {

--- a/proxy/src/main/java/net/md_5/bungee/netty/ChannelWrapper.java
+++ b/proxy/src/main/java/net/md_5/bungee/netty/ChannelWrapper.java
@@ -240,11 +240,6 @@ public class ChannelWrapper
 
         ch.eventLoop().submit( task ).addListener( future ->
         {
-            if ( isClosing() )
-            {
-                return;
-            }
-
             if ( !future.isSuccess() )
             {
                 ch.pipeline().fireExceptionCaught( future.cause() );

--- a/proxy/src/main/java/net/md_5/bungee/netty/ChannelWrapper.java
+++ b/proxy/src/main/java/net/md_5/bungee/netty/ChannelWrapper.java
@@ -238,6 +238,17 @@ public class ChannelWrapper
             return;
         }
 
-        ch.eventLoop().execute( task );
+        ch.eventLoop().submit( task ).addListener( future ->
+        {
+            if ( isClosing() )
+            {
+                return;
+            }
+
+            if ( !future.isSuccess() )
+            {
+                ch.pipeline().fireExceptionCaught( future.cause() );
+            }
+        } );
     }
 }


### PR DESCRIPTION
This pull request fixes an issue where any exceptions thrown in scheduled tasks do not disconnect the player, which currently results in exception spam in the logs if the player has reached the packet queue limit.

In addition, this pull request also more correctly schedules tasks in InitialHandler and UserConnection using ChannelWrapper#scheduleIfNecessary