### PR TITLE
Convert JavaZlib from byte arrays to NIO ByteBuffer

### DIFF
--- a/native/src/main/java/net/md_5/bungee/jni/zlib/JavaZlib.java
+++ b/native/src/main/java/net/md_5/bungee/jni/zlib/JavaZlib.java
@@ -59,10 +59,10 @@ public class JavaZlib implements BungeeZlib
 
             while ( !deflater.finished() )
             {
-                int count = deflater.deflate(bufferOut);
+                int count = deflater.deflate( bufferOut );
                 bufferOut.flip();
 
-                out.writeBytes(bufferOut);
+                out.writeBytes( bufferOut );
                 bufferOut.flip();
 
                 if ( count == 0 && deflater.needsInput() )
@@ -80,10 +80,10 @@ public class JavaZlib implements BungeeZlib
 
             while ( !inflater.finished() && inflater.getBytesRead() < readableBytes )
             {
-                int count = inflater.inflate(bufferOut);
+                int count = inflater.inflate( bufferOut );
                 bufferOut.flip();
 
-                out.writeBytes(bufferOut);
+                out.writeBytes( bufferOut );
                 bufferOut.flip();
 
                 if ( count == 0 && inflater.needsInput() )

--- a/native/src/main/java/net/md_5/bungee/jni/zlib/JavaZlib.java
+++ b/native/src/main/java/net/md_5/bungee/jni/zlib/JavaZlib.java
@@ -9,7 +9,7 @@ import java.util.zip.Inflater;
 public class JavaZlib implements BungeeZlib
 {
 
-    private final ByteBuffer buffer = ByteBuffer.allocate( 8192 );
+    private final ByteBuffer bufferOut = ByteBuffer.allocate( 8192 );
     //
     private boolean compress;
     private Deflater deflater;
@@ -33,6 +33,8 @@ public class JavaZlib implements BungeeZlib
     @Override
     public void free()
     {
+        bufferOut.clear();
+
         if ( deflater != null )
         {
             deflater.end();
@@ -47,46 +49,46 @@ public class JavaZlib implements BungeeZlib
     public void process(ByteBuf in, ByteBuf out) throws DataFormatException
     {
         int bufferIndex = 0;
-        ByteBuffer[] buffers = in.nioBuffers();
-        buffer.clear();
+        ByteBuffer[] buffersIn = in.nioBuffers();
+        bufferOut.clear();
 
         if ( compress )
         {
-            deflater.setInput( buffers[ 0 ] );
+            deflater.setInput( buffersIn[ bufferIndex ] );
             deflater.finish();
 
             while ( !deflater.finished() )
             {
-                int count = deflater.deflate( buffer );
-                buffer.flip();
+                int count = deflater.deflate(bufferOut);
+                bufferOut.flip();
 
-                out.writeBytes( buffer );
-                buffer.flip();
+                out.writeBytes(bufferOut);
+                bufferOut.flip();
 
                 if ( count == 0 && deflater.needsInput() )
                 {
-                    deflater.setInput( buffers[ ++bufferIndex ] );
+                    deflater.setInput( buffersIn[ ++bufferIndex ] );
                 }
             }
 
             deflater.reset();
         } else
         {
-            int inLength = in.readableBytes();
+            int readableBytes = in.readableBytes();
 
-            inflater.setInput( buffers[ 0 ] );
+            inflater.setInput( buffersIn[ 0 ] );
 
-            while ( !inflater.finished() && inflater.getBytesRead() < inLength )
+            while ( !inflater.finished() && inflater.getBytesRead() < readableBytes )
             {
-                int count = inflater.inflate( buffer );
-                buffer.flip();
+                int count = inflater.inflate(bufferOut);
+                bufferOut.flip();
 
-                out.writeBytes( buffer );
-                buffer.flip();
+                out.writeBytes(bufferOut);
+                bufferOut.flip();
 
                 if ( count == 0 && inflater.needsInput() )
                 {
-                    inflater.setInput( buffers[ ++bufferIndex ] );
+                    inflater.setInput( buffersIn[ ++bufferIndex ] );
                 }
             }
 

--- a/native/src/main/java/net/md_5/bungee/jni/zlib/JavaZlib.java
+++ b/native/src/main/java/net/md_5/bungee/jni/zlib/JavaZlib.java
@@ -1,6 +1,7 @@
 package net.md_5.bungee.jni.zlib;
 
 import io.netty.buffer.ByteBuf;
+import java.nio.ByteBuffer;
 import java.util.zip.DataFormatException;
 import java.util.zip.Deflater;
 import java.util.zip.Inflater;
@@ -8,7 +9,7 @@ import java.util.zip.Inflater;
 public class JavaZlib implements BungeeZlib
 {
 
-    private final byte[] buffer = new byte[ 8192 ];
+    private final ByteBuffer buffer = ByteBuffer.allocate( 8192 );
     //
     private boolean compress;
     private Deflater deflater;
@@ -45,29 +46,48 @@ public class JavaZlib implements BungeeZlib
     @Override
     public void process(ByteBuf in, ByteBuf out) throws DataFormatException
     {
-        byte[] inData = new byte[ in.readableBytes() ];
-        in.readBytes( inData );
+        int bufferIndex = 0;
+        ByteBuffer[] buffers = in.nioBuffers();
+        buffer.clear();
 
         if ( compress )
         {
-            deflater.setInput( inData );
+            deflater.setInput( buffers[ 0 ] );
             deflater.finish();
 
             while ( !deflater.finished() )
             {
                 int count = deflater.deflate( buffer );
-                out.writeBytes( buffer, 0, count );
+                buffer.flip();
+
+                out.writeBytes( buffer );
+                buffer.flip();
+
+                if ( count == 0 && deflater.needsInput() )
+                {
+                    deflater.setInput( buffers[ ++bufferIndex ] );
+                }
             }
 
             deflater.reset();
         } else
         {
-            inflater.setInput( inData );
+            int inLength = in.readableBytes();
 
-            while ( !inflater.finished() && inflater.getTotalIn() < inData.length )
+            inflater.setInput( buffers[ 0 ] );
+
+            while ( !inflater.finished() && inflater.getBytesRead() < inLength )
             {
                 int count = inflater.inflate( buffer );
-                out.writeBytes( buffer, 0, count );
+                buffer.flip();
+
+                out.writeBytes( buffer );
+                buffer.flip();
+
+                if ( count == 0 && inflater.needsInput() )
+                {
+                    inflater.setInput( buffers[ ++bufferIndex ] );
+                }
             }
 
             inflater.reset();


### PR DESCRIPTION
This PR reimplements the JavaZlib class. Previously, BungeeCord used `byte[]` arrays that were copies of the content of a Netty `ByteBuf`. This has performance and memory penalties. With these changes, JavaZlib will utilize the underlying NIO `ByteBuffer`(s) that back a `ByteBuf`. While this implementation still has its drawbacks (buffering is utilized to transfer data after Deflate/Inflate calls from `ByteBuffer->ByteBuf`), I believe this will lay the groundwork required for someone to take initiative in ensuring this code is performant.