### PR TITLE
Do not add control characters to the ClickEvent with OPEN_URL action

### DIFF
--- a/chat/src/main/java/net/md_5/bungee/api/chat/TextComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/TextComponent.java
@@ -191,6 +191,8 @@ public final class TextComponent extends BaseComponent
                 component = new TextComponent( old );
                 String urlString = message.substring( i, pos );
                 component.setText( urlString );
+
+                urlString = urlString.replaceAll( "\\p{Cntrl}", "" );
                 component.setClickEvent( new ClickEvent( ClickEvent.Action.OPEN_URL,
                         urlString.startsWith( "http" ) ? urlString : "http://" + urlString ) );
                 appender.accept( component );

--- a/chat/src/main/java/net/md_5/bungee/api/chat/TextComponent.java
+++ b/chat/src/main/java/net/md_5/bungee/api/chat/TextComponent.java
@@ -170,7 +170,7 @@ public final class TextComponent extends BaseComponent
                 }
                 continue;
             }
-            int pos = message.indexOf( ' ', i );
+            int pos = indexOfSpecial( message, i );
             if ( pos == -1 )
             {
                 pos = message.length();
@@ -191,8 +191,6 @@ public final class TextComponent extends BaseComponent
                 component = new TextComponent( old );
                 String urlString = message.substring( i, pos );
                 component.setText( urlString );
-
-                urlString = urlString.replaceAll( "\\p{Cntrl}", "" );
                 component.setClickEvent( new ClickEvent( ClickEvent.Action.OPEN_URL,
                         urlString.startsWith( "http" ) ? urlString : "http://" + urlString ) );
                 appender.accept( component );
@@ -205,6 +203,20 @@ public final class TextComponent extends BaseComponent
 
         component.setText( builder.toString() );
         appender.accept( component );
+    }
+
+    private static int indexOfSpecial(String message, int pos)
+    {
+        for ( int i = pos; i < message.length(); i++ )
+        {
+            char c = message.charAt( i );
+
+            if ( c == ' ' || Character.isISOControl( c ) )
+            {
+                return i;
+            }
+        }
+        return -1;
     }
 
     /**

--- a/serializer/src/test/java/net/md_5/bungee/api/chat/ComponentsTest.java
+++ b/serializer/src/test/java/net/md_5/bungee/api/chat/ComponentsTest.java
@@ -562,6 +562,13 @@ public class ComponentsTest
         assertNotNull( url2 );
         assertTrue( url2.getAction() == ClickEvent.Action.OPEN_URL );
         assertEquals( "http://google.com/test", url2.getValue() );
+
+        BaseComponent[] test3 = TextComponent.fromLegacyText( "Text\nhttp://google.com\n newline3" );
+        ClickEvent url3 = test3[1].getClickEvent();
+        assertNotNull( url3 );
+        assertTrue( url3.getAction() == ClickEvent.Action.OPEN_URL );
+        assertEquals( "http://google.com", url3.getValue() );
+        assertEquals( "\n newline3", BaseComponent.toPlainText( test3[2] ) );
     }
 
     @Test


### PR DESCRIPTION
This pull request fixes an issue where TextComponent#populateComponentStructure can add a string containing control characters to a ClickEvent with OPEN_URL action, which either makes the text unclickable or causes the player to be disconnected immediately for 1.21.5+ clients.

The following example causes this problem:
```
player.sendMessage(TextComponent.fromLegacy("Example text\n www.example.com\n other text\n"));
```
For clients 1.21.4< when clicking on the chat component:
https://pastebin.com/3shMCStk
For clients 1.21.5+ when receiving the chat component:
https://pastebin.com/UccNTkpy

