### PR TITLE
Remove manual player removal from tab list

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
@@ -8,14 +8,12 @@ import io.netty.channel.Channel;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.UUID;
 import net.md_5.bungee.BungeeCord;
 import net.md_5.bungee.ServerConnection;
 import net.md_5.bungee.ServerConnection.KeepAliveData;
 import net.md_5.bungee.UserConnection;
 import net.md_5.bungee.Util;
 import net.md_5.bungee.api.ProxyServer;
-import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.event.ChatEvent;
 import net.md_5.bungee.api.event.CustomClickEvent;
 import net.md_5.bungee.api.event.PlayerDisconnectEvent;
@@ -38,8 +36,6 @@ import net.md_5.bungee.protocol.packet.CustomClickAction;
 import net.md_5.bungee.protocol.packet.KeepAlive;
 import net.md_5.bungee.protocol.packet.LoginAcknowledged;
 import net.md_5.bungee.protocol.packet.LoginPayloadResponse;
-import net.md_5.bungee.protocol.packet.PlayerListItem;
-import net.md_5.bungee.protocol.packet.PlayerListItemRemove;
 import net.md_5.bungee.protocol.packet.PluginMessage;
 import net.md_5.bungee.protocol.packet.StartConfiguration;
 import net.md_5.bungee.protocol.packet.TabCompleteRequest;
@@ -79,38 +75,6 @@ public class UpstreamBridge extends PacketHandler
 
         if ( con.getServer() != null )
         {
-            // Manually remove from everyone's tab list
-            // since the packet from the server arrives
-            // too late
-            // TODO: This should only done with server_unique
-            //       tab list (which is the only one supported
-            //       currently)
-            PlayerListItem oldPacket = new PlayerListItem();
-            oldPacket.setAction( PlayerListItem.Action.REMOVE_PLAYER );
-            PlayerListItem.Item item = new PlayerListItem.Item();
-            item.setUuid( con.getRewriteId() );
-            oldPacket.setItems( new PlayerListItem.Item[]
-            {
-                item
-            } );
-
-            PlayerListItemRemove newPacket = new PlayerListItemRemove();
-            newPacket.setUuids( new UUID[]
-            {
-                con.getRewriteId()
-            } );
-
-            for ( ProxiedPlayer player : con.getServer().getInfo().getPlayers() )
-            {
-                if ( player.getPendingConnection().getVersion() >= ProtocolConstants.MINECRAFT_1_19_3 )
-                {
-                    // need to queue, because players in config state could receive it
-                    player.unsafe().sendPacketQueued( newPacket );
-                } else
-                {
-                    player.unsafe().sendPacket( oldPacket );
-                }
-            }
             con.getServer().disconnect( "Quitting" );
         }
     }


### PR DESCRIPTION
It seems like my changes in #3656 made this redundant.

I could not reproduce what was described in https://github.com/SpigotMC/BungeeCord/commit/830f18a

I guess the reason for that is that in my change i used the offline uuid for rewriting if ip forward is disabled and online mode enabled.

In exactly this case the premium uuid was used and could later not be rewrited anymore when the player has disconnected.