### PR TITLE
Declare some DefinedPacket util methods as static

### DIFF
--- a/protocol/src/main/java/net/md_5/bungee/protocol/DefinedPacket.java
+++ b/protocol/src/main/java/net/md_5/bungee/protocol/DefinedPacket.java
@@ -36,12 +36,12 @@ import net.md_5.bungee.protocol.util.TagUtil;
 public abstract class DefinedPacket
 {
 
-    public <T> T readNullable(Function<ByteBuf, T> reader, ByteBuf buf)
+    public static <T> T readNullable(Function<ByteBuf, T> reader, ByteBuf buf)
     {
         return buf.readBoolean() ? reader.apply( buf ) : null;
     }
 
-    public <T> void writeNullable(T t0, BiConsumer<T, ByteBuf> writer, ByteBuf buf)
+    public static <T> void writeNullable(T t0, BiConsumer<T, ByteBuf> writer, ByteBuf buf)
     {
         if ( t0 != null )
         {
@@ -53,7 +53,7 @@ public abstract class DefinedPacket
         }
     }
 
-    public <T> T readLengthPrefixed(Function<ByteBuf, T> reader, ByteBuf buf, int maxSize)
+    public static <T> T readLengthPrefixed(Function<ByteBuf, T> reader, ByteBuf buf, int maxSize)
     {
         int size = readVarInt( buf );
 
@@ -65,7 +65,7 @@ public abstract class DefinedPacket
         return reader.apply( buf.readSlice( size ) );
     }
 
-    public <T> void writeLengthPrefixed(T value, BiConsumer<T, ByteBuf> writer, ByteBuf buf, int maxSize)
+    public static <T> void writeLengthPrefixed(T value, BiConsumer<T, ByteBuf> writer, ByteBuf buf, int maxSize)
     {
         ByteBuf tempBuffer = buf.alloc().buffer();
         try


### PR DESCRIPTION
Seems like we forgot some of them, but we should make them all static for consistency