### PR TITLE
Convert JavaCipher from byte arrays to NIO ByteBuffer

### DIFF
--- a/native/src/main/java/net/md_5/bungee/jni/cipher/JavaCipher.java
+++ b/native/src/main/java/net/md_5/bungee/jni/cipher/JavaCipher.java
@@ -13,7 +13,6 @@ import javax.crypto.spec.IvParameterSpec;
 public class JavaCipher implements BungeeCipher
 {
 
-    private boolean type;
     private final Cipher cipher;
     private static final FastThreadLocal<ByteBuffer> bufferOutLocal = new EmptyByteThreadLocal();
 
@@ -41,7 +40,6 @@ public class JavaCipher implements BungeeCipher
     @Override
     public void init(boolean forEncryption, SecretKey key) throws GeneralSecurityException
     {
-        this.type = forEncryption;
         int mode = forEncryption ? Cipher.ENCRYPT_MODE : Cipher.DECRYPT_MODE;
         cipher.init( mode, key, new IvParameterSpec( key.getEncoded() ) );
     }
@@ -49,7 +47,6 @@ public class JavaCipher implements BungeeCipher
     @Override
     public void cipher(ByteBuf in, ByteBuf out) throws ShortBufferException
     {
-        System.out.println( this.type ? "enc" : "dec" );
         int readableBytes = in.readableBytes();
 
         ByteBuffer bufferOut = bufferOutLocal.get();

--- a/native/src/main/java/net/md_5/bungee/jni/cipher/JavaCipher.java
+++ b/native/src/main/java/net/md_5/bungee/jni/cipher/JavaCipher.java
@@ -3,6 +3,7 @@ package net.md_5.bungee.jni.cipher;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.util.concurrent.FastThreadLocal;
+import java.nio.ByteBuffer;
 import java.security.GeneralSecurityException;
 import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
@@ -12,17 +13,17 @@ import javax.crypto.spec.IvParameterSpec;
 public class JavaCipher implements BungeeCipher
 {
 
+    private boolean type;
     private final Cipher cipher;
-    private static final FastThreadLocal<byte[]> heapInLocal = new EmptyByteThreadLocal();
-    private static final FastThreadLocal<byte[]> heapOutLocal = new EmptyByteThreadLocal();
+    private static final FastThreadLocal<ByteBuffer> bufferOutLocal = new EmptyByteThreadLocal();
 
-    private static class EmptyByteThreadLocal extends FastThreadLocal<byte[]>
+    private static class EmptyByteThreadLocal extends FastThreadLocal<ByteBuffer>
     {
 
         @Override
-        protected byte[] initialValue()
+        protected ByteBuffer initialValue()
         {
-            return new byte[ 0 ];
+            return ByteBuffer.allocate( 0 );
         }
     }
 
@@ -40,6 +41,7 @@ public class JavaCipher implements BungeeCipher
     @Override
     public void init(boolean forEncryption, SecretKey key) throws GeneralSecurityException
     {
+        this.type = forEncryption;
         int mode = forEncryption ? Cipher.ENCRYPT_MODE : Cipher.DECRYPT_MODE;
         cipher.init( mode, key, new IvParameterSpec( key.getEncoded() ) );
     }
@@ -47,47 +49,42 @@ public class JavaCipher implements BungeeCipher
     @Override
     public void cipher(ByteBuf in, ByteBuf out) throws ShortBufferException
     {
+        System.out.println( this.type ? "enc" : "dec" );
         int readableBytes = in.readableBytes();
-        byte[] heapIn = bufToByte( in );
 
-        byte[] heapOut = heapOutLocal.get();
+        ByteBuffer bufferOut = bufferOutLocal.get();
         int outputSize = cipher.getOutputSize( readableBytes );
-        if ( heapOut.length < outputSize )
+        if ( bufferOut.capacity() < outputSize )
         {
-            heapOut = new byte[ outputSize ];
-            heapOutLocal.set( heapOut );
+            bufferOut = ByteBuffer.allocate( outputSize );
+            bufferOutLocal.set( bufferOut );
         }
-        out.writeBytes( heapOut, 0, cipher.update( heapIn, 0, readableBytes, heapOut ) );
+        bufferOut.clear();
+
+        ByteBuffer[] buffersIn = in.nioBuffers();
+        for ( ByteBuffer bufferIn : buffersIn )
+        {
+            cipher.update( bufferIn, bufferOut );
+        }
+        bufferOut.flip();
+
+        out.writeBytes( bufferOut );
     }
 
     @Override
     public ByteBuf cipher(ChannelHandlerContext ctx, ByteBuf in) throws ShortBufferException
     {
         int readableBytes = in.readableBytes();
-        byte[] heapIn = bufToByte( in );
-
         ByteBuf heapOut = ctx.alloc().heapBuffer( cipher.getOutputSize( readableBytes ) );
-        heapOut.writerIndex( cipher.update( heapIn, 0, readableBytes, heapOut.array(), heapOut.arrayOffset() ) );
 
+        cipher( in, heapOut );
         return heapOut;
     }
 
     @Override
     public void free()
     {
-    }
-
-    private byte[] bufToByte(ByteBuf in)
-    {
-        byte[] heapIn = heapInLocal.get();
-        int readableBytes = in.readableBytes();
-        if ( heapIn.length < readableBytes )
-        {
-            heapIn = new byte[ readableBytes ];
-            heapInLocal.set( heapIn );
-        }
-        in.readBytes( heapIn, 0, readableBytes );
-        return heapIn;
+        bufferOutLocal.get().clear();
     }
 
     @Override


### PR DESCRIPTION
Similarly to #3981 , this PR reimplements the JavaCipher class. It attempts to minimize the amount of data copying from Netty `ByteBuf`s that happens by utilizing their underlying NIO `ByteBuffer`(s), and lays the groundwork for future improvements.