### PR TITLE
Add @NotNull annotation to onTabComplete method

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/plugin/TabExecutor.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/TabExecutor.java
@@ -2,10 +2,10 @@ package net.md_5.bungee.api.plugin;
 
 import net.md_5.bungee.api.CommandSender;
 
-import org.jetbrains.annotations.NotNull;
+import lombok.NonNull;
 
 public interface TabExecutor
 {
 
-    public @NotNull Iterable<String> onTabComplete(CommandSender sender, String[] args);
+    public @NonNull Iterable<String> onTabComplete(CommandSender sender, String[] args);
 }


### PR DESCRIPTION
If some plugin returns null inside TabExecutor#onTabComplete, https://github.com/SpigotMC/BungeeCord/blob/36e61543036703a1136aaa977194ca5a06e565ea/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java#L229 will log a warn but won't put the plugin in the stack trace