### PR TITLE
fix: make getServers() thread-safe with getServersCopy() and synchronized mutations (#4005)

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/ProxyConfig.java
+++ b/api/src/main/java/net/md_5/bungee/api/ProxyConfig.java
@@ -39,8 +39,85 @@ public interface ProxyConfig
      * Set of all servers.
      *
      * @return servers
+     * @deprecated The returned map may be modified concurrently by the proxy.
+     *             The safe alternative is {@link #getServersCopy()}.
      */
+    @Deprecated
     Map<String, ServerInfo> getServers();
+
+    /**
+     * Return all servers registered to this proxy, keyed by name. The returned map
+     * is an immutable snapshot of the actual server collection. It cannot be modified,
+     * and it will not change.
+     *
+     * @return all registered remote server destinations
+     */
+    Map<String, ServerInfo> getServersCopy();
+
+    /**
+     * Gets the server info of a server.
+     *
+     * @param name the name of the configured server
+     * @return the server info belonging to the specified server
+     */
+    ServerInfo getServerInfo(String name);
+
+    /**
+     * Register the given server to the proxy.
+     * Any currently registered server with the same name will be replaced.
+     * This change is not saved to config.yml.
+     *
+     * @param server The server to register with the proxy
+     * @return the previously registered server with the same name, or null if there was no such server.
+     */
+    ServerInfo addServer(ServerInfo server);
+
+    /**
+     * Register all of the given servers to the proxy.
+     * This change is not saved to config.yml.
+     *
+     * @param servers The collection of servers to register with the proxy
+     * @return true if any servers were added or replaced.
+     */
+    boolean addServers(Collection<ServerInfo> servers);
+
+    /**
+     * Un-register the server with the given name from the proxy.
+     * This change is not saved to config.yml.
+     *
+     * @param name The name of the server to unregister
+     * @return the server that was removed, or null if there is no server with the given name.
+     */
+    ServerInfo removeServerNamed(String name);
+
+    /**
+     * Un-register the given server from the proxy.
+     * The server is matched by name only, other fields in the given {@link ServerInfo} are ignored.
+     * This change is not saved to config.yml.
+     *
+     * @param server the server to unregister from the proxy
+     * @return the server that was removed, or null if there is no server with a matching name.
+     */
+    ServerInfo removeServer(ServerInfo server);
+
+    /**
+     * Un-register servers with any of the given names from the proxy.
+     * This change is not saved to config.yml.
+     *
+     * @param names a collection of server names to be unregistered
+     * @return true if any servers were removed.
+     */
+    boolean removeServersNamed(Collection<String> names);
+
+    /**
+     * Un-register all of the given servers from the proxy.
+     * The servers are matched by name only, other fields in the given {@link ServerInfo} are ignored.
+     * This change is not saved to config.yml.
+     *
+     * @param servers a collection of servers to be unregistered
+     * @return true if any servers were removed.
+     */
+    boolean removeServers(Collection<ServerInfo> servers);
 
     /**
      * Does the server authenticate with Mojang.

--- a/api/src/main/java/net/md_5/bungee/api/ProxyServer.java
+++ b/api/src/main/java/net/md_5/bungee/api/ProxyServer.java
@@ -97,8 +97,21 @@ public abstract class ProxyServer
      * return a fresh map each time.
      *
      * @return all registered remote server destinations
+     * @deprecated The returned map is part of the proxy's internal state,
+     *             and may be modified concurrently by the proxy.
+     *             The safe alternative is {@link #getServersCopy()}.
      */
+    @Deprecated
     public abstract Map<String, ServerInfo> getServers();
+
+    /**
+     * Return all servers registered to this proxy, keyed by name. The returned map
+     * is an immutable snapshot of the actual server collection. It cannot be modified,
+     * and it will not change.
+     *
+     * @return all registered remote server destinations
+     */
+    public abstract Map<String, ServerInfo> getServersCopy();
 
     /**
      * Gets the server info of a server.

--- a/module/cmd-list/src/main/java/net/md_5/bungee/module/cmd/list/CommandList.java
+++ b/module/cmd-list/src/main/java/net/md_5/bungee/module/cmd/list/CommandList.java
@@ -34,7 +34,7 @@ public class CommandList extends Command implements TabExecutor
         boolean hideEmptyServers = ( args.length == 0 ) || !args[0].equalsIgnoreCase( "all" );
         boolean moduleLoaded = ProxyServer.getInstance().getPluginManager().getPlugin( "cmd_server" ) != null;
 
-        for ( ServerInfo server : ProxyServer.getInstance().getServers().values() )
+        for ( ServerInfo server : ProxyServer.getInstance().getServersCopy().values() )
         {
             if ( !server.canAccess( sender ) )
             {

--- a/module/cmd-send/src/main/java/net/md_5/bungee/module/cmd/send/CommandSend.java
+++ b/module/cmd-send/src/main/java/net/md_5/bungee/module/cmd/send/CommandSend.java
@@ -187,7 +187,7 @@ public class CommandSend extends Command implements TabExecutor
         } else
         {
             String search = args[1].toLowerCase( Locale.ROOT );
-            for ( String server : ProxyServer.getInstance().getServers().keySet() )
+            for ( String server : ProxyServer.getInstance().getServersCopy().keySet() )
             {
                 if ( server.toLowerCase( Locale.ROOT ).startsWith( search ) )
                 {

--- a/module/cmd-server/src/main/java/net/md_5/bungee/module/cmd/server/CommandServer.java
+++ b/module/cmd-server/src/main/java/net/md_5/bungee/module/cmd/server/CommandServer.java
@@ -28,7 +28,7 @@ public class CommandServer extends Command implements TabExecutor
     @Override
     public void execute(CommandSender sender, String[] args)
     {
-        Map<String, ServerInfo> servers = ProxyServer.getInstance().getServers();
+        Map<String, ServerInfo> servers = ProxyServer.getInstance().getServersCopy();
         if ( args.length == 0 )
         {
             if ( sender instanceof ProxiedPlayer )
@@ -80,7 +80,7 @@ public class CommandServer extends Command implements TabExecutor
     public Iterable<String> onTabComplete(final CommandSender sender, final String[] args)
     {
         final String serverFilter = ( args.length == 0 ) ? "" : args[0].toLowerCase( Locale.ROOT );
-        return () -> ProxyServer.getInstance().getServers().values().stream()
+        return () -> ProxyServer.getInstance().getServersCopy().values().stream()
                 .filter( serverInfo -> serverInfo.getName().toLowerCase( Locale.ROOT ).startsWith( serverFilter ) && serverInfo.canAccess( sender ) )
                 .map( ServerInfo::getName )
                 .iterator();

--- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
@@ -637,15 +637,22 @@ public class BungeeCord extends ProxyServer
     }
 
     @Override
+    @Deprecated
     public Map<String, ServerInfo> getServers()
     {
         return config.getServers();
     }
 
     @Override
+    public Map<String, ServerInfo> getServersCopy()
+    {
+        return config.getServersCopy();
+    }
+
+    @Override
     public ServerInfo getServerInfo(String name)
     {
-        return getServers().get( name );
+        return config.getServerInfo( name );
     }
 
     @Override

--- a/proxy/src/main/java/net/md_5/bungee/conf/Configuration.java
+++ b/proxy/src/main/java/net/md_5/bungee/conf/Configuration.java
@@ -1,15 +1,18 @@
 package net.md_5.bungee.conf;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Level;
 import javax.imageio.ImageIO;
 import lombok.Getter;
+import lombok.Synchronized;
 import net.md_5.bungee.api.Favicon;
 import net.md_5.bungee.api.ProxyConfig;
 import net.md_5.bungee.api.ProxyServer;
@@ -42,6 +45,7 @@ public class Configuration implements ProxyConfig
      * Set of all servers.
      */
     private Map<String, ServerInfo> servers;
+    private final ReentrantLock serversLock = new ReentrantLock();
     /**
      * Should we check minecraft.net auth.
      */
@@ -71,6 +75,7 @@ public class Configuration implements ProxyConfig
     private int maxPacketsPerSecond = 1 << 12;
     private int maxPacketDataPerSecond = 1 << 25;
 
+    @Synchronized("serversLock")
     public void load()
     {
         ConfigurationAdapter adapter = ProxyServer.getInstance().getConfigurationAdapter();
@@ -165,5 +170,84 @@ public class Configuration implements ProxyConfig
     public Favicon getFaviconObject()
     {
         return favicon;
+    }
+
+    @Override
+    @Deprecated
+    public Map<String, ServerInfo> getServers()
+    {
+        return servers;
+    }
+
+    @Override
+    @Synchronized("serversLock")
+    public Map<String, ServerInfo> getServersCopy()
+    {
+        return ImmutableMap.copyOf( servers );
+    }
+
+    @Override
+    @Synchronized("serversLock")
+    public ServerInfo getServerInfo(String name)
+    {
+        return servers != null ? servers.get( name ) : null;
+    }
+
+    @Override
+    @Synchronized("serversLock")
+    public ServerInfo addServer(ServerInfo server)
+    {
+        return servers != null ? servers.put( server.getName(), server ) : null;
+    }
+
+    @Override
+    @Synchronized("serversLock")
+    public boolean addServers(Collection<ServerInfo> servers)
+    {
+        boolean changed = false;
+        for ( ServerInfo server : servers )
+        {
+            if ( server != this.servers.put( server.getName(), server ) )
+            {
+                changed = true;
+            }
+        }
+        return changed;
+    }
+
+    @Override
+    @Synchronized("serversLock")
+    public ServerInfo removeServerNamed(String name)
+    {
+        return servers != null ? servers.remove( name ) : null;
+    }
+
+    @Override
+    @Synchronized("serversLock")
+    public ServerInfo removeServer(ServerInfo server)
+    {
+        return servers != null ? servers.remove( server.getName() ) : null;
+    }
+
+    @Override
+    @Synchronized("serversLock")
+    public boolean removeServersNamed(Collection<String> names)
+    {
+        return servers != null && servers.keySet().removeAll( names );
+    }
+
+    @Override
+    @Synchronized("serversLock")
+    public boolean removeServers(Collection<ServerInfo> servers)
+    {
+        boolean changed = false;
+        for ( ServerInfo server : servers )
+        {
+            if ( this.servers.remove( server.getName() ) != null )
+            {
+                changed = true;
+            }
+        }
+        return changed;
     }
 }

--- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
@@ -399,7 +399,7 @@ public class DownstreamBridge extends PacketHandler
                     switch ( target )
                     {
                         case "ALL":
-                            for ( ServerInfo server : bungee.getServers().values() )
+                            for ( ServerInfo server : bungee.getServersCopy().values() )
                             {
                                 if ( server != this.server.getInfo() )
                                 {
@@ -408,7 +408,7 @@ public class DownstreamBridge extends PacketHandler
                             }
                             break;
                         case "ONLINE":
-                            for ( ServerInfo server : bungee.getServers().values() )
+                            for ( ServerInfo server : bungee.getServersCopy().values() )
                             {
                                 if ( server != this.server.getInfo() )
                                 {
@@ -542,7 +542,7 @@ public class DownstreamBridge extends PacketHandler
                 case "GetServers":
                 {
                     out.writeUTF( "GetServers" );
-                    out.writeUTF( Util.csv( bungee.getServers().keySet() ) );
+                    out.writeUTF( Util.csv( bungee.getServersCopy().keySet() ) );
                     break;
                 }
                 case "Message":

--- a/proxy/src/test/java/net/md_5/bungee/conf/ConfigurationConcurrencyTest.java
+++ b/proxy/src/test/java/net/md_5/bungee/conf/ConfigurationConcurrencyTest.java
@@ -1,0 +1,198 @@
+package net.md_5.bungee.conf;
+
+import static org.junit.jupiter.api.Assertions.*;
+import java.lang.reflect.Field;
+import java.net.InetSocketAddress;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import net.md_5.bungee.api.ServerPing;
+import net.md_5.bungee.api.command.CommandSender;
+import net.md_5.bungee.api.config.ServerInfo;
+import net.md_5.bungee.util.CaseInsensitiveMap;
+import org.junit.jupiter.api.Test;
+
+class ConfigurationConcurrencyTest
+{
+
+    private static class DummyServerInfo implements ServerInfo
+    {
+
+        private final String name;
+
+        DummyServerInfo( String name )
+        {
+            this.name = name;
+        }
+
+        @Override
+        public String getName()
+        {
+            return name;
+        }
+
+        @Override
+        public InetSocketAddress getAddress()
+        {
+            return new InetSocketAddress( "127.0.0.1", 25565 );
+        }
+
+        @Override
+        public boolean isRestricted()
+        {
+            return false;
+        }
+
+        @Override
+        public String getPermission()
+        {
+            return null;
+        }
+
+        @Override
+        public boolean canAccess( CommandSender sender )
+        {
+            return true;
+        }
+
+        @Override
+        public void sendData( String channel, byte[] data )
+        {
+        }
+
+        @Override
+        public boolean sendData( String channel, byte[] data, boolean queue )
+        {
+            return false;
+        }
+
+        @Override
+        public void ping( Callback<ServerPing> callback )
+        {
+        }
+    }
+
+    private Configuration createConfigWithServers() throws Exception
+    {
+        Configuration config = new Configuration();
+        Map<String, ServerInfo> initialServers = new HashMap<>();
+        initialServers.put( "lobby", new DummyServerInfo( "lobby" ) );
+        initialServers.put( "survival", new DummyServerInfo( "survival" ) );
+        Field serversField = Configuration.class.getDeclaredField( "servers" );
+        serversField.setAccessible( true );
+        serversField.set( config, new CaseInsensitiveMap<>( initialServers ) );
+        return config;
+    }
+
+    @Test
+    void testConcurrentReadWrite() throws InterruptedException
+    {
+        Configuration config = createConfigWithServers();
+
+        ExecutorService executor = Executors.newFixedThreadPool( 4 );
+        CountDownLatch startLatch = new CountDownLatch( 1 );
+        CountDownLatch doneLatch = new CountDownLatch( 8 );
+        AtomicInteger errors = new AtomicInteger( 0 );
+
+        Runnable reader = () ->
+        {
+            try
+            {
+                startLatch.await();
+                for ( int i = 0; i < 1000; i++ )
+                {
+                    Map<String, ServerInfo> copy = config.getServersCopy();
+                    assertNotNull( copy );
+                    for ( ServerInfo si : copy.values() )
+                    {
+                        assertNotNull( si.getName() );
+                    }
+                    config.getServerInfo( "lobby" );
+                }
+            }
+            catch ( Exception ex )
+            {
+                errors.incrementAndGet();
+                ex.printStackTrace();
+            }
+            finally
+            {
+                doneLatch.countDown();
+            }
+        };
+
+        Runnable writer = () ->
+        {
+            try
+            {
+                startLatch.await();
+                for ( int i = 0; i < 500; i++ )
+                {
+                    ServerInfo info = new DummyServerInfo( "dynamic-" + i );
+                    config.addServer( info );
+                    config.getServerInfo( "dynamic-" + i );
+                    config.removeServerNamed( "dynamic-" + i );
+                }
+            }
+            catch ( Exception ex )
+            {
+                errors.incrementAndGet();
+                ex.printStackTrace();
+            }
+            finally
+            {
+                doneLatch.countDown();
+            }
+        };
+
+        executor.submit( reader );
+        executor.submit( reader );
+        executor.submit( writer );
+        executor.submit( writer );
+        executor.submit( reader );
+        executor.submit( reader );
+        executor.submit( writer );
+        executor.submit( writer );
+
+        startLatch.countDown();
+        assertTrue( doneLatch.await( 30, TimeUnit.SECONDS ) );
+        assertEquals( 0, errors.get() );
+        executor.shutdown();
+    }
+
+    @Test
+    void testSnapshotIsImmutable() throws Exception
+    {
+        Configuration config = createConfigWithServers();
+        Map<String, ServerInfo> snapshot = config.getServersCopy();
+        assertNotNull( snapshot );
+        assertEquals( 2, snapshot.size() );
+
+        config.addServer( new DummyServerInfo( "new_server" ) );
+        assertEquals( 2, snapshot.size() );
+        assertEquals( 3, config.getServersCopy().size() );
+    }
+
+    @Test
+    void testServerLifecycle() throws Exception
+    {
+        Configuration config = createConfigWithServers();
+
+        ServerInfo newServer = new DummyServerInfo( "test" );
+        assertNull( config.addServer( newServer ) );
+        assertEquals( newServer, config.getServerInfo( "test" ) );
+
+        ServerInfo added = config.addServer( new DummyServerInfo( "test" ) );
+        assertEquals( newServer.getName(), added.getName() );
+
+        assertTrue( config.removeServersNamed( java.util.Collections.singletonList( "test" ) ) );
+        assertNull( config.getServerInfo( "test" ) );
+
+        assertFalse( config.removeServersNamed( java.util.Collections.singletonList( "nonexistent" ) ) );
+    }
+}


### PR DESCRIPTION
Fixes #4005 — `getServers()` can corrupt on concurrent access.

**Root cause:** `getServers()` returns the internal `CaseInsensitiveMap` directly. When a plugin iterates the map from one thread while an orchestration system (e.g. CloudNet) adds/removes servers from another, the map can enter an irrecoverable corrupted state — throwing `ConcurrentModificationException` or `NullPointerException`.

**What this PR does:**
1. Adds `getServersCopy()` — returns an immutable snapshot via `ImmutableMap.copyOf(servers)`, safe for concurrent iteration
2. Deprecates `getServers()` — marks it `@Deprecated` with javadoc pointing to `getServersCopy()` as the safe alternative
3. Adds `ReentrantLock serversLock` — all mutations (`addServer`, `removeServer`, `removeServersNamed`, etc.) are now synchronized on this lock
4. Synchronizes `load()` — the config reload path is now thread-safe too
5. Makes `getServerInfo()` thread-safe — delegates through the lock instead of `getServers().get()`
6. Updates all internal BungeeCord callers (`CommandList`, `CommandSend`, `CommandServer`, `DownstreamBridge`, `BungeeCord.getServerInfo()`) to use `getServersCopy()`
7. Adds `ConfigurationConcurrencyTest` — validates concurrent reads and writes do not throw

**Approach:** Based on the fix pioneered in Waterfall, but fully integrated into BungeeCord with server lifecycle API (`addServer`, `removeServer`, etc.) from ProxyConfig.

Fixes https://github.com/SpigotMC/BungeeCord/issues/4005