### PR TITLE
fixes an elytra boosting bug on 1.12 - 1.13.2 clients when joining a …

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
+++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
@@ -260,11 +260,12 @@ public class ServerConnector extends PacketHandler
         if ( user.getServer() == null || user.getPendingConnection().getVersion() >= ProtocolConstants.MINECRAFT_1_16 )
         {
             // Once again, first connection
-            user.setClientEntityId( login.getEntityId() );
+            int entityId = login.getEntityId() == 0 ? 1 : login.getEntityId();
+            user.setClientEntityId( entityId );
             user.setServerEntityId( login.getEntityId() );
 
             // Set tab list size, TODO: what shall we do about packet mutability
-            Login modLogin = new Login( login.getEntityId(), login.isHardcore(), login.getGameMode(), login.getPreviousGameMode(), login.getWorldNames(), login.getDimensions(), login.getDimension(), login.getWorldName(), login.getSeed(), login.getDifficulty(),
+            Login modLogin = new Login( entityId, login.isHardcore(), login.getGameMode(), login.getPreviousGameMode(), login.getWorldNames(), login.getDimensions(), login.getDimension(), login.getWorldName(), login.getSeed(), login.getDifficulty(),
                     (byte) user.getPendingConnection().getListener().getTabListSize(), login.getLevelType(), login.getViewDistance(), login.getSimulationDistance(), login.isReducedDebugInfo(), login.isNormalRespawn(), login.isLimitedCrafting(), login.isDebug(), login.isFlat(), login.getDeathLocation(),
                     login.getPortalCooldown(), login.getSeaLevel(), login.isOnlineMode(), login.isSecureProfile() );
 


### PR DESCRIPTION
…limbo server as the first server to join

legacy clients see entity id 0 as unset, which breaks firework rocket elytra boosting. this can be fixed by mapping initial entity ids of 0 to 1 instead