### PR TITLE
Check for dialog loops

### DIFF
--- a/serializer/src/main/java/net/md_5/bungee/dialog/DialogSerializer.java
+++ b/serializer/src/main/java/net/md_5/bungee/dialog/DialogSerializer.java
@@ -32,9 +32,7 @@ import org.jetbrains.annotations.ApiStatus;
 @RequiredArgsConstructor
 public class DialogSerializer implements JsonDeserializer<Dialog>, JsonSerializer<Dialog>
 {
-    @ApiStatus.Internal
-    public static final ThreadLocal<Set<Dialog>> serializedDialogs = new ThreadLocal<Set<Dialog>>();
-
+    private static final ThreadLocal<Set<Dialog>> serializedDialogs = new ThreadLocal<Set<Dialog>>();
     private static final BiMap<String, Class<? extends Dialog>> TYPES;
     private final VersionedComponentSerializer serializer;
 


### PR DESCRIPTION
Currently stack overflows are possible due to cycling dialog references.

This is the same fix as for component loops

Example code to achieve a stack overflow:

```java

public class TestCommand extends Command {

    public TestCommand() {
        super("btest");
    }

    @Override
    public void execute(CommandSender sender, String[] args) {
        ProxiedPlayer player = (ProxiedPlayer) sender;
        DialogBase base = new DialogBase(new ComponentBuilder("Hello").color(ChatColor.RED).build());
        DialogListDialog list = new DialogListDialog(base, new NoticeDialog(base));
        list.dialogs(Collections.singletonList(list));
        player.showDialog(list);
    }
}

```