### PR TITLE
Provided names

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/plugin/PluginDescription.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/PluginDescription.java
@@ -54,4 +54,8 @@ public class PluginDescription
      * Optional libraries.
      */
     private List<String> libraries = new LinkedList<>();
+    /**
+     * Optional provided names.
+     */
+    private List<String> provides = new LinkedList<>();
 }

--- a/api/src/main/java/net/md_5/bungee/api/plugin/PluginDescription.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/PluginDescription.java
@@ -55,7 +55,7 @@ public class PluginDescription
      */
     private List<String> libraries = new LinkedList<>();
     /**
-     * Optional provided names.
+     * Optional provided names that act as alternative names for the plugin.
      */
     private List<String> provides = new LinkedList<>();
 }

--- a/api/src/main/java/net/md_5/bungee/api/plugin/PluginDescription.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/PluginDescription.java
@@ -56,6 +56,7 @@ public class PluginDescription
     private List<String> libraries = new LinkedList<>();
     /**
      * Optional provided names that act as alternative names for the plugin.
+     * These names can be referenced in {@link PluginManager#getPlugin(String)}
      */
     private List<String> provides = new LinkedList<>();
 }

--- a/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
@@ -61,7 +61,7 @@ public final class PluginManager
     private final LibraryLoader libraryLoader;
     private final Map<String, Command> commandMap = new HashMap<>();
     private Map<String, PluginDescription> toLoad = new HashMap<>();
-    private Map<String, String> providedMap = new HashMap<>();
+    private Map<String, String> providedNameMap = new HashMap<>();
     private final Multimap<Plugin, Command> commandsByPlugin = ArrayListMultimap.create();
     private final Multimap<Plugin, Listener> listenersByPlugin = ArrayListMultimap.create();
 
@@ -258,7 +258,7 @@ public final class PluginManager
      */
     public Plugin getPlugin(String name)
     {
-        return plugins.get( providedMap.getOrDefault( name, name ) );
+        return plugins.get( providedNameMap.getOrDefault( name, name ) );
     }
 
     public void loadPlugins()
@@ -312,7 +312,7 @@ public final class PluginManager
         // try to load dependencies first
         for ( String dependName : dependencies )
         {
-            PluginDescription depend = toLoad.get( providedMap.getOrDefault( dependName, dependName ) );
+            PluginDescription depend = toLoad.get( providedNameMap.getOrDefault( dependName, dependName ) );
             Boolean dependStatus = ( depend != null ) ? pluginStatuses.get( depend.getName() ) : Boolean.FALSE;
 
             if ( dependStatus == null )
@@ -413,7 +413,7 @@ public final class PluginManager
                         toLoad.put( desc.getName(), desc );
                         for ( String providedName : desc.getProvides() )
                         {
-                            providedMap.put( providedName, desc.getName() );
+                            providedNameMap.put( providedName, desc.getName() );
                         }
                     }
                 } catch ( Exception ex )

--- a/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
@@ -360,6 +360,10 @@ public final class PluginManager
                 Plugin clazz = (Plugin) main.getDeclaredConstructor().newInstance();
 
                 plugins.put( plugin.getName(), clazz );
+                for ( String providedName : plugin.getProvides() )
+                {
+                    plugins.put( providedName, clazz );
+                }
                 clazz.onLoad();
                 ProxyServer.getInstance().getLogger().log( Level.INFO, "Loaded plugin {0} version {1} by {2}", new Object[]
                 {

--- a/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
@@ -11,18 +11,7 @@ import java.io.File;
 import java.io.InputStream;
 import java.lang.reflect.Method;
 import java.net.URLClassLoader;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
-import java.util.Stack;
+import java.util.*;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -277,8 +266,11 @@ public final class PluginManager
 
     public void enablePlugins()
     {
+        List<Plugin> enabled = new LinkedList<>();
         for ( Plugin plugin : plugins.values() )
         {
+            if ( enabled.contains( plugin ) ) continue;
+            enabled.add( plugin );
             try
             {
                 plugin.onEnable();

--- a/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
+++ b/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
@@ -11,7 +11,18 @@ import java.io.File;
 import java.io.InputStream;
 import java.lang.reflect.Method;
 import java.net.URLClassLoader;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.Stack;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -50,6 +61,7 @@ public final class PluginManager
     private final LibraryLoader libraryLoader;
     private final Map<String, Command> commandMap = new HashMap<>();
     private Map<String, PluginDescription> toLoad = new HashMap<>();
+    private Map<String, String> providedMap = new HashMap<>();
     private final Multimap<Plugin, Command> commandsByPlugin = ArrayListMultimap.create();
     private final Multimap<Plugin, Listener> listenersByPlugin = ArrayListMultimap.create();
 
@@ -246,12 +258,12 @@ public final class PluginManager
      */
     public Plugin getPlugin(String name)
     {
-        return plugins.get( name );
+        return plugins.get( providedMap.getOrDefault( name, name ) );
     }
 
     public void loadPlugins()
     {
-        Map<PluginDescription, Boolean> pluginStatuses = new HashMap<>();
+        Map<String, Boolean> pluginStatuses = new HashMap<>();
         for ( Map.Entry<String, PluginDescription> entry : toLoad.entrySet() )
         {
             PluginDescription plugin = entry.getValue();
@@ -266,11 +278,8 @@ public final class PluginManager
 
     public void enablePlugins()
     {
-        List<Plugin> enabled = new LinkedList<>();
         for ( Plugin plugin : plugins.values() )
         {
-            if ( enabled.contains( plugin ) ) continue;
-            enabled.add( plugin );
             try
             {
                 plugin.onEnable();
@@ -285,11 +294,11 @@ public final class PluginManager
         }
     }
 
-    private boolean enablePlugin(Map<PluginDescription, Boolean> pluginStatuses, Stack<PluginDescription> dependStack, PluginDescription plugin)
+    private boolean enablePlugin(Map<String, Boolean> pluginStatuses, Stack<PluginDescription> dependStack, PluginDescription plugin)
     {
-        if ( pluginStatuses.containsKey( plugin ) )
+        if ( pluginStatuses.containsKey( plugin.getName() ) )
         {
-            return pluginStatuses.get( plugin );
+            return pluginStatuses.get( plugin.getName() );
         }
 
         // combine all dependencies for 'for loop'
@@ -303,8 +312,8 @@ public final class PluginManager
         // try to load dependencies first
         for ( String dependName : dependencies )
         {
-            PluginDescription depend = toLoad.get( dependName );
-            Boolean dependStatus = ( depend != null ) ? pluginStatuses.get( depend ) : Boolean.FALSE;
+            PluginDescription depend = toLoad.get( providedMap.getOrDefault( dependName, dependName ) );
+            Boolean dependStatus = ( depend != null ) ? pluginStatuses.get( depend.getName() ) : Boolean.FALSE;
 
             if ( dependStatus == null )
             {
@@ -352,10 +361,6 @@ public final class PluginManager
                 Plugin clazz = (Plugin) main.getDeclaredConstructor().newInstance();
 
                 plugins.put( plugin.getName(), clazz );
-                for ( String providedName : plugin.getProvides() )
-                {
-                    plugins.put( providedName, clazz );
-                }
                 clazz.onLoad();
                 ProxyServer.getInstance().getLogger().log( Level.INFO, "Loaded plugin {0} version {1} by {2}", new Object[]
                 {
@@ -367,7 +372,11 @@ public final class PluginManager
             }
         }
 
-        pluginStatuses.put( plugin, status );
+        pluginStatuses.put( plugin.getName(), status );
+        for ( String providedName : plugin.getProvides() )
+        {
+            pluginStatuses.put( providedName, status );
+        }
         return status;
     }
 
@@ -402,6 +411,10 @@ public final class PluginManager
 
                         desc.setFile( file );
                         toLoad.put( desc.getName(), desc );
+                        for ( String providedName : desc.getProvides() )
+                        {
+                            providedMap.put( providedName, desc.getName() );
+                        }
                     }
                 } catch ( Exception ex )
                 {


### PR DESCRIPTION
Allows plugins to provide alternative names the plugin goes under, this has 2 good use cases:
- A plugin has changed it's name, but would like the old name present for compatibility reasons
- A plugin is providing another plugins API, and would like other plugins that depend on the API to continue working