### PR TITLE
drop packets of different phases that are not transition acknowledges

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
@@ -98,17 +98,18 @@ public class UpstreamBridge extends PacketHandler
     @Override
     public boolean shouldHandle(PacketWrapper packet) throws Exception
     {
-        // We move the client to a new protocol before it acknowledges the switch, so we may still decode packets in a
-        // protocol we have already left - those can neither be answered nor forwarded. Packets driving the transition
-        // itself are exempt, they are by definition still sent in the previous protocol.
-        // vanilla also guards incoming connection in a similar way
-        if ( con.getPendingConnection().getVersion() >= ProtocolConstants.MINECRAFT_1_20_2 && packet.protocol != con.getCh().getEncodeProtocol() && ( packet.packet == null || packet.packet.nextProtocol() == null ) )
+        ServerConnection server = con.getServer();
+        if ( server != null && server.isConnected() )
         {
-            // not a protocol transition ack packet, drop it.
-            return false;
+            Protocol serverEncode = server.getCh().getEncodeProtocol();
+            // #3527, #4010: May still have old packets from client in game state when switching server to configuration state - discard those
+            // packets which switch the protocol phase are exempt, they are what advances the server connection to the new phase
+            if ( packet.protocol != serverEncode && ( packet.packet == null || packet.packet.nextProtocol() == null ) )
+            {
+                return false;
+            }
         }
-
-        return con.getServer() != null || packet.packet instanceof PluginMessage || packet.packet instanceof CookieResponse || packet.packet instanceof LoginPayloadResponse;
+        return server != null || packet.packet instanceof PluginMessage || packet.packet instanceof CookieResponse || packet.packet instanceof LoginPayloadResponse;
     }
 
     @Override
@@ -117,15 +118,8 @@ public class UpstreamBridge extends PacketHandler
         ServerConnection server = con.getServer();
         if ( server != null && server.isConnected() )
         {
-            Protocol serverEncode = server.getCh().getEncodeProtocol();
-            // #3527: May still have old packets from client in game state when switching server to configuration state - discard those
-            if ( packet.protocol != serverEncode )
-            {
-                return;
-            }
-
             EntityMap rewrite = con.getEntityRewrite();
-            if ( rewrite != null && serverEncode == Protocol.GAME )
+            if ( rewrite != null && server.getCh().getEncodeProtocol() == Protocol.GAME )
             {
                 rewrite.rewriteServerbound( packet.buf, con.getClientEntityId(), con.getServerEntityId(), con.getPendingConnection().getVersion() );
             }

--- a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
@@ -98,6 +98,16 @@ public class UpstreamBridge extends PacketHandler
     @Override
     public boolean shouldHandle(PacketWrapper packet) throws Exception
     {
+        // We move the client to a new protocol before it acknowledges the switch, so we may still decode packets in a
+        // protocol we have already left - those can neither be answered nor forwarded. Packets driving the transition
+        // itself are exempt, they are by definition still sent in the previous protocol.
+        // vanilla also guards incoming connection in a similar way
+        if ( con.getPendingConnection().getVersion() >= ProtocolConstants.MINECRAFT_1_20_2 && packet.protocol != con.getCh().getEncodeProtocol() && ( packet.packet == null || packet.packet.nextProtocol() == null ) )
+        {
+            // not a protocol transition ack packet, drop it.
+            return false;
+        }
+
         return con.getServer() != null || packet.packet instanceof PluginMessage || packet.packet instanceof CookieResponse || packet.packet instanceof LoginPayloadResponse;
     }
 


### PR DESCRIPTION
I encountered this error:

Cannot get ID for packet class net.md_5.bungee.protocol.packet.TabCompleteResponse in phase CONFIGURATION with direction TO_CLIENT

Caused by a race condition.

This was executed in CONFIG phase, which should never happen:
https://github.com/SpigotMC/BungeeCord/blob/2e729325be2a4486adc0819cc03779e896ca0108/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java#L238

It seems like the reason for this is a small window in which the client encoder is GAME phase and the the bungees decoder is also GAME but the encoder is CONFIG.

This can happen for example if bungee send out a StartConfiguration (switches encoder to CONFIG) and then the client before receiving that packet sends out any old data (in that case it was a TabComplete that resulted in a disconnect). 


