### PR TITLE
Add PipelineConstants class

### DIFF
--- a/protocol/src/main/java/net/md_5/bungee/protocol/channel/PipelineConstants.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/channel/PipelineConstants.java
@@ -1,0 +1,20 @@
+package net.md_5.bungee.protocol.channel;
+
+import org.jetbrains.annotations.ApiStatus;
+
+@ApiStatus.Internal
+public class PipelineConstants
+{
+    public static final String TIMEOUT_HANDLER = "timeout";
+    public static final String WRITE_TIMEOUT_HANDLER = "write-timeout";
+    public static final String PACKET_DECODER = "packet-decoder";
+    public static final String PACKET_ENCODER = "packet-encoder";
+    public static final String BOSS_HANDLER = "inbound-boss";
+    public static final String ENCRYPT_HANDLER = "encrypt";
+    public static final String DECRYPT_HANDLER = "decrypt";
+    public static final String FRAME_DECODER = "frame-decoder";
+    public static final String FRAME_PREPENDER_AND_COMPRESS = "frame-prepender-compress";
+    public static final String DECOMPRESS = "decompress";
+    public static final String LEGACY_DECODER = "legacy-decoder";
+    public static final String LEGACY_KICKER = "legacy-kick";
+}

--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -53,7 +53,6 @@ import net.md_5.bungee.jni.cipher.BungeeCipher;
 import net.md_5.bungee.netty.ChannelWrapper;
 import net.md_5.bungee.netty.HandlerBoss;
 import net.md_5.bungee.netty.PacketHandler;
-import net.md_5.bungee.netty.PipelineUtils;
 import net.md_5.bungee.netty.cipher.CipherDecoder;
 import net.md_5.bungee.netty.cipher.CipherEncoder;
 import net.md_5.bungee.protocol.DefinedPacket;
@@ -61,6 +60,7 @@ import net.md_5.bungee.protocol.PacketWrapper;
 import net.md_5.bungee.protocol.PlayerPublicKey;
 import net.md_5.bungee.protocol.Protocol;
 import net.md_5.bungee.protocol.ProtocolConstants;
+import net.md_5.bungee.protocol.channel.PipelineConstants;
 import net.md_5.bungee.protocol.packet.CookieRequest;
 import net.md_5.bungee.protocol.packet.CookieResponse;
 import net.md_5.bungee.protocol.packet.EncryptionRequest;
@@ -345,7 +345,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
         Preconditions.checkState( thisState == State.HANDSHAKE && !this.legacy, "Not expecting HANDSHAKE" );
         this.handshake = handshake;
         ch.setVersion( handshake.getProtocolVersion() );
-        ch.getHandle().pipeline().remove( PipelineUtils.LEGACY_KICKER );
+        ch.getHandle().pipeline().remove( PipelineConstants.LEGACY_KICKER );
 
         // Starting with FML 1.8, a "\0FML\0" token is appended to the handshake. This interferes
         // with Bungee's IP forwarding, so we detect it, and remove it from the host string, for now.
@@ -506,9 +506,9 @@ public class InitialHandler extends PacketHandler implements PendingConnection
 
         SecretKey sharedKey = EncryptionUtil.getSecret( encryptResponse, request );
         BungeeCipher decrypt = EncryptionUtil.getCipher( false, sharedKey );
-        ch.addBefore( PipelineUtils.FRAME_DECODER, PipelineUtils.DECRYPT_HANDLER, new CipherDecoder( decrypt ) );
+        ch.addBefore( PipelineConstants.FRAME_DECODER, PipelineConstants.DECRYPT_HANDLER, new CipherDecoder( decrypt ) );
         BungeeCipher encrypt = EncryptionUtil.getCipher( true, sharedKey );
-        ch.addBefore( PipelineUtils.FRAME_PREPENDER_AND_COMPRESS, PipelineUtils.ENCRYPT_HANDLER, new CipherEncoder( encrypt ) );
+        ch.addBefore( PipelineConstants.FRAME_PREPENDER_AND_COMPRESS, PipelineConstants.ENCRYPT_HANDLER, new CipherEncoder( encrypt ) );
         // disable use of composite buffers if we use natives
         ch.updateComposite();
 

--- a/proxy/src/main/java/net/md_5/bungee/connection/PingHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/PingHandler.java
@@ -13,11 +13,11 @@ import net.md_5.bungee.api.config.ServerInfo;
 import net.md_5.bungee.chat.VersionedComponentSerializer;
 import net.md_5.bungee.netty.ChannelWrapper;
 import net.md_5.bungee.netty.PacketHandler;
-import net.md_5.bungee.netty.PipelineUtils;
 import net.md_5.bungee.protocol.MinecraftDecoder;
 import net.md_5.bungee.protocol.MinecraftEncoder;
 import net.md_5.bungee.protocol.PacketWrapper;
 import net.md_5.bungee.protocol.Protocol;
+import net.md_5.bungee.protocol.channel.PipelineConstants;
 import net.md_5.bungee.protocol.packet.Handshake;
 import net.md_5.bungee.protocol.packet.StatusRequest;
 import net.md_5.bungee.protocol.packet.StatusResponse;
@@ -42,8 +42,8 @@ public class PingHandler extends PacketHandler
         this.channel = channel;
         MinecraftEncoder encoder = new MinecraftEncoder( Protocol.HANDSHAKE, false, protocol );
 
-        channel.getHandle().pipeline().addAfter( PipelineUtils.FRAME_DECODER, PipelineUtils.PACKET_DECODER, new MinecraftDecoder( Protocol.STATUS, false, ProxyServer.getInstance().getProtocolVersion() ) );
-        channel.getHandle().pipeline().addAfter( PipelineUtils.FRAME_PREPENDER_AND_COMPRESS, PipelineUtils.PACKET_ENCODER, encoder );
+        channel.getHandle().pipeline().addAfter( PipelineConstants.FRAME_DECODER, PipelineConstants.PACKET_DECODER, new MinecraftDecoder( Protocol.STATUS, false, ProxyServer.getInstance().getProtocolVersion() ) );
+        channel.getHandle().pipeline().addAfter( PipelineConstants.FRAME_PREPENDER_AND_COMPRESS, PipelineConstants.PACKET_ENCODER, encoder );
 
         channel.write( new Handshake( protocol, target.getAddress().getHostString(), target.getAddress().getPort(), 1 ) );
 

--- a/proxy/src/main/java/net/md_5/bungee/netty/ChannelWrapper.java
+++ b/proxy/src/main/java/net/md_5/bungee/netty/ChannelWrapper.java
@@ -18,6 +18,7 @@ import net.md_5.bungee.protocol.MinecraftDecoder;
 import net.md_5.bungee.protocol.MinecraftEncoder;
 import net.md_5.bungee.protocol.PacketWrapper;
 import net.md_5.bungee.protocol.Protocol;
+import net.md_5.bungee.protocol.channel.PipelineConstants;
 import net.md_5.bungee.protocol.packet.Kick;
 
 public class ChannelWrapper
@@ -177,6 +178,13 @@ public class ChannelWrapper
         ch.pipeline().addBefore( baseName, name, handler );
     }
 
+    public void addAfter(String baseName, String name, ChannelHandler handler)
+    {
+        Preconditions.checkState( ch.eventLoop().inEventLoop(), "cannot add handler outside of event loop" );
+        ch.pipeline().flush();
+        ch.pipeline().addAfter( baseName, name, handler );
+    }
+
     public Channel getHandle()
     {
         return ch;
@@ -196,14 +204,14 @@ public class ChannelWrapper
 
             if ( decompressor == null )
             {
-                addBefore( PipelineUtils.PACKET_DECODER, "decompress", decompressor = new PacketDecompressor() );
+                addAfter( PipelineConstants.FRAME_DECODER, PipelineConstants.DECOMPRESS, decompressor = new PacketDecompressor() );
             }
         } else
         {
             compressor.setCompress( false );
             if ( decompressor != null )
             {
-                ch.pipeline().remove( "decompress" );
+                ch.pipeline().remove( PipelineConstants.DECOMPRESS );
             }
         }
 

--- a/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java
+++ b/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java
@@ -1,5 +1,6 @@
 package net.md_5.bungee.netty;
 
+import static net.md_5.bungee.protocol.channel.PipelineConstants.*;
 import com.google.common.base.Preconditions;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelException;
@@ -101,9 +102,9 @@ public class PipelineUtils
 
         ProxyServer.getInstance().unsafe().setBackendChannelInitializer( BungeeChannelInitializer.create( ch ->
         {
-            PipelineUtils.BASE_SERVERSIDE.accept( ch );
-            ch.pipeline().addAfter( PipelineUtils.FRAME_DECODER, PipelineUtils.PACKET_DECODER, new MinecraftDecoder( Protocol.HANDSHAKE, false, ProxyServer.getInstance().getProtocolVersion() ) );
-            ch.pipeline().addAfter( PipelineUtils.FRAME_PREPENDER_AND_COMPRESS, PipelineUtils.PACKET_ENCODER, new MinecraftEncoder( Protocol.HANDSHAKE, false, ProxyServer.getInstance().getProtocolVersion() ) );
+            BASE_SERVERSIDE.accept( ch );
+            ch.pipeline().addAfter( FRAME_DECODER, PACKET_DECODER, new MinecraftDecoder( Protocol.HANDSHAKE, false, ProxyServer.getInstance().getProtocolVersion() ) );
+            ch.pipeline().addAfter( FRAME_PREPENDER_AND_COMPRESS, PACKET_ENCODER, new MinecraftEncoder( Protocol.HANDSHAKE, false, ProxyServer.getInstance().getProtocolVersion() ) );
 
             return true;
         } ) );
@@ -114,17 +115,6 @@ public class PipelineUtils
     private static final ChannelAcceptor BASE = new Base( false );
     private static final ChannelAcceptor BASE_SERVERSIDE = new Base( true );
     private static final KickStringWriter legacyKicker = new KickStringWriter();
-    public static final String TIMEOUT_HANDLER = "timeout";
-    public static final String WRITE_TIMEOUT_HANDLER = "write-timeout";
-    public static final String PACKET_DECODER = "packet-decoder";
-    public static final String PACKET_ENCODER = "packet-encoder";
-    public static final String BOSS_HANDLER = "inbound-boss";
-    public static final String ENCRYPT_HANDLER = "encrypt";
-    public static final String DECRYPT_HANDLER = "decrypt";
-    public static final String FRAME_DECODER = "frame-decoder";
-    public static final String FRAME_PREPENDER_AND_COMPRESS = "frame-prepender-compress";
-    public static final String LEGACY_DECODER = "legacy-decoder";
-    public static final String LEGACY_KICKER = "legacy-kick";
 
     private static boolean epoll;
     private static boolean io_uring;


### PR DESCRIPTION
Allows simpler handling of the pipeline, by exposing these constants via protocol module.

The class is marked as  Internal, as we don't guarantee that there will be no changes to the members of the class.

This pr also contains a small change affecting the way the PacketDecompressor will be added to the pipeline.
Closes #3798