### PR TITLE
Supports loading plugins from non-built-in plugin folder

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/ProxyConfig.java
+++ b/api/src/main/java/net/md_5/bungee/api/ProxyConfig.java
@@ -1,5 +1,6 @@
 package net.md_5.bungee.api;
 
+import java.io.File;
 import java.util.Collection;
 import java.util.Map;
 import net.md_5.bungee.api.config.ListenerInfo;
@@ -125,4 +126,10 @@ public interface ProxyConfig
      * @return favicon
      */
     Favicon getFaviconObject();
+
+    /**
+     * The directories to load plugin from.
+     * @return directories
+     */
+    Collection<File> getPluginDirectories();
 }

--- a/api/src/main/java/net/md_5/bungee/api/ProxyServer.java
+++ b/api/src/main/java/net/md_5/bungee/api/ProxyServer.java
@@ -237,6 +237,13 @@ public abstract class ProxyServer
     public abstract File getPluginsFolder();
 
     /**
+     * Return all the directories to load plugins from.
+     *
+     * @return all the plugin directories
+     */
+    public abstract Collection<File> getPluginDirectories();
+
+    /**
      * Get the scheduler instance for this proxy.
      *
      * @return the in use scheduler

--- a/api/src/main/java/net/md_5/bungee/api/plugin/Plugin.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/Plugin.java
@@ -76,7 +76,7 @@ public class Plugin
      */
     public final File getDataFolder()
     {
-        return new File( getProxy().getPluginsFolder(), getDescription().getName() );
+        return new File( getProxy().getPluginManager().matchPluginDirectory( description ), getDescription().getName() );
     }
 
     /**

--- a/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
@@ -61,6 +61,7 @@ public final class PluginManager
     private final LibraryLoader libraryLoader;
     private final Map<String, Command> commandMap = new HashMap<>();
     private Map<String, PluginDescription> toLoad = new HashMap<>();
+    private final Map<PluginDescription, File> pluginDirectoryToPlugin = new HashMap<>();
     private final Multimap<Plugin, Command> commandsByPlugin = ArrayListMultimap.create();
     private final Multimap<Plugin, Listener> listenersByPlugin = ArrayListMultimap.create();
 
@@ -406,6 +407,7 @@ public final class PluginManager
 
                         desc.setFile( file );
                         toLoad.put( desc.getName(), desc );
+                        pluginDirectoryToPlugin.put( desc, folder );
                     }
                 } catch ( Exception ex )
                 {
@@ -486,6 +488,17 @@ public final class PluginManager
             eventBus.unregister( it.next() );
             it.remove();
         }
+    }
+
+    /**
+     * Gets which directory is the plugin in.
+     *
+     * @param desc plugin description
+     * @return the directory
+     */
+    public File matchPluginDirectory(PluginDescription desc)
+    {
+        return pluginDirectoryToPlugin.get( desc );
     }
 
     /**

--- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
@@ -147,6 +147,8 @@ public class BungeeCord extends ProxyServer
     @Getter
     private final File pluginsFolder = new File( "plugins" );
     @Getter
+    private final Collection<File> pluginDirectories = config.getPluginDirectories();
+    @Getter
     private final BungeeScheduler scheduler = new BungeeScheduler();
     @Getter
     private final LineReader consoleReader;
@@ -283,11 +285,16 @@ public class BungeeCord extends ProxyServer
         moduleManager.load( this, moduleDirectory );
         pluginManager.detectPlugins( moduleDirectory );
 
+        config.load();
+
         pluginsFolder.mkdir();
-        pluginManager.detectPlugins( pluginsFolder );
+        for ( File pluginDirectory : pluginDirectories )
+        {
+            pluginDirectory.mkdir();
+            pluginManager.detectPlugins( pluginDirectory );
+        }
 
         pluginManager.loadPlugins();
-        config.load();
 
         if ( config.isForgeSupport() )
         {

--- a/proxy/src/main/java/net/md_5/bungee/conf/Configuration.java
+++ b/proxy/src/main/java/net/md_5/bungee/conf/Configuration.java
@@ -3,10 +3,7 @@ package net.md_5.bungee.conf;
 import com.google.common.base.Preconditions;
 import java.io.File;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 import java.util.logging.Level;
 import javax.imageio.ImageIO;
 import lombok.Getter;
@@ -70,6 +67,7 @@ public class Configuration implements ProxyConfig
     private boolean rejectTransfers;
     private int maxPacketsPerSecond = 1 << 12;
     private int maxPacketDataPerSecond = 1 << 25;
+    private final Collection<File> pluginDirectories = new ArrayList<>( Collections.singletonList( new File( "plugins" ) ) );
 
     public void load()
     {
@@ -112,6 +110,13 @@ public class Configuration implements ProxyConfig
         disabledCommands = new CaseInsensitiveSet( (Collection<String>) adapter.getList( "disabled_commands", Arrays.asList( "disabledcommandhere" ) ) );
 
         Preconditions.checkArgument( listeners != null && !listeners.isEmpty(), "No listeners defined." );
+
+        for ( String path : (Collection<String>) adapter.getList( "plugin_directories", Collections.emptyList() ) )
+        {
+            File directory = new File( path );
+            Preconditions.checkArgument( directory.isDirectory(), "'%s' isn't a valid plugin directory", path );
+            pluginDirectories.add( directory );
+        }
 
         Map<String, ServerInfo> newServers = adapter.getServers();
         Preconditions.checkArgument( newServers != null && !newServers.isEmpty(), "No servers defined" );


### PR DESCRIPTION
A "plugin_directories" option has been added to config.yml. Now BungeeCord can load plugins from directories other than plugins (i.e., directories configured in plugin_directories), and the plugin's data folder will also point to its respective plugin directory.