### PR TITLE
prevent some jdk24+ memory/native access warnings

### DIFF
--- a/bootstrap/pom.xml
+++ b/bootstrap/pom.xml
@@ -48,6 +48,7 @@
                             <Main-Class>net.md_5.bungee.Bootstrap</Main-Class> 
                             <Implementation-Version>${describe}</Implementation-Version>
                             <Specification-Version>${maven.build.timestamp}</Specification-Version>
+                            <Enable-Native-Access>ALL-UNNAMED</Enable-Native-Access>
                         </manifestEntries>
                     </archive>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>33.3.1-jre</version>
+            <version>33.4.8-jre</version>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
1. A warning is printed when native libraries are loaded (https://openjdk.org/jeps/472), this is prevented by adding `Enable-Native-Access: ALL-UNNAMED` to the manifest
2. A warning is printed on the first access of a memory-access method in `sun.misc.Unsafe` (https://openjdk.org/jeps/498). I've updated to guava as they replaced their unsafe usages with safe replacement, but other libratries (such as netty) will continue to use unsafe which can/should not be supressed for now without a possible performance impact.