### PR TITLE
Add separate permission for "/alertraw".

### DIFF
--- a/module/cmd-alert/src/main/java/net/md_5/bungee/module/cmd/alert/CommandAlertRaw.java
+++ b/module/cmd-alert/src/main/java/net/md_5/bungee/module/cmd/alert/CommandAlertRaw.java
@@ -15,7 +15,7 @@ public class CommandAlertRaw extends Command
 
     public CommandAlertRaw()
     {
-        super( "alertraw", "bungeecord.command.alert" );
+        super( "alertraw", "bungeecord.command.alertraw" );
     }
 
     @Override

--- a/proxy/src/main/java/net/md_5/bungee/conf/YamlConfig.java
+++ b/proxy/src/main/java/net/md_5/bungee/conf/YamlConfig.java
@@ -94,7 +94,7 @@ public class YamlConfig implements ConfigurationAdapter
             } ) );
             set( "permissions.admin", Arrays.asList( new String[]
             {
-                "bungeecord.command.alert", "bungeecord.command.end", "bungeecord.command.ip", "bungeecord.command.reload", "bungeecord.command.kick", "bungeecord.command.send", "bungeecord.command.find"
+                "bungeecord.command.alert", "bungeecord.command.alertraw", "bungeecord.command.end", "bungeecord.command.ip", "bungeecord.command.reload", "bungeecord.command.kick", "bungeecord.command.send", "bungeecord.command.find"
             } ) );
         }
 


### PR DESCRIPTION
I would like to suggest adding a separate permission node for the "/alertraw" command. This would allow for more control over what tools should be available to a player.