### PR TITLE
Add permissions for "/bungee" and "/perms".

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/command/CommandBungee.java
+++ b/proxy/src/main/java/net/md_5/bungee/command/CommandBungee.java
@@ -10,7 +10,7 @@ public class CommandBungee extends Command
 
     public CommandBungee()
     {
-        super( "bungee" );
+        super( "bungee", "bungeecord.command.bungee" );
     }
 
     @Override

--- a/proxy/src/main/java/net/md_5/bungee/command/CommandPerms.java
+++ b/proxy/src/main/java/net/md_5/bungee/command/CommandPerms.java
@@ -12,7 +12,7 @@ public class CommandPerms extends Command
 
     public CommandPerms()
     {
-        super( "perms" );
+        super( "perms", "bungeecord.command.perms" );
     }
 
     @Override


### PR DESCRIPTION
I would like to suggest adding permission nodes for the "/bungee" and "/perms" commands. This would allow for more control over what commands should be available.

"/bungee" can be used by anyone to see what version you're running. Many server owners don't want regular players to have this information.

"/perms" can be used by anyone to see what permission nodes they have. Many server owners don't want regular players to know how their permissions system is configured either.