### PR TITLE
Improve packet queue handling with warning for excessive queued packets

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/ServerConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/ServerConnection.java
@@ -72,7 +72,8 @@ public class ServerConnection implements Server
                     packetQueue.add( packet );
                 } else
                 {
-                    BungeeCord.getInstance().getLogger().warning( "Too many queued packets. Bad API usage? Try removing plugins and report to the authors. This prevented the server from overloading." );
+                    BungeeCord.getInstance().getLogger().warning( "Too many queued packets to server. Bad API usage? Try removing plugins and report to the authors. This prevented the server from overloading." );
+                    ch.close();
                 }
             } else
             {

--- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
+++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
@@ -208,8 +208,14 @@ public final class UserConnection implements ProxiedPlayer
             if ( !encodeProtocol.TO_CLIENT.hasPacket( packet.getClass(), getPendingConnection().getVersion() ) )
             {
                 // we should limit this so bad api usage won't oom the server.
-                Preconditions.checkState( packetQueue.size() <= 4096, "too many queued packets" );
-                packetQueue.add( packet );
+                if ( packetQueue.size() <= 4096 )
+                {
+                    packetQueue.add( packet );
+                } else
+                {
+                    BungeeCord.getInstance().getLogger().warning( "Too many queued packets to client. Bad API usage? Try removing plugins and report to the authors. This prevented the server from overloading." );
+                    ch.close();
+                }
             } else
             {
                 unsafe().sendPacket( packet );


### PR DESCRIPTION
Instead of throwing a exception for those server owners used fucked up plugins, warn them instead so they take action about it instead of sending a stack-trace that they cannot read.