### PR TITLE
Check memory address availability

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
@@ -8,6 +8,7 @@ import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelException;
 import io.netty.channel.ChannelFuture;
@@ -228,16 +229,22 @@ public class BungeeCord extends ProxyServer
         getPluginManager().registerCommand( null, new CommandBungee() );
         getPluginManager().registerCommand( null, new CommandPerms() );
 
+        boolean hasMemoryAddress = Unpooled.directBuffer().hasMemoryAddress();
+        if ( !hasMemoryAddress )
+        {
+            logger.warning( "Memory addresses are not available in direct buffers" );
+        }
+
         if ( !Boolean.getBoolean( "net.md_5.bungee.native.disable" ) )
         {
-            if ( EncryptionUtil.nativeFactory.load() )
+            if ( hasMemoryAddress && EncryptionUtil.nativeFactory.load() )
             {
                 logger.info( "Using mbed TLS based native cipher." );
             } else
             {
                 logger.info( "Using standard Java JCE cipher." );
             }
-            if ( CompressFactory.zlib.load() )
+            if ( hasMemoryAddress && CompressFactory.zlib.load() )
             {
                 logger.info( "Using zlib based native compressor." );
             } else

--- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
@@ -8,6 +8,7 @@ import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelException;
@@ -229,7 +230,9 @@ public class BungeeCord extends ProxyServer
         getPluginManager().registerCommand( null, new CommandBungee() );
         getPluginManager().registerCommand( null, new CommandPerms() );
 
-        boolean hasMemoryAddress = Unpooled.directBuffer().hasMemoryAddress();
+        ByteBuf directBuffer = Unpooled.directBuffer();
+        boolean hasMemoryAddress = directBuffer.hasMemoryAddress();
+        directBuffer.release();
         if ( !hasMemoryAddress )
         {
             logger.warning( "Memory addresses are not available in direct buffers" );


### PR DESCRIPTION
Closes https://github.com/SpigotMC/BungeeCord/issues/3825

native cipher and compression requires memory addresses to function.
if the unsafe is not available netty will use normal PooledDirectByteBufs that do not provide a memory address
With unsafe it would use PooledUnsafeDirectByteBuf that provide a memory address