### PR TITLE
Replace pre-Java 8 functional interface instantiation in CommandServer

### DIFF
--- a/module/cmd-server/src/main/java/net/md_5/bungee/module/cmd/server/CommandServer.java
+++ b/module/cmd-server/src/main/java/net/md_5/bungee/module/cmd/server/CommandServer.java
@@ -2,7 +2,6 @@ package net.md_5.bungee.module.cmd.server;
 
 import java.util.Locale;
 import java.util.Map;
-import java.util.stream.Collectors;
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.chat.ClickEvent;
@@ -81,9 +80,9 @@ public class CommandServer extends Command implements TabExecutor
     public Iterable<String> onTabComplete(final CommandSender sender, final String[] args)
     {
         final String serverFilter = ( args.length == 0 ) ? "" : args[0].toLowerCase( Locale.ROOT );
-        return ProxyServer.getInstance().getServers().values().stream()
+        return () -> ProxyServer.getInstance().getServers().values().stream()
                 .filter( serverInfo -> serverInfo.getName().toLowerCase( Locale.ROOT ).startsWith( serverFilter ) && serverInfo.canAccess( sender ) )
                 .map( ServerInfo::getName )
-                .collect( Collectors.toList() );
+                .iterator();
     }
 }

--- a/module/cmd-server/src/main/java/net/md_5/bungee/module/cmd/server/CommandServer.java
+++ b/module/cmd-server/src/main/java/net/md_5/bungee/module/cmd/server/CommandServer.java
@@ -1,11 +1,8 @@
 package net.md_5.bungee.module.cmd.server;
 
-import com.google.common.base.Function;
-import com.google.common.base.Predicate;
-import com.google.common.collect.Iterables;
-import java.util.Collections;
 import java.util.Locale;
 import java.util.Map;
+import java.util.stream.Collectors;
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.chat.ClickEvent;
@@ -83,22 +80,11 @@ public class CommandServer extends Command implements TabExecutor
     @Override
     public Iterable<String> onTabComplete(final CommandSender sender, final String[] args)
     {
-        return ( args.length > 1 ) ? Collections.EMPTY_LIST : Iterables.transform( Iterables.filter( ProxyServer.getInstance().getServers().values(), new Predicate<ServerInfo>()
-        {
-            private final String lower = ( args.length == 0 ) ? "" : args[0].toLowerCase( Locale.ROOT );
-
-            @Override
-            public boolean apply(ServerInfo input)
-            {
-                return input.getName().toLowerCase( Locale.ROOT ).startsWith( lower ) && input.canAccess( sender );
-            }
-        } ), new Function<ServerInfo, String>()
-        {
-            @Override
-            public String apply(ServerInfo input)
-            {
-                return input.getName();
-            }
-        } );
+        final String serverFilter = ( args.length == 0 ) ? "" : args[0].toLowerCase( Locale.ROOT );
+        return ProxyServer.getInstance().getServers().values().stream()
+                .filter( serverInfo -> serverInfo.canAccess( sender ) )
+                .map( ServerInfo::getName )
+                .filter( serverName -> serverName.toLowerCase( Locale.ROOT ).startsWith( serverFilter ) )
+                .collect( Collectors.toList() );
     }
 }

--- a/module/cmd-server/src/main/java/net/md_5/bungee/module/cmd/server/CommandServer.java
+++ b/module/cmd-server/src/main/java/net/md_5/bungee/module/cmd/server/CommandServer.java
@@ -82,9 +82,8 @@ public class CommandServer extends Command implements TabExecutor
     {
         final String serverFilter = ( args.length == 0 ) ? "" : args[0].toLowerCase( Locale.ROOT );
         return ProxyServer.getInstance().getServers().values().stream()
-                .filter( serverInfo -> serverInfo.canAccess( sender ) )
+                .filter( serverInfo -> serverInfo.getName().toLowerCase( Locale.ROOT ).startsWith( serverFilter ) && serverInfo.canAccess( sender ) )
                 .map( ServerInfo::getName )
-                .filter( serverName -> serverName.toLowerCase( Locale.ROOT ).startsWith( serverFilter ) )
                 .collect( Collectors.toList() );
     }
 }


### PR DESCRIPTION
This code was written 12 years ago, long before [BungeeCord adopted Java 8](https://github.com/SpigotMC/BungeeCord/commit/129884f44d950ed97b36e1237dc1a098975c0475). #2846 from many years ago tried bumping some other code to Java 8, but I think it was too broad in scope. This just has a narrower improvement in tab completion.