### PR TITLE
Gracefully handle any protocol errors

### DIFF
--- a/protocol/src/main/java/net/md_5/bungee/protocol/MinecraftEncoder.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/MinecraftEncoder.java
@@ -22,8 +22,14 @@ public class MinecraftEncoder extends MessageToByteEncoder<DefinedPacket>
     @Override
     protected void encode(ChannelHandlerContext ctx, DefinedPacket msg, ByteBuf out) throws Exception
     {
-        Protocol.DirectionData prot = ( server ) ? protocol.TO_CLIENT : protocol.TO_SERVER;
-        DefinedPacket.writeVarInt( prot.getId( msg.getClass(), protocolVersion ), out );
-        msg.write( out, protocol, prot.getDirection(), protocolVersion );
+        try
+        {
+            Protocol.DirectionData prot = ( server ) ? protocol.TO_CLIENT : protocol.TO_SERVER;
+            DefinedPacket.writeVarInt( prot.getId( msg.getClass(), protocolVersion ), out );
+            msg.write( out, protocol, prot.getDirection(), protocolVersion );
+        } catch (IllegalArgumentException e) {
+            // Gracefully handle any protocol errors
+            System.out.println( e.getMessage() );
+        }
     }
 }


### PR DESCRIPTION
On the latest version we noticed some packets being sent to 1.8 clients are not for that version, thus causing protocol errors because of the inability to find a protocol to find them. This causes a big error and the kick of the player, which is too much considering it's a mistake that can happen from version to version. Instead, issue a warning and ignore the sending of the packet. This aligns to the ViaVersion approach of warning in the case of conversion errors instead of kicking the player.