### PR TITLE
Fix race condition that leads to incorrect packet order

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
@@ -55,6 +55,7 @@ import net.md_5.bungee.protocol.Protocol;
 import net.md_5.bungee.protocol.ProtocolConstants;
 import net.md_5.bungee.protocol.packet.BossBar;
 import net.md_5.bungee.protocol.packet.Commands;
+import net.md_5.bungee.protocol.packet.FinishConfiguration;
 import net.md_5.bungee.protocol.packet.KeepAlive;
 import net.md_5.bungee.protocol.packet.Kick;
 import net.md_5.bungee.protocol.packet.Login;
@@ -798,6 +799,16 @@ public class DownstreamBridge extends PacketHandler
         receivedLogin = true;
         ServerConnector.handleLogin( bungee, server.getCh(), con, server.getInfo(), null, server, login );
 
+        throw CancelSendSignal.INSTANCE;
+    }
+
+    @Override
+    public void handle(FinishConfiguration finishConfiguration) throws Exception
+    {
+        // the clients protocol will change to GAME after this packet
+        con.unsafe().sendPacket( finishConfiguration );
+        // send queued packets as early as possible
+        con.sendQueuedPackets();
         throw CancelSendSignal.INSTANCE;
     }
 

--- a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
@@ -33,7 +33,6 @@ import net.md_5.bungee.protocol.packet.ClientChat;
 import net.md_5.bungee.protocol.packet.ClientCommand;
 import net.md_5.bungee.protocol.packet.ClientSettings;
 import net.md_5.bungee.protocol.packet.CookieResponse;
-import net.md_5.bungee.protocol.packet.FinishConfiguration;
 import net.md_5.bungee.protocol.packet.KeepAlive;
 import net.md_5.bungee.protocol.packet.LoginAcknowledged;
 import net.md_5.bungee.protocol.packet.LoginPayloadResponse;
@@ -365,12 +364,6 @@ public class UpstreamBridge extends PacketHandler
 
             throw CancelSendSignal.INSTANCE;
         }
-    }
-
-    @Override
-    public void handle(FinishConfiguration finishConfiguration) throws Exception
-    {
-        con.sendQueuedPackets();
     }
 
     @Override


### PR DESCRIPTION
if you send a packet with sendPacketQueued  for example in an async loop

the packets will be queued until the protocol switches to GAME

if it is in game state  the packet will be sent instantly, the problem here is that currently its possible that packets are sent instantly before the queued packets are sent. Because we send the queued packets when the client sends the FinishConfiguration packet, but the players encoder protocol will be GAME before that.

This leads to incorrect packet order which can cause disconnects

BEFORE:

Client Encoder Protocol = CONFIG
FinishConfiguration ( SERVER -> CLIENT )
Client Encoder Protocol = GAME

// At this moment we wait for client response but sendQueuedPacket will flush instantly ( before the other packets that are queued are flushed)

FinishConfiguration ( CLIENT -> SERVER )
Send queued packets


AFTER:

Client Encoder Protocol = CONFIG
FinishConfiguration ( SERVER -> CLIENT )
Client Encoder Protocol = GAME

// now the order will remain as the queued packets will be flushed first
Send queued packets

FinishConfiguration ( CLIENT -> SERVER )
