### PR TITLE
Use pending connections online mode state for login packet

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
+++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
@@ -266,7 +266,7 @@ public class ServerConnector extends PacketHandler
             // Set tab list size, TODO: what shall we do about packet mutability
             Login modLogin = new Login( login.getEntityId(), login.isHardcore(), login.getGameMode(), login.getPreviousGameMode(), login.getWorldNames(), login.getDimensions(), login.getDimension(), login.getWorldName(), login.getSeed(), login.getDifficulty(),
                     (byte) user.getPendingConnection().getListener().getTabListSize(), login.getLevelType(), login.getViewDistance(), login.getSimulationDistance(), login.isReducedDebugInfo(), login.isNormalRespawn(), login.isLimitedCrafting(), login.isDebug(), login.isFlat(), login.getDeathLocation(),
-                    login.getPortalCooldown(), login.getSeaLevel(), login.isOnlineMode(), login.isSecureProfile() );
+                    login.getPortalCooldown(), login.getSeaLevel(), user.getPendingConnection().isOnlineMode(), login.isSecureProfile() );
 
             user.unsafe().sendPacket( modLogin );
 


### PR DESCRIPTION
Otherwise player heads won't be displayed in tablist even tho bungee is on online mode