### PR TITLE
Set allocator using netty system property to apply pooled allocator globally

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
@@ -262,6 +262,14 @@ public class BungeeCord extends ProxyServer
             ResourceLeakDetector.setLevel( ResourceLeakDetector.Level.DISABLED ); // Eats performance
         }
 
+        // https://github.com/netty/netty/wiki/Netty-4.2-Migration-Guide
+        // The adaptive allocator, the new default allocator since Netty 4.2, has some memory issues.
+        // Setting it globally also ensures that any plugins would also use the pooled allocator.
+        if ( System.getProperty("io.netty.allocator.type") == null )
+        {
+            System.setProperty("io.netty.allocator.type", "pooled");
+        }
+
         eventLoops = PipelineUtils.newEventLoopGroup( 0, new ThreadFactoryBuilder().setNameFormat( "Netty IO Thread #%1$d" ).build() );
 
         File moduleDirectory = new File( "modules" );

--- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
@@ -265,9 +265,9 @@ public class BungeeCord extends ProxyServer
         // https://github.com/netty/netty/wiki/Netty-4.2-Migration-Guide
         // The adaptive allocator, the new default allocator since Netty 4.2, has some memory issues.
         // Setting it globally also ensures that any plugins would also use the pooled allocator.
-        if ( System.getProperty("io.netty.allocator.type") == null )
+        if ( System.getProperty( "io.netty.allocator.type" ) == null )
         {
-            System.setProperty("io.netty.allocator.type", "pooled");
+            System.setProperty( "io.netty.allocator.type", "pooled" );
         }
 
         eventLoops = PipelineUtils.newEventLoopGroup( 0, new ThreadFactoryBuilder().setNameFormat( "Netty IO Thread #%1$d" ).build() );

--- a/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java
+++ b/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java
@@ -1,7 +1,6 @@
 package net.md_5.bungee.netty;
 
 import com.google.common.base.Preconditions;
-import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelException;
 import io.netty.channel.ChannelOption;
@@ -219,9 +218,6 @@ public class PipelineUtils
             {
                 // IP_TOS is not supported (Windows XP / Windows Server 2003)
             }
-            // https://github.com/netty/netty/wiki/Netty-4.2-Migration-Guide
-            // TODO: check for AdaptiveByteBufAllocator
-            ch.config().setAllocator( PooledByteBufAllocator.DEFAULT );
             ch.config().setWriteBufferWaterMark( MARK );
 
             ch.pipeline().addLast( FRAME_DECODER, new Varint21FrameDecoder() );


### PR DESCRIPTION
Hey 👋 
I'd like to propose the change here to set the pooled allocator more globally. This would ensure that plugins which might be using netty allocators wouldn't fall back to the adaptive allocator. As seen in e.g. https://github.com/GeyserMC/Geyser/issues/5468#issuecomment-2817105239, plugins that are still using the default allocator will cause issues that can also lead to the proxy crashing due to direct memory OOMs. This appears to happen very quickly when there's both pooled and adaptive allocation in use.

Please let me know if you'd like to see any changes made to this PR. Thanks!

