### PR TITLE
Ensure ping response for unthrotteling

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -284,7 +284,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
     public void handle(StatusRequest statusRequest) throws Exception
     {
         Preconditions.checkState( thisState == State.STATUS, "Not expecting STATUS" );
-        thisState = null; // don't accept ping multiple status requests, set state to ping in async event callback
+        thisState = null; // don't accept multiple status requests and set state to ping in async event callback
 
         ServerInfo forced = AbstractReconnectHandler.getForcedHost( this );
         final String motd = ( forced != null ) ? forced.getMotd() : listener.getMotd();


### PR DESCRIPTION
Also don't accept ping responses if we have not send ping packet to the client
This generally mitigates motd spam attacks a bit better, just packet spamming for unthrotteling does not work anymore, the client has to wait for the status response now, and needs to send the ping request before we unthrottle the connection